### PR TITLE
Updated template for new tab styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ acceptance/scripts/.env_docker
 static/assets
 vendor/*
 !vendor/vendor.json
+.DS_Store

--- a/static_src/components/tabnav.jsx
+++ b/static_src/components/tabnav.jsx
@@ -2,12 +2,16 @@
 import React from 'react';
 
 import classNames from 'classnames';
+import navStyles from 'cloudgov-style/css/components/nav.css';
+import createStyler from '../util/create_styler';
+
 
 export default class Tabnav extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
     this.state = { current: this.props.initialItem };
+    this.styler = createStyler(navStyles);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -15,14 +19,14 @@ export default class Tabnav extends React.Component {
   }
 
   render() {
-    var defaultClasses = ['nav', 'nav-tabs', 'nav-justified'];
+    var defaultClasses = [this.styler('nav'), this.styler('nav-tabs'), this.styler('nav-justified')];
     var classes = classNames(defaultClasses, this.props.classes);
 
     return (
     <ul className={ classes }>
       { this.props.items.map((item, i) => {
         if (item.name === this.state.current) {
-          return <li className="active" key={ i }>{ item.element }</li>;
+          return <li className={ this.styler('active') } key={ i }>{ item.element }</li>;
         } else {
           return <li key={ i }>{ item.element }</li>;
         }


### PR DESCRIPTION
**What:** Updated class calls in `navbar.jsx` to allow styling from `cg-styles`.

**Why:** The nav template needed styling added through React to correctly read the new tab styles (see https://github.com/18F/cg-style/pull/81) from the stylesheet. 
