### PR TITLE
Updated template for new table styles

### DIFF
--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -3,7 +3,10 @@ import dedent from 'dedent';
 import React from 'react';
 import Reactable from 'reactable';
 
+import createStyler from '../util/create_styler';
+
 import SpaceStore from '../stores/space_store.js';
+import tableStyles from 'cloudgov-style/css/base.css';
 
 var Table = Reactable.Table,
     unsafe = Reactable.unsafe;
@@ -25,6 +28,7 @@ export default class AppList extends React.Component {
     this.state = stateSetter(props);
     this.state.apps = props.initialApps;
     this._onChange = this._onChange.bind(this);
+    this.styler = createStyler(tableStyles);
   }
 
   componentDidMount() {
@@ -77,7 +81,7 @@ export default class AppList extends React.Component {
     }
 
     return (
-      <div className="tableWrapper">
+      <div className={ this.styler('tableWrapper') }>
         { content }
       </div>
     );

--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 
 import RouteStore from '../stores/route_store.js';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 function stateSetter(appGuid) {
   const routes = RouteStore.getAll();
   const appRoutes = routes.filter((route) => route.appGuid === appGuid);
@@ -18,6 +21,7 @@ export default class RouteList extends React.Component {
     this.props = props;
     this.state = stateSetter(props.initialAppGuid);
     this._onChange = this._onChange.bind(this);
+    this.styler = createStyler(tableStyles);
   }
 
   componentDidMount() {
@@ -70,7 +74,7 @@ export default class RouteList extends React.Component {
     }
 
     return (
-      <div className="tableWrapper">
+      <div className={ this.styler('tableWrapper') }>
         { content }
         <aside>
           <p>To modify, create or delete a route, view <a

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -4,14 +4,12 @@ import Reactable from 'reactable';
 
 import formatDateTime from '../util/format_date';
 
-import baseStyle from 'cloudgov-style/css/base.css';
 import createStyler from '../util/create_styler';
+import baseStyle from 'cloudgov-style/css/base.css';
+import tableStyles from 'cloudgov-style/css/base.css';
 import Button from './button.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
-
-import createStyler from '../util/create_styler';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 const Table = Reactable.Table;
 const Thead = Reactable.Thead;

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -6,7 +6,6 @@ import formatDateTime from '../util/format_date';
 
 import createStyler from '../util/create_styler';
 import baseStyle from 'cloudgov-style/css/base.css';
-import tableStyles from 'cloudgov-style/css/base.css';
 import Button from './button.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
@@ -31,7 +30,7 @@ export default class ServiceInstanceList extends React.Component {
     this.state = stateSetter(props);
     this._onChange = this._onChange.bind(this);
     this._handleDelete = this._handleDelete.bind(this);
-    this.styler = createStyler(baseStyle, tableStyles);
+    this.styler = createStyler(baseStyle);
   }
 
   componentDidMount() {

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -10,6 +10,9 @@ import Button from './button.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 const Table = Reactable.Table;
 const Thead = Reactable.Thead;
 const Th = Reactable.Th;
@@ -30,7 +33,7 @@ export default class ServiceInstanceList extends React.Component {
     this.state = stateSetter(props);
     this._onChange = this._onChange.bind(this);
     this._handleDelete = this._handleDelete.bind(this);
-    this.styler = createStyler(baseStyle);
+    this.styler = createStyler(baseStyle, tableStyles);
   }
 
   componentDidMount() {
@@ -97,7 +100,7 @@ export default class ServiceInstanceList extends React.Component {
     }
 
     return (
-      <div className="tableWrapper">
+      <div className={ this.styler('tableWrapper') }>
         { content }
       </div>
     );

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -52,6 +52,7 @@ export default class ServiceList extends React.Component {
       content = (
       <table>
         <thead>
+          <tr>
           { this.columns.map((column) => {
             return (
               <th className={ column.key } key={ column.key }>
@@ -59,7 +60,9 @@ export default class ServiceList extends React.Component {
               </th>
             )
           })}
+          </tr>
         </thead>
+        <tbody>
         { this.rows.map((row) => {
           return [
           <tr key={ row.guid }>
@@ -79,6 +82,7 @@ export default class ServiceList extends React.Component {
           </tr>
           ]
         })}
+        </tbody>
       </table>
       );
     }

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -8,6 +8,9 @@ import Reactable from 'reactable';
 
 import ServicePlanList from './service_plan_list.jsx';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 var Table = Reactable.Table,
     Thead = Reactable.Thead,
     Th = Reactable.Th,
@@ -21,6 +24,7 @@ export default class ServiceList extends React.Component {
     this.state = {
       services: props.initialServices
     };
+    this.styler = createStyler(navStyles);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -80,7 +84,7 @@ export default class ServiceList extends React.Component {
     }
 
     return (
-    <div className="tableWrapper">
+    <div className={ this.styler('tableWrapper') }>
       { content }
     </div>
     );

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -10,6 +10,7 @@ import ServicePlanList from './service_plan_list.jsx';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
+import navStyles from 'cloudgov-style/css/components/nav.css';
 
 var Table = Reactable.Table,
     Thead = Reactable.Thead,

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -10,7 +10,6 @@ import ServicePlanList from './service_plan_list.jsx';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
-import navStyles from 'cloudgov-style/css/components/nav.css';
 
 var Table = Reactable.Table,
     Thead = Reactable.Thead,
@@ -25,7 +24,7 @@ export default class ServiceList extends React.Component {
     this.state = {
       services: props.initialServices
     };
-    this.styler = createStyler(navStyles);
+    this.styler = createStyler(tableStyles);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -12,6 +12,7 @@ import ServicePlanStore from '../stores/service_plan_store.js';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
+import navStyles from 'cloudgov-style/css/components/nav.css';
 
 var Table = Reactable.Table,
     Thead = Reactable.Thead,

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -10,6 +10,9 @@ import Button from './button.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 var Table = Reactable.Table,
     Thead = Reactable.Thead,
     Th = Reactable.Th,
@@ -34,6 +37,7 @@ export default class ServicePlanList extends React.Component {
     };
     this._onChange = this._onChange.bind(this);
     this._handleAdd = this._handleAdd.bind(this);
+    this.styler = createStyler(navStyles);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -110,7 +114,7 @@ export default class ServicePlanList extends React.Component {
     }
 
     return (
-    <div className="tableWrapper">
+    <div className={ this.styler('tableWrapper') }>
       { content }
     </div>
     );

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -12,7 +12,6 @@ import ServicePlanStore from '../stores/service_plan_store.js';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
-import navStyles from 'cloudgov-style/css/components/nav.css';
 
 var Table = Reactable.Table,
     Thead = Reactable.Thead,
@@ -38,7 +37,7 @@ export default class ServicePlanList extends React.Component {
     };
     this._onChange = this._onChange.bind(this);
     this._handleAdd = this._handleAdd.bind(this);
-    this.styler = createStyler(navStyles);
+    this.styler = createStyler(tableStyles);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -7,6 +7,7 @@ import OrgStore from '../stores/org_store';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
+import navStyles from 'cloudgov-style/css/components/nav.css';
 
 var Table = Reactable.Table,
     unsafe = Reactable.unsafe;

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -7,7 +7,6 @@ import OrgStore from '../stores/org_store';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
-import navStyles from 'cloudgov-style/css/components/nav.css';
 
 var Table = Reactable.Table,
     unsafe = Reactable.unsafe;
@@ -30,7 +29,7 @@ export default class SpaceList extends React.Component {
     this.state = { rows: [], currentOrgGuid: this.props.initialOrgGuid };
     this._onChange = this._onChange.bind(this);
     this.spaceLink = this.spaceLink.bind(this);
-    this.styler = createStyler(navStyles);
+    this.styler = createStyler(tableStyles);
   }
 
   componentDidMount() {

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -5,6 +5,9 @@ import Reactable from 'reactable';
 import AppDispatcher from '../dispatcher';
 import OrgStore from '../stores/org_store';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 var Table = Reactable.Table,
     unsafe = Reactable.unsafe;
 
@@ -26,6 +29,7 @@ export default class SpaceList extends React.Component {
     this.state = { rows: [], currentOrgGuid: this.props.initialOrgGuid };
     this._onChange = this._onChange.bind(this);
     this.spaceLink = this.spaceLink.bind(this);
+    this.styler = createStyler(navStyles);
   }
 
   componentDidMount() {
@@ -80,7 +84,7 @@ export default class SpaceList extends React.Component {
         <div>
           <h3>{ this.title }  Spaces</h3>
         </div>
-        <div className="tableWrapper">
+        <div className={ this.styler('tableWrapper') }>
           { content }
         </div>
       </div>

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -13,6 +13,9 @@ import createStyler from '../util/create_styler';
 import Button from './button.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
 
+import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
+
 
 export default class UserList extends React.Component {
   constructor(props) {
@@ -23,6 +26,7 @@ export default class UserList extends React.Component {
     };
     this.styler = createStyler(baseStyle);
     this._handleDelete = this._handleDelete.bind(this);
+    this.styler = createStyler(navStyles);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -98,7 +102,7 @@ export default class UserList extends React.Component {
     }
 
     return (
-    <div className="tableWrapper">
+    <div className={ this.styler('tableWrapper') }>
       { content }
     </div>
     );

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -9,12 +9,10 @@ import formatDateTime from '../util/format_date';
 
 import baseStyle from 'cloudgov-style/css/base.css';
 import createStyler from '../util/create_styler';
+import tableStyles from 'cloudgov-style/css/base.css';
 
 import Button from './button.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
-
-import createStyler from '../util/create_styler';
-import tableStyles from 'cloudgov-style/css/base.css';
 
 
 export default class UserList extends React.Component {

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -15,7 +15,6 @@ import UserRoleListControl from './user_role_list_control.jsx';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
-import navStyles from 'cloudgov-style/css/components/nav.css';
 
 
 export default class UserList extends React.Component {
@@ -27,7 +26,7 @@ export default class UserList extends React.Component {
     };
     this.styler = createStyler(baseStyle);
     this._handleDelete = this._handleDelete.bind(this);
-    this.styler = createStyler(navStyles);
+    this.styler = createStyler(tableStyles);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -15,6 +15,7 @@ import UserRoleListControl from './user_role_list_control.jsx';
 
 import createStyler from '../util/create_styler';
 import tableStyles from 'cloudgov-style/css/base.css';
+import navStyles from 'cloudgov-style/css/components/nav.css';
 
 
 export default class UserList extends React.Component {


### PR DESCRIPTION
**What:** Updated class calls in all components that need table styling to allow styling from `cg-styles`.

**Why:** The table template needed styling added through React to correctly read the new table styles (see https://github.com/18F/cg-style/pull/79) from the stylesheet.
