### PR TITLE
include better defaults in sample credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you are deploying to cloud foundry, modify the `manifest.yml`
 ## Front end
 Front end build commands should be run in the same directory as the `package.json` file. If you've used the cloning command from this README it should be something like `/path/to/cg-deck-ws/src/github.com/18F/cg-deck`
 
-Install front end dependencies:
+Install front end dependencies (may require [special steps for node-gyp](https://github.com/nodejs/node-gyp#installation)):
 ```
 npm install
 ```

--- a/env.sample
+++ b/env.sample
@@ -9,23 +9,23 @@ export CONSOLE_CLIENT_ID=
 export CONSOLE_CLIENT_SECRET=
 
 # The URL of the service itself.
-export CONSOLE_HOSTNAME=
+export CONSOLE_HOSTNAME=http://localhost:9999
 
-# The base URL of the auth service. i.e. `https://login.domain.com`
-export CONSOLE_LOGIN_URL=
+# The base URL of the auth service.
+export CONSOLE_LOGIN_URL=https://login.cloud.gov
 
-# The URL of the UAA service. i.e. `https://uaa.domain.com`
-export CONSOLE_UAA_URL=
+# The URL of the UAA service.
+export CONSOLE_UAA_URL=https://uaa.cloud.gov
 
-# The URL of the API service. i.e. `http://api.domain.com`
-export CONSOLE_API_URL=
+# The URL of the API service.
+export CONSOLE_API_URL=https://api.cloud.gov
 
-# The URL of the loggregator service. i.e. `http://loggregator.domain.com`
-export CONSOLE_LOG_URL=
+# The URL of the loggregator service.
+export CONSOLE_LOG_URL=https://loggregator.cloud.gov
 
 # <optional> If set to `true` or `1`, will turn on `/debug/pprof` endpoints as seen [here](https://golang.org/pkg/net/http/pprof/)
-export PPROF_ENABLED=
+# export PPROF_ENABLED=true
 
 # <optional> The absolute path to your `cg-style` repo. If set, will use a local
 # copy of `cloudgov-style` to build the front end application.
-export CG_STYLE_PATH=
+# export CG_STYLE_PATH=


### PR DESCRIPTION
Since this app is mostly going to be run by 18F staff, makes setup easier if we include better defaults. Also, included link to the node-gyp instructions in the README, which I have needed a couple of times already.
