### PR TITLE
Show domains and routes in app view

### DIFF
--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -8,7 +8,7 @@ import createStyler from '../util/create_styler';
 
 function stateSetter(appGuid) {
   const routes = RouteStore.getAll();
-  const appRoutes = routes.filter((route) => route.appGuid === appGuid);
+  const appRoutes = routes.filter((route) => route.app_guid === appGuid);
 
   return {
     routes: appRoutes
@@ -67,7 +67,7 @@ export default class RouteList extends React.Component {
                 { this.columns.map((column) =>
                    <td key={route.guid + column.key}>{route[column.key]}</td>) }
               </tr>
-            )
+            );
           })}
           </tbody>
         </table>
@@ -86,7 +86,7 @@ export default class RouteList extends React.Component {
       </div>
     );
   }
-};
+}
 
 RouteList.propTypes = {
   initialAppGuid: React.PropTypes.string.isRequired

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -16,7 +16,6 @@ import Home from './components/home.jsx';
 import Login from './components/login.jsx';
 import Marketplace from './components/marketplace.jsx';
 import orgActions from './actions/org_actions.js';
-import routeActions from './actions/route_actions.js';
 import spaceActions from './actions/space_actions.js';
 import serviceActions from './actions/service_actions.js';
 import Space from './components/space.jsx';
@@ -80,7 +79,6 @@ function app(orgGuid, spaceGuid, appGuid) {
   spaceActions.fetch(spaceGuid);
   appActions.fetch(appGuid);
   appActions.fetchStats(appGuid);
-  routeActions.fetchRoutesForApp(appGuid);
   ReactDOM.render(
     <App initialSpaceGuid={ spaceGuid }>
       <AppPage

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -8,7 +8,7 @@ import Immutable from 'immutable';
 
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
-import { domainActionTypes, routeActionTypes } from '../constants.js';
+import { appActionTypes, domainActionTypes, routeActionTypes } from '../constants.js';
 
 class RouteStore extends BaseStore {
   constructor() {
@@ -25,7 +25,7 @@ class RouteStore extends BaseStore {
 
       case routeActionTypes.ROUTES_FOR_APP_RECEIVED: {
         const routes = this.formatSplitResponse(action.routes).map((route) =>
-          Object.assign({}, route, { appGuid: action.appGuid })
+          Object.assign({}, route, { app_guid: action.appGuid })
         );
         this.mergeMany('guid', routes, (changed) => {
           if (changed) this.emitChange();
@@ -51,6 +51,28 @@ class RouteStore extends BaseStore {
         this.mergeAll('domain_guid', domain, (changed) => {
           if (changed) this.emitChange();
         });
+        break;
+      }
+
+      case appActionTypes.APP_RECEIVED: {
+        if (!action.app.routes) break;
+        const routes = action.app.routes.map((route) => {
+          const r = {
+            app_guid: action.app.guid,
+            guid: route.guid,
+            host: route.host,
+            path: route.path,
+            domain_guid: route.domain.guid,
+            domain: route.domain.name
+          };
+
+          return r;
+        });
+
+        this.mergeMany('domain_guid', routes, (changed) => {
+          if (changed) this.emitChange();
+        });
+
         break;
       }
 

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -71,13 +71,13 @@ describe('RouteStore', function() {
       let actual = RouteStore.get(routeA.guid);
 
       expect(actual).toEqual(
-        Object.assign({}, routeA, { appGuid: sharedGuid }));
+        Object.assign({}, routeA, { app_guid: sharedGuid }));
     });
 
     it('should merge all the routes in', function() {
       const sharedGuid = 'zxcb234nvc654ad';
       const spy = sandbox.spy(RouteStore, 'mergeMany');
-      const existingRoute = { guid: 'zxcb', appGuid: sharedGuid };
+      const existingRoute = { guid: 'zxcb', app_guid: sharedGuid };
 
       RouteStore.push(existingRoute);
 


### PR DESCRIPTION
When an `APP_RECEIVED` event is fired, the `app` object that comes along with it contains all the route and domain information we need. So on that event, we can update the route store instead of only relying on sending a subsequent network request. If the `app` object doesn’t contain a child `routes` array then we will just ignore the event.

Also changed the `appGuid` key in the route store to `app_guid` to be consistent with the kinds of data structures we keep in our stores.

Refs #468 