### PR TITLE
Rename container components

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -21,7 +21,7 @@ function stateSetter(current) {
   };
 }
 
-export default class AppPage extends React.Component {
+export default class AppContainer extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
@@ -199,6 +199,6 @@ export default class AppPage extends React.Component {
   }
 }
 
-AppPage.propTypes = {
+AppContainer.propTypes = {
   initialAppGuid: React.PropTypes.string.isRequired
 };

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -1,12 +1,7 @@
 
 import React from 'react';
-
-import cgBaseStyles from 'cloudgov-style/css/base.css';
-import mainContentStyles from 'cloudgov-style/css/components/main-content.css';
-import sidenavStyles from 'cloudgov-style/css/components/sidenav.css';
-import titleBarStyles from 'cloudgov-style/css/components/title_bar.css';
-import navToggleStyles from 'cloudgov-style/css/components/nav_toggle.css';
-import overrideStyles from '../css/overrides.css';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+import overrideStyle from '../css/overrides.css';
 
 import createStyler from '../util/create_styler';
 
@@ -23,14 +18,7 @@ function getState() {
 export default class App extends React.Component {
   constructor(props) {
     super(props);
-    this.styler = createStyler(
-      cgBaseStyles,
-      mainContentStyles,
-      sidenavStyles,
-      titleBarStyles,
-      navToggleStyles,
-      overrideStyles
-    );
+    this.styler = createStyler(style, overrideStyle);
     this.state = { isLoggedIn: false };
     this._onChange = this._onChange.bind(this);
   }

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -6,15 +6,15 @@ import mainContentStyles from 'cloudgov-style/css/components/main-content.css';
 import sidenavStyles from 'cloudgov-style/css/components/sidenav.css';
 import titleBarStyles from 'cloudgov-style/css/components/title_bar.css';
 import navToggleStyles from 'cloudgov-style/css/components/nav_toggle.css';
-import overrideStyles from './css/overrides.css';
+import overrideStyles from '../css/overrides.css';
 
-import createStyler from './util/create_styler';
+import createStyler from '../util/create_styler';
 
-import Disclaimer from './components/disclaimer.jsx';
-import Header from './components/header.jsx';
-import Login from './components/login.jsx';
-import LoginStore from './stores/login_store.js';
-import { Nav } from './components/navbar.jsx';
+import Disclaimer from './disclaimer.jsx';
+import Header from './header.jsx';
+import Login from './login.jsx';
+import LoginStore from '../stores/login_store.js';
+import { Nav } from './navbar.jsx';
 
 function getState() {
   return { isLoggedIn: LoginStore.isLoggedIn() };

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -15,7 +15,7 @@ const PAGES = {
   'users': Users
 }
 
-export default class Space extends React.Component {
+export default class SpaceContainer extends React.Component {
   constructor(props) {
     super(props);
 
@@ -122,12 +122,12 @@ export default class Space extends React.Component {
   }
 };
 
-Space.propTypes = {
+SpaceContainer.propTypes = {
   currentPage: React.PropTypes.string,
   initialOrgGuid: React.PropTypes.string.isRequired,
   initialSpaceGuid: React.PropTypes.string.isRequired
 };
 
-Space.defaultProps = {
+SpaceContainer.defaultProps = {
   currentPage: 'apps'
 };

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -8,17 +8,17 @@ import { Router } from 'director';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import App from './app.jsx';
-import AppPage from './components/app_page.jsx';
+import AppContainer from './components/app_container.jsx';
 import appActions from './actions/app_actions.js';
 import cfApi from './util/cf_api.js';
 import Home from './components/home.jsx';
 import Login from './components/login.jsx';
+import MainContainer from './components/main_container.jsx';
 import Marketplace from './components/marketplace.jsx';
 import orgActions from './actions/org_actions.js';
 import spaceActions from './actions/space_actions.js';
 import serviceActions from './actions/service_actions.js';
-import Space from './components/space.jsx';
+import SpaceContainer from './components/space_container.jsx';
 import SpaceList from './components/space_list.jsx';
 import { trackPageView } from './util/analytics.js';
 import uaaApi from './util/uaa_api.js';
@@ -26,15 +26,14 @@ import userActions from './actions/user_actions.js';
 
 const mainEl = document.querySelector('.js-app');
 
-
 function login() {
-  ReactDOM.render(<App><Login /></App>, mainEl);
+  ReactDOM.render(<MainContainer><Login /></MainContainer>, mainEl);
 }
 
 function dashboard() {
-  ReactDOM.render(<App>
+  ReactDOM.render(<MainContainer>
     <Home />
-  </App>, mainEl);
+  </MainContainer>, mainEl);
 }
 
 function org(orgGuid) {
@@ -42,9 +41,9 @@ function org(orgGuid) {
   orgActions.toggleSpaceMenu(orgGuid);
   orgActions.fetch(orgGuid);
   ReactDOM.render(
-    <App>
+    <MainContainer>
       <SpaceList initialOrgGuid={ orgGuid } />
-    </App>, mainEl);
+    </MainContainer>, mainEl);
 }
 
 function space(orgGuid, spaceGuid, potentialPage) {
@@ -64,13 +63,13 @@ function space(orgGuid, spaceGuid, potentialPage) {
     userActions.fetchSpaceUsers(spaceGuid);
   }
   ReactDOM.render(
-    <App initialSpaceGuid={spaceGuid}>
-      <Space
+    <MainContainer initialSpaceGuid={spaceGuid}>
+      <SpaceContainer
         initialSpaceGuid={ spaceGuid}
         initialOrgGuid={ orgGuid }
         currentPage={ potentialPage }
       />
-    </App>, mainEl);
+    </MainContainer>, mainEl);
 }
 
 function app(orgGuid, spaceGuid, appGuid) {
@@ -80,11 +79,11 @@ function app(orgGuid, spaceGuid, appGuid) {
   appActions.fetch(appGuid);
   appActions.fetchStats(appGuid);
   ReactDOM.render(
-    <App initialSpaceGuid={ spaceGuid }>
-      <AppPage
+    <MainContainer initialSpaceGuid={ spaceGuid }>
+      <AppContainer
         initialAppGuid={ appGuid }
       />
-    </App>, mainEl);
+    </MainContainer>, mainEl);
 }
 
 function marketplace(orgGuid, serviceGuid, servicePlanGuid) {
@@ -97,9 +96,9 @@ function marketplace(orgGuid, serviceGuid, servicePlanGuid) {
     serviceActions.createInstanceForm(serviceGuid, servicePlanGuid);
   }
   ReactDOM.render(
-    <App>
+    <MainContainer>
       <Marketplace initialOrgGuid={ orgGuid } />
-    </App>,
+    </MainContainer>,
   mainEl);
 }
 

--- a/static_src/test/unit/app.spec.jsx
+++ b/static_src/test/unit/app.spec.jsx
@@ -3,11 +3,11 @@ import '../global_setup.js';
 import React from 'react';
 import TestUtils from 'react/lib/ReactTestUtils';
 
-import App from '../../app.jsx';
+import MainContainer from '../../components/main_container.jsx';
 
 describe('App', function() {
   it('should work', function() {
-    var app = TestUtils.renderIntoDocument(<App/>);
+    var app = TestUtils.renderIntoDocument(<MainContainer/>);
     expect(app).toBeDefined();
   });
 });


### PR DESCRIPTION
Renaming some components to use a “_container” naming scheme which implies that it uses other components to form full views

Refs #461