### PR TITLE
Update domains.

### DIFF
--- a/manifests/eastwest/manifest-region-base.yml
+++ b/manifests/eastwest/manifest-region-base.yml
@@ -1,6 +1,7 @@
 ---
 inherit: ../manifest-base.yml
-domain: cloud.gov
+no-hostname: true
+domain: dashboard.cloud.gov
 env:
   CONSOLE_LOGIN_URL: https://login.cloud.gov/
   CONSOLE_UAA_URL: https://uaa.cloud.gov/

--- a/manifests/govcloud/manifest-region-base.yml
+++ b/manifests/govcloud/manifest-region-base.yml
@@ -1,6 +1,5 @@
 ---
 inherit: ../manifest-base.yml
-domain: fr.cloud.gov
 env:
   CONSOLE_LOGIN_URL: https://login.fr.cloud.gov/
   CONSOLE_UAA_URL: https://uaa.fr.cloud.gov/


### PR DESCRIPTION
Part of https://github.com/18F/cg-atlas/issues/133.

* Use new custom domain `dashboard.cloud.gov` for EW
* Drop custom domain for GC