### PR TITLE
Refactor fetching to not emit a change event

### DIFF
--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -42,7 +42,7 @@ export default class App extends React.Component {
     if (this.state.isLoggedIn) {
       content = this.props.children;
       sidebar = <Nav
-        initialCurrentOrgGuid={ this.props.currentOrgGuid }
+        initialCurrentOrgGuid={ this.props.initialOrgGuid }
         initialSpaceGuid={ this.props.initialSpaceGuid }
       />;
     } else {
@@ -70,12 +70,12 @@ export default class App extends React.Component {
 }
 App.propTypes = {
   children: React.PropTypes.any,
-  currentOrgGuid: React.PropTypes.string,
+  initialOrgGuid: React.PropTypes.string,
   initialSpaceGuid: React.PropTypes.string
 };
 
 App.defaultProps = {
   children: [],
-  currentOrgGuid: '0',
+  initialOrgGuid: '0',
   initialSpaceGuid: '0'
 };

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -24,7 +24,7 @@ export class Nav extends React.Component {
     super(props);
     this.props = props;
     this.state = {
-      currentOrg: OrgStore.get(this.props.initialCurrentOrgGuid),
+      currentOrg: OrgStore.get(this.props.initialOrgGuid),
       currentSpace: SpaceStore.get(this.props.initialSpaceGuid),
       orgs: OrgStore.getAll() || []
     };
@@ -53,7 +53,7 @@ export class Nav extends React.Component {
   }
 
   _handleOrgClick(orgGuid) {
-    orgActions.changeCurrentOrg(orgGuid);
+    orgActions.toggleSpaceMenu(orgGuid);
   }
 
   _toggleSpacesMenu(orgGuid, ev) {
@@ -156,10 +156,10 @@ export class Nav extends React.Component {
 }
 Nav.propTypes = {
   subLinks: React.PropTypes.array,
-  initialCurrentOrgGuid: React.PropTypes.string,
+  initialOrgGuid: React.PropTypes.string,
   initialSpaceGuid: React.PropTypes.string
 };
 Nav.defaultProps = {
-  initialCurrentOrgGuid: '0',
+  initialOrgGuid: '0',
   initialSpaceGuid: '0'
 };

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -15,16 +15,20 @@ const PAGES = {
   'users': Users
 }
 
+function stateSetter() {
+  return {
+    space: SpaceStore.currentSpace(),
+    currentOrg: OrgStore.currentOrg(),
+    currentOrgGuid: OrgStore.currentOrgGuid
+    currentSpaceGuid: SpaceStore.currentSpaceGuid
+  };
+}
+
 export default class SpaceContainer extends React.Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      space: SpaceStore.get(this.props.initialSpaceGuid) || {},
-      currentOrg: OrgStore.get(this.props.initialOrgGuid),
-      currentSpaceGuid: this.props.initialSpaceGuid
-    };
-
+    this.props = props;
+    this.state = stateSetter();
     this._onChange = this._onChange.bind(this);
     this.spaceUrl = this.spaceUrl.bind(this);
   }
@@ -38,11 +42,7 @@ export default class SpaceContainer extends React.Component {
   }
 
   _onChange() {
-    this.setState({
-      currentOrg: OrgStore.get(OrgStore.currentOrgGuid),
-      currentSpaceGuid: this.props.initialSpaceGuid,
-      space: SpaceStore.get(this.props.initialSpaceGuid)
-    });
+    this.setState(stateSetter());
   }
 
   spaceUrl(page) {
@@ -76,7 +76,7 @@ export default class SpaceContainer extends React.Component {
   }
 
   get currentOrgGuid() {
-    return this.state.currentOrg ? this.state.currentOrg.guid : '0';
+    return this.state.currentOrg ? this.props.initialOrgGuid : '0';
   }
 
   render() {
@@ -123,9 +123,7 @@ export default class SpaceContainer extends React.Component {
 };
 
 SpaceContainer.propTypes = {
-  currentPage: React.PropTypes.string,
-  initialOrgGuid: React.PropTypes.string.isRequired,
-  initialSpaceGuid: React.PropTypes.string.isRequired
+  currentPage: React.PropTypes.string
 };
 
 SpaceContainer.defaultProps = {

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -21,7 +21,7 @@ export default class SpaceList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = { rows: [], currentOrgGuid: this.props.initialOrgGuid };
+    this.state = { rows: [], currentOrgGuid: OrgStore.currentOrgGuid };
     this._onChange = this._onChange.bind(this);
     this.spaceLink = this.spaceLink.bind(this);
     this.styler = createStyler(style);
@@ -107,6 +107,4 @@ export default class SpaceList extends React.Component {
   }
 }
 
-SpaceList.propTypes = {
-  initialOrgGuid: React.PropTypes.string.isRequired
-};
+SpaceList.propTypes = {};

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -37,17 +37,15 @@ function dashboard() {
 }
 
 function org(orgGuid) {
-  orgActions.changeCurrentOrg(orgGuid);
   orgActions.toggleSpaceMenu(orgGuid);
   orgActions.fetch(orgGuid);
   ReactDOM.render(
     <MainContainer>
-      <SpaceList initialOrgGuid={ orgGuid } />
+      <SpaceList />
     </MainContainer>, mainEl);
 }
 
 function space(orgGuid, spaceGuid, potentialPage) {
-  orgActions.changeCurrentOrg(orgGuid);
   orgActions.toggleSpaceMenu(orgGuid);
   spaceActions.changeCurrentSpace(spaceGuid);
   // TODO what happens if the space arrives before the changelistener is added?
@@ -89,7 +87,6 @@ function app(orgGuid, spaceGuid, appGuid) {
 function marketplace(orgGuid, serviceGuid, servicePlanGuid) {
   orgActions.fetch(orgGuid);
   serviceActions.fetchAllServices(orgGuid);
-  orgActions.changeCurrentOrg(orgGuid);
   orgActions.toggleSpaceMenu(orgGuid);
   spaceActions.changeCurrentSpace('0');
   if (serviceGuid && servicePlanGuid) {

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -21,7 +21,7 @@ class AppStore extends BaseStore {
     switch (action.type) {
       case appActionTypes.APP_FETCH:
         cfApi.fetchApp(action.appGuid);
-        this.fetching = true; // set fetching will .emitChange()
+        this.fetching = true;
         break;
 
       case appActionTypes.APP_STATS_FETCH:
@@ -31,6 +31,7 @@ class AppStore extends BaseStore {
       case appActionTypes.APP_RECEIVED:
         this.merge('guid', action.app, () => {
           this.fetching = false;
+          this.emitChange();
         });
         break;
 
@@ -50,6 +51,7 @@ class AppStore extends BaseStore {
 
       case appActionTypes.APP_ALL_RECEIVED: {
         this.fetching = false;
+        this.emitChange();
         break;
       }
 

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -36,7 +36,6 @@ export default class BaseStore extends EventEmitter {
     if (!!value === this._fetching) return;
 
     this._fetching = !!value;
-    this.emitChange();
   }
 
   isEmpty() {

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -75,14 +75,6 @@ class OrgStore extends BaseStore {
         break;
       }
 
-      case orgActionTypes.ORG_CHANGE_CURRENT: {
-        // TODO is this needed anymore or should we use toggle space menu?
-        this._currentOrgGuid = action.orgGuid;
-        this.emitChange();
-
-        break;
-      }
-
       case orgActionTypes.ORG_TOGGLE_SPACE_MENU: {
         this._currentOrgGuid = action.orgGuid;
         const updates = this.updateOpenOrgs(action.orgGuid);
@@ -95,6 +87,10 @@ class OrgStore extends BaseStore {
       default:
         break;
     }
+  }
+
+  currentOrg() {
+    return this.get(this._currentOrgGuid);
   }
 
   get currentOrgGuid() {

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -39,6 +39,7 @@ class OrgStore extends BaseStore {
         if (action.org) {
           this.merge('guid', action.org, () => {
             this.fetching = false;
+            this.emitChange();
           });
         }
         break;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -52,6 +52,7 @@ class ServiceInstanceStore extends BaseStore {
         const services = this.formatSplitResponse(action.serviceInstances);
         this._data = Immutable.fromJS(services);
         this.fetching = false;
+        this.emitChange();
         break;
       }
 

--- a/static_src/stores/service_plan_store.js
+++ b/static_src/stores/service_plan_store.js
@@ -64,6 +64,7 @@ class ServicePlanStore extends BaseStore {
 
           this.mergeMany('guid', servicePlans, () => {
             this.fetching = false;
+            this.emitChange();
           });
         }
         break;

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -57,6 +57,10 @@ class SpaceStore extends BaseStore {
     }
   }
 
+  currentSpace() {
+    return this.get(this._currentSpaceGuid);
+  }
+
   get currentSpaceGuid() {
     return this._currentSpaceGuid;
   }

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -41,6 +41,7 @@ class SpaceStore extends BaseStore {
       case spaceActionTypes.SPACE_RECEIVED: {
         this.merge('guid', action.space, () => {
           this.fetching = false;
+          this.emitChange();
         });
         break;
       }

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -81,7 +81,6 @@ describe('AppStore', function() {
     it('should emit a change event if data was updated', function() {
       var spy = sandbox.spy(AppStore, 'emitChange');
 
-      AppStore._fetching = true;
       AppDispatcher.handleViewAction({
         type: appActionTypes.APP_RECEIVED,
         app: { guid: 'asdf' }
@@ -91,10 +90,11 @@ describe('AppStore', function() {
     });
 
     it('should not emit a change event if data was not changed', function() {
-      var spy = sandbox.spy(AppStore, 'emitChange');
       var app = { guid: 'asdf' };
 
       AppStore.push(app);
+
+      const spy = sandbox.spy(AppStore, 'emitChange');
 
       AppDispatcher.handleViewAction({
         type: appActionTypes.APP_RECEIVED,

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -217,14 +217,6 @@ describe('BaseStore', () => {
       expect(store.fetching).toEqual(false);
     });
 
-    it('should emit change if the value is different', function () {
-      var spy = sandbox.spy();
-
-      store.on('CHANGE', spy);
-      store.fetching = true;
-      expect(spy).toHaveBeenCalledOnce();
-    });
-
     it('should not emit change if the value is the same', function () {
       var spy = sandbox.spy();
 

--- a/static_src/test/unit/stores/org_store.spec.js
+++ b/static_src/test/unit/stores/org_store.spec.js
@@ -177,26 +177,6 @@ describe('OrgStore', () => {
     });
   });
 
-  describe('on org change current', function() {
-    let expected;
-
-    beforeEach(function () {
-      expected = { guid: 'sdsf', name: 'testA' };
-      OrgStore.push(expected);
-    });
-
-    it('should emit a change event if it finds the org', function() {
-      var spy = sandbox.spy(OrgStore, 'emitChange');
-
-      AppDispatcher.handleViewAction({
-        type: orgActionTypes.ORG_CHANGE_CURRENT,
-        orgGuid: expected.guid
-      });
-
-      expect(spy).toHaveBeenCalledOnce();
-    });
-  });
-
   describe('on a space menu toggle', function() {
     let expected;
     beforeEach(function () {


### PR DESCRIPTION
Refactors fetching code so it doesn't emit a change event.

This allows more precise control to the developer when a change event should happen. The exact problem that lead to this was when new service plans were coming in, they weren't being shown because a change event wasn't firing because fetching was already set to false. Might need to further expand this pattern of fetching.