### PR TITLE
Attempt to fix deploy

### DIFF
--- a/manifests/eastwest/manifest-region-base.yml
+++ b/manifests/eastwest/manifest-region-base.yml
@@ -1,7 +1,5 @@
 ---
 inherit: ../manifest-base.yml
-no-hostname: true
-domain: dashboard.cloud.gov
 env:
   CONSOLE_LOGIN_URL: https://login.cloud.gov/
   CONSOLE_UAA_URL: https://uaa.cloud.gov/


### PR DESCRIPTION
If we set the domain key in the base manifest the deploy fails with:

```
error: The route dashboard.cloud.gov is already in use.
```

I think we're not supposed to have a domain set, but it will use the
domain already set on the app?