### PR TITLE
Separate user page routes

### DIFF
--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -9,17 +9,23 @@ import Disclaimer from './disclaimer.jsx';
 import Header from './header.jsx';
 import Login from './login.jsx';
 import LoginStore from '../stores/login_store.js';
+import OrgStore from '../stores/org_store.js';
+import SpaceStore from '../stores/space_store.js';
 import { Nav } from './navbar.jsx';
 
-function getState() {
-  return { isLoggedIn: LoginStore.isLoggedIn() };
+function stateSetter() {
+  return {
+    currentOrgGuid: OrgStore.currentOrgGuid,
+    currentSpaceGuid: SpaceStore.currentSpaceGuid,
+    isLoggedIn: LoginStore.isLoggedIn()
+  };
 }
 
 export default class App extends React.Component {
   constructor(props) {
     super(props);
     this.styler = createStyler(style, overrideStyle);
-    this.state = { isLoggedIn: false };
+    this.state = stateSetter();;
     this._onChange = this._onChange.bind(this);
   }
 
@@ -32,7 +38,7 @@ export default class App extends React.Component {
   }
 
   _onChange() {
-    this.setState(getState());
+    this.setState(stateSetter());
   }
 
   render() {
@@ -42,8 +48,8 @@ export default class App extends React.Component {
     if (this.state.isLoggedIn) {
       content = this.props.children;
       sidebar = <Nav
-        initialCurrentOrgGuid={ this.props.initialOrgGuid }
-        initialSpaceGuid={ this.props.initialSpaceGuid }
+        initialCurrentOrgGuid={ this.state.currentOrgGuid }
+        initialSpaceGuid={ this.state.currentSpaceGuid }
       />;
     } else {
       content = <Login />;
@@ -69,13 +75,9 @@ export default class App extends React.Component {
   }
 }
 App.propTypes = {
-  children: React.PropTypes.any,
-  initialOrgGuid: React.PropTypes.string,
-  initialSpaceGuid: React.PropTypes.string
+  children: React.PropTypes.any
 };
 
 App.defaultProps = {
-  children: [],
-  initialOrgGuid: '0',
-  initialSpaceGuid: '0'
+  children: []
 };

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -15,6 +15,11 @@ const PAGES = {
   'users': Users
 }
 
+const USER_PAGES = {
+  'space': 'space_users',
+  'org': 'org_users'
+}
+
 function stateSetter() {
   return {
     space: SpaceStore.currentSpace(),
@@ -123,11 +128,9 @@ export default class SpaceContainer extends React.Component {
 };
 
 SpaceContainer.propTypes = {
-  currentPage: React.PropTypes.string,
-  currentUserPage: React.PropTypes.string
+  currentPage: React.PropTypes.string
 };
 
 SpaceContainer.defaultProps = {
-  currentPage: 'apps',
-  currentUserPage: 'space'
+  currentPage: 'apps'
 };

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -104,8 +104,8 @@ export default class SpaceContainer extends React.Component {
         <div>
           <div role="tabpanel" id={ this.props.currentPage }>
             <Content
-              initialOrgGuid={ this.currentOrgGuid }
-              initialSpaceGuid={ this.state.space.guid }
+              initialOrgGuid={ this.state.currentOrgGuid }
+              initialSpaceGuid={ this.state.currentSpaceGuid }
               intitialApps={ this.state.space.apps || [] }
             />
           </div>
@@ -123,9 +123,11 @@ export default class SpaceContainer extends React.Component {
 };
 
 SpaceContainer.propTypes = {
-  currentPage: React.PropTypes.string
+  currentPage: React.PropTypes.string,
+  currentUserPage: React.PropTypes.string
 };
 
 SpaceContainer.defaultProps = {
-  currentPage: 'apps'
+  currentPage: 'apps',
+  currentUserPage: 'space'
 };

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -44,7 +44,7 @@ export default class Users extends React.Component {
     this.state = {
       currentOrgGuid: props.initialOrgGuid,
       currentSpaceGuid: props.initialSpaceGuid,
-      currentTab: props.initialCurrentTab,
+      currentTab: UserStore.currentlyViewedType,
       loading: UserStore.fetching,
       currentUserAccess: UserStore.currentUserHasOrgRole('org_manager'),
       users: (props.initialCurrentTab === TAB_ORG_NAME) ?
@@ -111,6 +111,10 @@ export default class Users extends React.Component {
     return resourceGuid;
   }
 
+  userUrl(page) {
+    return `/#/org/${this.state.currentOrgGuid}/spaces/${this.state.currentSpaceGuid}/users/${page}`;
+  }
+
   get subNav() {
     const tabs = [
       { name: 'space_users' },
@@ -118,13 +122,13 @@ export default class Users extends React.Component {
     ];
     // TODO refactor link, use a special link component.
     tabs[0].element = (
-      <a onClick={ this.handleTabClick.bind(this, tabs[0].name) }>
+      <a href={ this.userUrl('space') }>
         Current space users
       </a>
     );
 
     tabs[1].element = (
-      <a onClick={ this.handleTabClick.bind(this, tabs[1].name) }>
+      <a href={ this.userUrl('org') }>
         All organization users
       </a>
     );
@@ -180,11 +184,9 @@ export default class Users extends React.Component {
 }
 
 Users.propTypes = {
-  initialCurrentTab: React.PropTypes.string.isRequired,
   initialOrgGuid: React.PropTypes.string.isRequired,
   initialSpaceGuid: React.PropTypes.string.isRequired
 };
 
 Users.defaultProps = {
-  initialCurrentTab: 'space_users'
 };

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -83,7 +83,7 @@ function users(orgGuid, spaceGuid, potentialPage) {
     userActions.changeCurrentlyViewedType('space_users');
     userActions.fetchSpaceUsers(spaceGuid);
   }
-  renderSpaceContainer('users')
+  renderSpaceContainer('users');
 }
 
 function app(orgGuid, spaceGuid, appGuid) {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -53,12 +53,11 @@ function space(orgGuid, spaceGuid) {
   spaceActions.fetch(spaceGuid);
 }
 
-function renderSpaceContainer(page, potentialUserPage) {
+function renderSpaceContainer(page) {
   ReactDOM.render(
     <MainContainer>
       <SpaceContainer
         currentPage={ page }
-        currentUserPage={ potentialUserPage }
       />
     </MainContainer>, mainEl);
 }
@@ -76,13 +75,15 @@ function services(orgGuid, spaceGuid) {
 
 function users(orgGuid, spaceGuid, potentialPage) {
   space(orgGuid, spaceGuid);
-  if (potentialPage === 'organization') {
+  if (potentialPage === 'org') {
+    userActions.changeCurrentlyViewedType('org_users');
     userActions.fetchOrgUsers(orgGuid);
     userActions.fetchOrgUserRoles(orgGuid);
   } else {
+    userActions.changeCurrentlyViewedType('space_users');
     userActions.fetchSpaceUsers(spaceGuid);
   }
-  renderSpaceContainer('users', potentialPage);
+  renderSpaceContainer('users')
 }
 
 function app(orgGuid, spaceGuid, appGuid) {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -45,29 +45,44 @@ function org(orgGuid) {
     </MainContainer>, mainEl);
 }
 
-function space(orgGuid, spaceGuid, potentialPage) {
+function space(orgGuid, spaceGuid) {
   orgActions.toggleSpaceMenu(orgGuid);
   spaceActions.changeCurrentSpace(spaceGuid);
   // TODO what happens if the space arrives before the changelistener is added?
   cfApi.fetchOrg(orgGuid);
   spaceActions.fetch(spaceGuid);
-  // TODO use constant
-  if (potentialPage === 'services') {
-    serviceActions.fetchAllInstances(spaceGuid);
-  }
-  if (potentialPage === 'users') {
-    userActions.fetchOrgUsers(orgGuid);
-    userActions.fetchOrgUserRoles(orgGuid);
-    userActions.fetchSpaceUsers(spaceGuid);
-  }
+}
+
+function renderSpaceContainer(page, potentialUserPage) {
   ReactDOM.render(
-    <MainContainer initialSpaceGuid={spaceGuid}>
+    <MainContainer>
       <SpaceContainer
-        initialSpaceGuid={ spaceGuid}
-        initialOrgGuid={ orgGuid }
-        currentPage={ potentialPage }
+        currentPage={ page }
+        currentUserPage={ potentialUserPage }
       />
     </MainContainer>, mainEl);
+}
+
+function apps(orgGuid, spaceGuid) {
+  space(orgGuid, spaceGuid);
+  renderSpaceContainer('apps');
+}
+
+function services(orgGuid, spaceGuid) {
+  space(orgGuid, spaceGuid);
+  serviceActions.fetchAllInstances(spaceGuid);
+  renderSpaceContainer('services');
+}
+
+function users(orgGuid, spaceGuid, potentialPage) {
+  space(orgGuid, spaceGuid);
+  if (potentialPage === 'organization') {
+    userActions.fetchOrgUsers(orgGuid);
+    userActions.fetchOrgUserRoles(orgGuid);
+  } else {
+    userActions.fetchSpaceUsers(spaceGuid);
+  }
+  renderSpaceContainer('users', potentialPage);
 }
 
 function app(orgGuid, spaceGuid, appGuid) {
@@ -118,15 +133,23 @@ const routes = {
     '/:orgGuid': {
       '/spaces': {
         '/:spaceGuid': {
-          '/:page': {
-            on: space
+          '/services': {
+            on: services
+          },
+          '/users': {
+            '/:page': {
+              on: users
+            },
+
+            on: users
           },
           '/apps': {
             '/:appGuid': {
               on: app
-            }
+            },
+            on: apps
           },
-          on: space
+          on: apps
         }
       },
       '/marketplace': {


### PR DESCRIPTION
Fixes the loading state problems on the user page by having separate routes for org and space users and only loading the correct corresponding user types.

Also refactors the space router so each page has it's own function that all use a few central method for spaces.