### PR TITLE
Refactor initial load

### DIFF
--- a/static_src/actions/service_actions.js
+++ b/static_src/actions/service_actions.js
@@ -4,8 +4,6 @@
  * updating, etc should go here.
  */
 
-// TODO I'm still unsure of how to model services vs service entities.
-
 import AppDispatcher from '../dispatcher.js';
 import { serviceActionTypes } from '../constants';
 

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -6,18 +6,22 @@ import Reactable from 'reactable';
 
 import createStyler from '../util/create_styler';
 import Loading from './loading.jsx';
+import OrgStore from '../stores/org_store.js';
 import SpaceStore from '../stores/space_store.js';
 
 const unsafe = Reactable.unsafe;
 
-function stateSetter(props) {
-  const space = SpaceStore.get(props.initialSpaceGuid);
+function stateSetter() {
+  const currentOrgGuid = OrgStore.currentOrgGuid;
+  const currentSpaceGuid = SpaceStore.currentSpaceGuid;
+
+  const space = SpaceStore.get(currentSpaceGuid);
   const apps = (space && space.apps) ? space.apps : [];
 
   return {
     apps: apps,
-    currentOrgGuid: props.initialOrgGuid,
-    currentSpaceGuid: props.initialSpaceGuid,
+    currentOrgGuid,
+    currentSpaceGuid,
     loading: SpaceStore.fetching,
     empty: SpaceStore.fetched && !apps.length
   };
@@ -27,7 +31,7 @@ export default class AppList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = stateSetter(props);
+    this.state = stateSetter();
     this._onChange = this._onChange.bind(this);
     this.styler = createStyler(style);
   }
@@ -37,7 +41,7 @@ export default class AppList extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState(stateSetter(nextProps));
+    this.setState(stateSetter());
   }
 
   componentWillUnmount() {
@@ -124,9 +128,7 @@ export default class AppList extends React.Component {
 }
 
 AppList.propTypes = {
-  initialApps: React.PropTypes.array,
-  initialOrgGuid: React.PropTypes.string.isRequired,
-  initialSpaceGuid: React.PropTypes.string.isRequired
+  initialApps: React.PropTypes.array
 };
 
 AppList.defaultProps = {

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -47,10 +47,7 @@ export default class App extends React.Component {
 
     if (this.state.isLoggedIn) {
       content = this.props.children;
-      sidebar = <Nav
-        initialCurrentOrgGuid={ this.state.currentOrgGuid }
-        initialSpaceGuid={ this.state.currentSpaceGuid }
-      />;
+      sidebar = <Nav />;
     } else {
       content = <Login />;
     }

--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -13,17 +13,19 @@ import ServiceStore from '../stores/service_store.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
 
-function stateSetter(orgGuid) {
+function stateSetter() {
   const loading = ServiceStore.fetching || ServicePlanStore.fetching;
   const services = ServiceStore.getAll().map((service) => {
     const plan = ServicePlanStore.getAllFromService(service.guid);
     return { ...service, servicePlans: plan };
   });
+  const currentOrgGuid = OrgStore.currentOrgGuid;
 
   return {
     loading,
     services,
-    currentOrg: OrgStore.get(orgGuid),
+    currentOrgGuid,
+    currentOrg: OrgStore.get(currentOrgGuid),
     createInstanceForm: ServiceInstanceStore.createInstanceForm
   };
 }
@@ -32,7 +34,7 @@ export default class Marketplace extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = stateSetter(this.props.initialOrgGuid);
+    this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);
   }
@@ -52,7 +54,7 @@ export default class Marketplace extends React.Component {
   }
 
   _onChange() {
-    this.setState(stateSetter(this.props.initialOrgGuid));
+    this.setState(stateSetter());
   }
 
   render() {
@@ -93,6 +95,4 @@ export default class Marketplace extends React.Component {
   }
 }
 
-Marketplace.propTypes = {
-  initialOrgGuid: React.PropTypes.string.isRequired
-};
+Marketplace.propTypes = { };

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -23,11 +23,7 @@ export class Nav extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = {
-      currentOrg: OrgStore.get(this.props.initialOrgGuid),
-      currentSpace: SpaceStore.get(this.props.initialSpaceGuid),
-      orgs: OrgStore.getAll() || []
-    };
+    this.state = stateSetter();
     this.styler = createStyler(style);
     this._onChange = this._onChange.bind(this);
     this._handleOverviewClick = this._handleOverviewClick.bind(this);
@@ -155,11 +151,8 @@ export class Nav extends React.Component {
   }
 }
 Nav.propTypes = {
-  subLinks: React.PropTypes.array,
-  initialOrgGuid: React.PropTypes.string,
-  initialSpaceGuid: React.PropTypes.string
+  subLinks: React.PropTypes.array
 };
 Nav.defaultProps = {
-  initialOrgGuid: '0',
-  initialSpaceGuid: '0'
+  subLinks: []
 };

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -11,14 +11,16 @@ import ConfirmationBox from './confirmation_box.jsx';
 import Loading from './loading.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
+import SpaceStore from '../stores/space_store.js';
 
-function stateSetter(props) {
+function stateSetter() {
+  const currentSpaceGuid = SpaceStore.currentSpaceGuid;
   const serviceInstances = ServiceInstanceStore.getAllBySpaceGuid(
-    props.initialSpaceGuid);
+    currentSpaceGuid);
 
   return {
     serviceInstances: serviceInstances,
-    currentSpaceGuid: props.initialSpaceGuid,
+    currentSpaceGuid,
     loading: ServiceInstanceStore.fetching,
     empty: ServiceInstanceStore.fetched && !serviceInstances.length
   };
@@ -28,7 +30,8 @@ export default class ServiceInstanceList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = stateSetter(props);
+    this.state = stateSetter();
+
     this._onChange = this._onChange.bind(this);
     this._handleDelete = this._handleDelete.bind(this);
     this._handleDeleteConfirmation = this._handleDeleteConfirmation.bind(this);
@@ -38,7 +41,7 @@ export default class ServiceInstanceList extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState(stateSetter(nextProps));
+    this.setState(stateSetter());
   }
 
   componentDidMount() {
@@ -50,7 +53,7 @@ export default class ServiceInstanceList extends React.Component {
   }
 
   _onChange() {
-    this.setState(stateSetter(this.props));
+    this.setState(stateSetter());
   }
 
   _handleDelete(instanceGuid, ev) {
@@ -167,7 +170,4 @@ export default class ServiceInstanceList extends React.Component {
   }
 }
 
-ServiceInstanceList.propTypes = {
-  initialOrgGuid: React.PropTypes.string,
-  initialSpaceGuid: React.PropTypes.string
-};
+ServiceInstanceList.propTypes = { };

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -66,24 +66,30 @@ export default class ServiceList extends React.Component {
             </tr>
           </thead>
           <tbody>
-          { this.rows.map((row) =>
-            [
+          { this.rows.map((row) => {
+            let instance = [];
+            instance.push(
               <tr key={ row.guid }>
                 { this.columns.map((rowcolumn) =>
                   <td key={ rowcolumn.key }><span>
                     { row[rowcolumn.key] }
                   </span></td>
                 )}
-              </tr>,
-              <tr colSpan="3">
-                <td colSpan="3">
-                <ServicePlanList initialServiceGuid={ row.guid }
-                  initialServicePlans={ row.servicePlans }
-                />
-                </td>
               </tr>
-            ]
-          )}
+            );
+            if (row.servicePlans.length) {
+              instance.push(
+                <tr colSpan="3">
+                  <td colSpan="3">
+                  <ServicePlanList initialServiceGuid={ row.guid }
+                    initialServicePlans={ row.servicePlans }
+                  />
+                  </td>
+                </tr>
+              );
+            }
+            return instance;
+          })}
           </tbody>
         </table>
       </div>

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -65,7 +65,7 @@ export default class ServicePlanList extends React.Component {
   }
 
   render() {
-    let content = <div></div>
+    let content = <div></div>;
 
     if (this.state.empty) {
       content = <h4 className="test-none_message">No service plans</h4>;

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -81,7 +81,7 @@ export default class SpaceContainer extends React.Component {
   }
 
   get currentOrgGuid() {
-    return this.state.currentOrg ? this.props.initialOrgGuid : '0';
+    return this.state.currentOrg || '0';
   }
 
   render() {
@@ -109,8 +109,6 @@ export default class SpaceContainer extends React.Component {
         <div>
           <div role="tabpanel" id={ this.props.currentPage }>
             <Content
-              initialOrgGuid={ this.state.currentOrgGuid }
-              initialSpaceGuid={ this.state.currentSpaceGuid }
               intitialApps={ this.state.space.apps || [] }
             />
           </div>

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -51,7 +51,6 @@ export default class SpaceContainer extends React.Component {
   }
 
   spaceUrl(page) {
-    // TODO fix this with a link somehow
     return `/#/org/${this.state.currentOrg.guid}/spaces/${this.state.space.guid}/${page}`;
   }
 

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -21,7 +21,7 @@ export default class SpaceList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = { rows: [], currentOrgGuid: OrgStore.currentOrgGuid };
+    this.state = stateSetter();
     this._onChange = this._onChange.bind(this);
     this.spaceLink = this.spaceLink.bind(this);
     this.styler = createStyler(style);

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -12,26 +12,26 @@ import Button from './button.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
 import createStyler from '../util/create_styler';
 
+function stateSetter(props) {
+  return {
+    users: props.initialUsers,
+    userType: props.initialUserType,
+    currentUserAccess: props.initialCurrentUserAccess,
+    empty: props.initialEmpty
+  };
+}
 
 export default class UserList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = {
-      users: props.initialUsers,
-      userType: props.initialUserType,
-      currentUserAccess: props.initialCurrentUserAccess
-    };
+    this.state = stateSetter(props);
     this.styler = createStyler(style);
     this._handleDelete = this._handleDelete.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      users: nextProps.initialUsers,
-      userType: nextProps.initialUserType,
-      currentUserAccess: nextProps.initialCurrentUserAccess
-    });
+    this.setState(stateSetter(nextProps));
   }
 
   _handleDelete(userGuid, ev) {
@@ -57,9 +57,11 @@ export default class UserList extends React.Component {
   }
 
   render() {
-    let content = <h4 className="test-none_message">No users</h4>;
+    let content = <div></div>;
 
-    if (this.state.users.length) {
+    if (this.state.empty) {
+      content = <h4 className="test-none_message">No users</h4>;
+    } else if (this.state.users.length) {
       content = (
       <div>
         <p><em>
@@ -145,6 +147,7 @@ UserList.propTypes = {
   initialUsers: React.PropTypes.array,
   initialUserType: React.PropTypes.string,
   initialCurrentUserAccess: React.PropTypes.bool,
+  initialEmpty: React.PropTypes.bool,
   // Set to a function when there should be a remove button.
   onRemove: React.PropTypes.func,
   onRemovePermissions: React.PropTypes.func,
@@ -154,5 +157,6 @@ UserList.propTypes = {
 UserList.defaultProps = {
   initialUsers: [],
   initialUserType: 'space_users',
-  initialCurrentUserAccess: false
+  initialCurrentUserAccess: false,
+  initialEmpty: false
 };

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -48,7 +48,6 @@ function org(orgGuid) {
 function space(orgGuid, spaceGuid) {
   orgActions.toggleSpaceMenu(orgGuid);
   spaceActions.changeCurrentSpace(spaceGuid);
-  // TODO what happens if the space arrives before the changelistener is added?
   cfApi.fetchOrg(orgGuid);
   spaceActions.fetch(spaceGuid);
 }

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -93,7 +93,7 @@ function app(orgGuid, spaceGuid, appGuid) {
   appActions.fetch(appGuid);
   appActions.fetchStats(appGuid);
   ReactDOM.render(
-    <MainContainer initialSpaceGuid={ spaceGuid }>
+    <MainContainer>
       <AppContainer
         initialAppGuid={ appGuid }
       />
@@ -110,7 +110,7 @@ function marketplace(orgGuid, serviceGuid, servicePlanGuid) {
   }
   ReactDOM.render(
     <MainContainer>
-      <Marketplace initialOrgGuid={ orgGuid } />
+      <Marketplace />
     </MainContainer>,
   mainEl);
 }


### PR DESCRIPTION
Refactors initial load by having all components use the stores to get the initial org/space guids. This helps developers and reduces bugs because where you get the data is consistent, leading to less mistakes around not passing around props properly. 

Builds off #529, merge that first

Def #491 