### PR TITLE
Refactor current app guid

### DIFF
--- a/static_src/actions/app_actions.js
+++ b/static_src/actions/app_actions.js
@@ -49,5 +49,12 @@ export default {
       type: appActionTypes.APP_ALL_RECEIVED,
       appGuid
     });
+  },
+
+  changeCurrentApp(appGuid) {
+    AppDispatcher.handleUIAction({
+      type: appActionTypes.APP_CHANGE_CURRENT,
+      appGuid
+    });
   }
 };

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -15,12 +15,13 @@ function appReady(app) {
   return !!app && !!app.name;
 }
 
-function stateSetter(current) {
-  const app = AppStore.get(current.currentAppGuid);
+function stateSetter() {
+  const currentAppGuid = AppStore.currentAppGuid;
+  const app = AppStore.get(currentAppGuid);
 
   return {
     app: app || {},
-    currentAppGuid: current.currentAppGuid,
+    currentAppGuid,
     currentOrgName: OrgStore.currentOrgName,
     currentSpaceName: SpaceStore.currentSpaceName,
     empty: AppStore.fetched && !appReady(app),
@@ -32,7 +33,7 @@ export default class AppContainer extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = stateSetter({ currentAppGuid: this.props.initialAppGuid });
+    this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);
     this.getStat = this.getStat.bind(this);
@@ -52,7 +53,7 @@ export default class AppContainer extends React.Component {
   }
 
   _onChange() {
-    this.setState(stateSetter(this.state));
+    this.setState(stateSetter());
   }
 
   logsLink(appName) {
@@ -209,6 +210,4 @@ export default class AppContainer extends React.Component {
   }
 }
 
-AppContainer.propTypes = {
-  initialAppGuid: React.PropTypes.string.isRequired
-};
+AppContainer.propTypes = { };

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -89,7 +89,9 @@ const appActionTypes = keymirror({
   // The combined result of APP_FETCH and APP_STATS_FETCH
   APP_ALL_FETCH: null,
   // Action when all fetches come back from the server.
-  APP_ALL_RECEIVED: null
+  APP_ALL_RECEIVED: null,
+  // Action when user views a different app
+  APP_CHANGE_CURRENT: null
 });
 
 const userActionTypes = keymirror({

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -92,13 +92,12 @@ function app(orgGuid, spaceGuid, appGuid) {
   spaceActions.fetch(spaceGuid);
   activityActions.fetchSpaceEvents(spaceGuid);
   activityActions.fetchAppLogs(appGuid);
+  appActions.changeCurrentApp(appGuid);
   appActions.fetch(appGuid);
   appActions.fetchStats(appGuid);
   ReactDOM.render(
     <MainContainer>
-      <AppContainer
-        initialAppGuid={ appGuid }
-      />
+      <AppContainer />
     </MainContainer>, mainEl);
 }
 

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -14,6 +14,7 @@ class AppStore extends BaseStore {
   constructor() {
     super();
     this._data = new Immutable.List();
+    this._currentAppGuid = null;
     this.subscribe(() => this._registerToActions.bind(this));
   }
 
@@ -60,9 +61,19 @@ class AppStore extends BaseStore {
         break;
       }
 
+      case appActionTypes.APP_CHANGE_CURRENT: {
+        this._currentAppGuid = action.appGuid;
+        this.emitChange();
+        break;
+      }
+
       default:
         break;
     }
+  }
+
+  get currentAppGuid() {
+    return this._currentAppGuid;
   }
 }
 

--- a/static_src/test/unit/actions/app_actions.spec.js
+++ b/static_src/test/unit/actions/app_actions.spec.js
@@ -2,7 +2,7 @@
 import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
-import { assertAction, setupViewSpy, setupServerSpy } from '../helpers.js';
+import { assertAction, setupUISpy, setupViewSpy, setupServerSpy } from '../helpers.js';
 import cfApi from '../../../util/cf_api.js';
 import appActions from '../../../actions/app_actions.js';
 import { appActionTypes } from '../../../constants.js';
@@ -111,4 +111,17 @@ describe('appActions', function() {
     });
   });
 
+  describe('changeCurrentApp()', function() {
+    it('should dispatch a ui event of type app changed with guid', function() {
+      const appGuid = 'testingAppGuid';
+      const expectedParams = {
+        appGuid
+      };
+      const spy = setupUISpy(sandbox);
+
+      appActions.changeCurrentApp(appGuid);
+
+      assertAction(spy, appActionTypes.APP_CHANGE_CURRENT, {}, expectedParams);
+    });
+  });
 });

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -3,6 +3,7 @@ import Immutable from 'immutable';
 
 import '../../global_setup.js';
 
+import appActions from '../../../actions/app_actions.js';
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
 import { wrapInRes, unwrapOfRes } from '../helpers.js';
@@ -14,6 +15,7 @@ describe('AppStore', function() {
 
   beforeEach(() => {
     AppStore._data = Immutable.List();
+    AppStore._currentAppGuid = null;
     AppStore._fetching = false;
     AppStore._fetched = false;
     sandbox = sinon.sandbox.create();
@@ -224,6 +226,24 @@ describe('AppStore', function() {
         guid: expectedGuid,
         stats: { mem_quota: 12 }
       });
+    });
+  });
+
+  describe('on app change current', function() {
+    it('should set the current app guid to passed guid', function() {
+      const expectedGuid = 'aldfjvcczxcv';
+
+      appActions.changeCurrentApp(expectedGuid);
+
+      expect(AppStore.currentAppGuid).toEqual(expectedGuid);
+    });
+
+    it('should emit a change event', function() {
+      const spy = sandbox.spy(AppStore, 'emitChange');
+
+      appActions.changeCurrentApp('0');
+
+      expect(spy).toHaveBeenCalledOnce();
     });
   });
 });

--- a/static_src/test/unit/stores/service_plan_store.spec.js
+++ b/static_src/test/unit/stores/service_plan_store.spec.js
@@ -137,6 +137,7 @@ describe('ServicePlanStore', function() {
 
     it('should set fetching to false, fetched to true', function() {
       ServicePlanStore.fetching = true;
+      ServicePlanStore.waitingOnRequests = false;
       serviceActions.receivedPlans(wrapInRes([{ guid: 'adfklj' }]));
 
       expect(ServicePlanStore.fetching).toEqual(false);


### PR DESCRIPTION
Rather then passing the current app guid to the app container from main, this makes the container look for it in the store. The main function then changes it with a new change current action.

This is done to keep consistent with how space and org stores/containers are doing it. Sub components of app container will not be changed.

Built off #544 