### PR TITLE
Use separate fetched and fetching on activity

### DIFF
--- a/static_src/stores/activity_store.js
+++ b/static_src/stores/activity_store.js
@@ -60,33 +60,33 @@ class ActivityStore extends BaseStore {
     super();
     this._data = new Immutable.List();
     this.subscribe(() => this._registerToActions.bind(this));
-    this.eventsFetched = false;
-    this.eventsFetching = false;
-    this.logsFetched = false;
-    this.logsFetching = false;
+    this._eventsFetched = false;
+    this._eventsFetching = false;
+    this._logsFetched = false;
+    this._logsFetching = false;
   }
 
   get fetched() {
-    return this.eventsFetched && this.logsFetched;
+    return this._eventsFetched && this._logsFetched;
   }
 
   get fetching() {
-    return this.eventsFetching || this.logsFetching;
+    return this._eventsFetching || this._logsFetching;
   }
 
   _registerToActions(action) {
     let activity;
     switch (action.type) {
       case activityActionTypes.EVENTS_FETCH:
-        this.eventsFetching = true;
-        this.eventsFetched = false;
+        this._eventsFetching = true;
+        this._eventsFetched = false;
         cfApi.fetchSpaceEvents(action.spaceGuid);
         this.emitChange();
         break;
 
       case activityActionTypes.EVENTS_RECEIVED:
-        this.eventsFetching = false;
-        this.eventsFetched = true;
+        this._eventsFetching = false;
+        this._eventsFetched = true;
         activity = this.formatSplitResponse(action.events).map((event) => {
           const item = Object.assign({}, event, {
             activity_type: 'event'
@@ -98,15 +98,15 @@ class ActivityStore extends BaseStore {
         break;
 
       case activityActionTypes.LOGS_FETCH:
-        this.logsFetching = true;
-        this.logsFetched = false;
+        this._logsFetching = true;
+        this._logsFetched = false;
         cfApi.fetchAppLogs(action.appGuid);
         this.emitChange();
         break;
 
       case activityActionTypes.LOGS_RECEIVED:
-        this.logsFetching = false;
-        this.logsFetched = true;
+        this._logsFetching = false;
+        this._logsFetched = true;
         activity = action.logs.map((log) => {
           const parsed = Object.assign({}, parseLogItem(log), {
             activity_type: 'log'

--- a/static_src/stores/activity_store.js
+++ b/static_src/stores/activity_store.js
@@ -60,21 +60,33 @@ class ActivityStore extends BaseStore {
     super();
     this._data = new Immutable.List();
     this.subscribe(() => this._registerToActions.bind(this));
+    this.eventsFetched = false;
+    this.eventsFetching = false;
+    this.logsFetched = false;
+    this.logsFetching = false;
+  }
+
+  get fetched() {
+    return this.eventsFetched && this.logsFetched;
+  }
+
+  get fetching() {
+    return this.eventsFetching || this.logsFetching;
   }
 
   _registerToActions(action) {
     let activity;
     switch (action.type) {
       case activityActionTypes.EVENTS_FETCH:
-        this.fetching = true;
-        this.fetched = false;
+        this.eventsFetching = true;
+        this.eventsFetched = false;
         cfApi.fetchSpaceEvents(action.spaceGuid);
         this.emitChange();
         break;
 
       case activityActionTypes.EVENTS_RECEIVED:
-        this.fetching = false;
-        this.fetched = true;
+        this.eventsFetching = false;
+        this.eventsFetched = true;
         activity = this.formatSplitResponse(action.events).map((event) => {
           const item = Object.assign({}, event, {
             activity_type: 'event'
@@ -86,15 +98,15 @@ class ActivityStore extends BaseStore {
         break;
 
       case activityActionTypes.LOGS_FETCH:
-        this.fetching = true;
-        this.fetched = false;
+        this.logsFetching = true;
+        this.logsFetched = false;
         cfApi.fetchAppLogs(action.appGuid);
         this.emitChange();
         break;
 
       case activityActionTypes.LOGS_RECEIVED:
-        this.fetching = false;
-        this.fetched = true;
+        this.logsFetching = false;
+        this.logsFetched = true;
         activity = action.logs.map((log) => {
           const parsed = Object.assign({}, parseLogItem(log), {
             activity_type: 'log'

--- a/static_src/test/unit/stores/activity_store.spec.js
+++ b/static_src/test/unit/stores/activity_store.spec.js
@@ -14,10 +14,10 @@ describe('ActivityStore', function() {
 
   beforeEach(() => {
     ActivityStore._data = Immutable.List();
-    ActivityStore.eventsFetched = false;
-    ActivityStore.eventsFetching = false;
-    ActivityStore.logsFetched = false;
-    ActivityStore.logsFetching = false;
+    ActivityStore._eventsFetched = false;
+    ActivityStore._eventsFetching = false;
+    ActivityStore._logsFetched = false;
+    ActivityStore._logsFetching = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -49,8 +49,8 @@ describe('ActivityStore', function() {
         spaceGuid: 'fakeSpaceGuid'
       });
 
-      expect(ActivityStore.eventsFetched).toEqual(false);
-      expect(ActivityStore.eventsFetching).toEqual(true);
+      expect(ActivityStore._eventsFetched).toEqual(false);
+      expect(ActivityStore._eventsFetching).toEqual(true);
     });
 
     it('should emit a change event', function() {
@@ -104,8 +104,8 @@ describe('ActivityStore', function() {
         events: wrapInRes(activity)
       });
 
-      expect(ActivityStore.eventsFetched).toEqual(true);
-      expect(ActivityStore.eventsFetching).toEqual(false);
+      expect(ActivityStore._eventsFetched).toEqual(true);
+      expect(ActivityStore._eventsFetching).toEqual(false);
     });
   });
 
@@ -127,8 +127,8 @@ describe('ActivityStore', function() {
         appGuid: 'fakeAppGuid'
       });
 
-      expect(ActivityStore.logsFetched).toEqual(false);
-      expect(ActivityStore.logsFetching).toEqual(true);
+      expect(ActivityStore._logsFetched).toEqual(false);
+      expect(ActivityStore._logsFetching).toEqual(true);
     });
 
     it('should emit a change event', function() {
@@ -174,8 +174,8 @@ describe('ActivityStore', function() {
         logs
       });
 
-      expect(ActivityStore.logsFetched).toEqual(true);
-      expect(ActivityStore.logsFetching).toEqual(false);
+      expect(ActivityStore._logsFetched).toEqual(true);
+      expect(ActivityStore._logsFetching).toEqual(false);
     });
   });
 
@@ -183,14 +183,14 @@ describe('ActivityStore', function() {
     it('should be true when either events or logs fetching', function() {
       expect(ActivityStore.fetching).toEqual(false);
 
-      ActivityStore.logsFetching = true;
+      ActivityStore._logsFetching = true;
       expect(ActivityStore.fetching).toEqual(true);
 
-      ActivityStore.logsFetching = false;
-      ActivityStore.eventsFetching = true;
+      ActivityStore._logsFetching = false;
+      ActivityStore._eventsFetching = true;
       expect(ActivityStore.fetching).toEqual(true);
 
-      ActivityStore.logsFetching = true;
+      ActivityStore._logsFetching = true;
       expect(ActivityStore.fetching).toEqual(true);
     });
   });
@@ -199,14 +199,14 @@ describe('ActivityStore', function() {
     it('should only be true when both events and logs fetched', function() {
       expect(ActivityStore.fetched).toEqual(false);
 
-      ActivityStore.logsFetched = true;
+      ActivityStore._logsFetched = true;
       expect(ActivityStore.fetched).toEqual(false);
 
-      ActivityStore.logsFetched = false;
-      ActivityStore.eventsFetched = true;
+      ActivityStore._logsFetched = false;
+      ActivityStore._eventsFetched = true;
       expect(ActivityStore.fetched).toEqual(false);
 
-      ActivityStore.logsFetched = true;
+      ActivityStore._logsFetched = true;
       expect(ActivityStore.fetched).toEqual(true);
     });
   });

--- a/static_src/test/unit/stores/activity_store.spec.js
+++ b/static_src/test/unit/stores/activity_store.spec.js
@@ -14,8 +14,10 @@ describe('ActivityStore', function() {
 
   beforeEach(() => {
     ActivityStore._data = Immutable.List();
-    ActivityStore._fetching = false;
-    ActivityStore._fetched = false;
+    ActivityStore.eventsFetched = false;
+    ActivityStore.eventsFetching = false;
+    ActivityStore.logsFetched = false;
+    ActivityStore.logsFetching = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -41,14 +43,14 @@ describe('ActivityStore', function() {
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set fetching to true fetched to false', function() {
+    it('should set events fetching to true fetched to false', function() {
       AppDispatcher.handleViewAction({
         type: activityActionTypes.EVENTS_FETCH,
         spaceGuid: 'fakeSpaceGuid'
       });
 
-      expect(ActivityStore.fetched).toEqual(false);
-      expect(ActivityStore.fetching).toEqual(true);
+      expect(ActivityStore.eventsFetched).toEqual(false);
+      expect(ActivityStore.eventsFetching).toEqual(true);
     });
 
     it('should emit a change event', function() {
@@ -89,7 +91,7 @@ describe('ActivityStore', function() {
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set fetched to true, fetching to false', function() {
+    it('should set events fetched to true, fetching to false', function() {
       const activity = [
         {
           guid: 'fakeActivityGuidOne',
@@ -102,8 +104,8 @@ describe('ActivityStore', function() {
         events: wrapInRes(activity)
       });
 
-      expect(ActivityStore.fetched).toEqual(true);
-      expect(ActivityStore.fetching).toEqual(false);
+      expect(ActivityStore.eventsFetched).toEqual(true);
+      expect(ActivityStore.eventsFetching).toEqual(false);
     });
   });
 
@@ -119,14 +121,14 @@ describe('ActivityStore', function() {
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set fetching to true fetched to false', function() {
+    it('should set logs fetching to true fetched to false', function() {
       AppDispatcher.handleViewAction({
         type: activityActionTypes.LOGS_FETCH,
         appGuid: 'fakeAppGuid'
       });
 
-      expect(ActivityStore.fetched).toEqual(false);
-      expect(ActivityStore.fetching).toEqual(true);
+      expect(ActivityStore.logsFetched).toEqual(false);
+      expect(ActivityStore.logsFetching).toEqual(true);
     });
 
     it('should emit a change event', function() {
@@ -172,8 +174,40 @@ describe('ActivityStore', function() {
         logs
       });
 
-      expect(ActivityStore.fetched).toEqual(true);
+      expect(ActivityStore.logsFetched).toEqual(true);
+      expect(ActivityStore.logsFetching).toEqual(false);
+    });
+  });
+
+  describe('fetching', function() {
+    it('should be true when either events or logs fetching', function() {
       expect(ActivityStore.fetching).toEqual(false);
+
+      ActivityStore.logsFetching = true;
+      expect(ActivityStore.fetching).toEqual(true);
+
+      ActivityStore.logsFetching = false;
+      ActivityStore.eventsFetching = true;
+      expect(ActivityStore.fetching).toEqual(true);
+
+      ActivityStore.logsFetching = true;
+      expect(ActivityStore.fetching).toEqual(true);
+    });
+  });
+
+  describe('fetched', function() {
+    it('should only be true when both events and logs fetched', function() {
+      expect(ActivityStore.fetched).toEqual(false);
+
+      ActivityStore.logsFetched = true;
+      expect(ActivityStore.fetched).toEqual(false);
+
+      ActivityStore.logsFetched = false;
+      ActivityStore.eventsFetched = true;
+      expect(ActivityStore.fetched).toEqual(false);
+
+      ActivityStore.logsFetched = true;
+      expect(ActivityStore.fetched).toEqual(true);
     });
   });
 


### PR DESCRIPTION
As discussed in #547, in order for the activity store to be fetched
both events and logs should be fetched (and fetching same thing).

This changes the store to track each separately and provide the same
fetched and fetching API but based on the two separate things tracked.