### PR TITLE
Upgrade phantomjs to newer version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,12 +16,12 @@ machine:
 dependencies:
   cache_directories:
     - "$WS/node_modules/"
-    - "/home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic"
+    - "/home/ubuntu/bin/phantomjs-2.1.1"
   pre:
     - sudo apt-get update; sudo apt-get install libicu52
-    - curl --output /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic https://s3.amazonaws.com/circle-support-bucket/phantomjs/phantomjs-2.0.1-linux-x86_64-dynamic
-    - chmod a+x /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic
-    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic /usr/local/bin/phantomjs
+    - curl --output /home/ubuntu/bin/phantomjs-2.1.1 https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
+    - chmod a+x /home/ubuntu/bin/phantomjs-2.1.1
+    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.0.1 /usr/local/bin/phantomjs
     - go version
     - go get github.com/Masterminds/glide
     - mkdir -p $WS && chmod -R u+rw $WS && cp -R /home/ubuntu/cg-dashboard/. $WS
@@ -37,6 +37,7 @@ test:
     - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
   override:
     - cd $WS && ./codecheck.sh -u
+    - cd $WS && npm test
 
 deployment:
   deploy:

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - sudo apt-get update; sudo apt-get install libicu52
     - curl --output /home/ubuntu/bin/phantomjs-2.1.1 https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
     - chmod a+x /home/ubuntu/bin/phantomjs-2.1.1
-    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.0.1 /usr/local/bin/phantomjs
+    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.1.1 /usr/local/bin/phantomjs
     - go version
     - go get github.com/Masterminds/glide
     - mkdir -p $WS && chmod -R u+rw $WS && cp -R /home/ubuntu/cg-dashboard/. $WS

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@ const webpackConfig = require('./webpack.config');
 
 module.exports = function(config) {
   config.set({
-    browsers: ['PhantomJS2', 'Chrome'],
+    browsers: ['Chrome'],
 
     frameworks: ['jasmine', 'jasmine-matchers', 'sinon', 'phantomjs-shim'],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "codecov": "cat ./coverage/coverage-final.json | ./node_modules/codecov.io/bin/codecov.io.js",
     "clean": "rm -rf ./static/assets/*",
     "lint": "eslint -c .eslintrc ./static_src",
-    "test": "npm run lint && karma start --single-run --browsers PhantomJS2",
+    "test": "npm run lint && karma start --single-run",
     "testing-server": "node ./static_src/test/server/server.js",
     "watch-test": "karma start --browsers Chrome",
     "watch": "webpack --watch",


### PR DESCRIPTION
In an attempt to fix random test failures happening on just circle ci,
likely due to phantomjs memory leaks.