### PR TITLE
Create, update, or delete routes

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -25,6 +25,8 @@
 
 
     <link rel="stylesheet" type="text/css" href="assets/style.css">
+    <link rel="shortcut icon" type="image/png" href="assets/img/favicon.ico" />
+
     <title>Cloud.gov Deck</title>
   </head>
   <body>

--- a/static_src/actions/error_actions.js
+++ b/static_src/actions/error_actions.js
@@ -7,8 +7,19 @@ import errorActionTypes from '../constants.js';
 import Dispatcher from '../dispatcher.js';
 
 export default {
-  errorFetch(err) {
-    console.error('failure', err);
-    // Do nothing
+  errorDelete(err) {
+    console.error('delete failure', err);
   },
+
+  errorFetch(err) {
+    console.error('fetch failure', err);
+  },
+
+  errorPost(err) {
+    console.error('post failure', err);
+  },
+
+  errorPut(err) {
+    console.error('put failure', err);
+  }
 };

--- a/static_src/actions/error_actions.js
+++ b/static_src/actions/error_actions.js
@@ -9,21 +9,21 @@ import Dispatcher from '../dispatcher.js';
 export default {
   errorDelete(err) {
     console.error('delete failure', err);
-    throw err;
+    // throw err;
   },
 
   errorFetch(err) {
     console.error('fetch failure', err);
-    throw err;
+    // throw err;
   },
 
   errorPost(err) {
     console.error('post failure', err);
-    throw err;
+    // throw err;
   },
 
   errorPut(err) {
     console.error('put failure', err);
-    throw err;
+    // throw err;
   }
 };

--- a/static_src/actions/error_actions.js
+++ b/static_src/actions/error_actions.js
@@ -9,17 +9,21 @@ import Dispatcher from '../dispatcher.js';
 export default {
   errorDelete(err) {
     console.error('delete failure', err);
+    throw err;
   },
 
   errorFetch(err) {
     console.error('fetch failure', err);
+    throw err;
   },
 
   errorPost(err) {
     console.error('post failure', err);
+    throw err;
   },
 
   errorPut(err) {
     console.error('put failure', err);
+    throw err;
   }
 };

--- a/static_src/actions/route_actions.js
+++ b/static_src/actions/route_actions.js
@@ -8,10 +8,66 @@ import AppDispatcher from '../dispatcher.js';
 import { routeActionTypes } from '../constants';
 
 export default {
+  associatedApp(routeGuid, appGuid) {
+    AppDispatcher.handleViewAction({
+      type: routeActionTypes.ROUTE_APP_ASSOCIATED,
+      appGuid,
+      routeGuid
+    });
+  },
+
+  createRoute(domainGuid, spaceGuid, route) {
+    const { host, path } = route;
+    AppDispatcher.handleViewAction({
+      type: routeActionTypes.ROUTE_CREATE,
+      domainGuid,
+      spaceGuid,
+      host,
+      path
+    });
+  },
+
+  createdRoute(route) {
+    AppDispatcher.handleServerAction({
+      type: routeActionTypes.ROUTE_CREATED,
+      route
+    });
+  },
+
+  createRouteAndAssociate(appGuid, domainGuid, spaceGuid, route) {
+    AppDispatcher.handleViewAction({
+      type: routeActionTypes.ROUTE_CREATE_AND_ASSOCIATE,
+      appGuid,
+      domainGuid,
+      spaceGuid,
+      route
+    });
+  },
+
+  deleteRoute(routeGuid) {
+    AppDispatcher.handleViewAction({
+      type: routeActionTypes.ROUTE_DELETE,
+      routeGuid
+    });
+  },
+
+  deletedRoute(routeGuid) {
+    AppDispatcher.handleViewAction({
+      type: routeActionTypes.ROUTE_DELETED,
+      routeGuid
+    });
+  },
+
   fetchRoutesForApp(appGuid) {
     AppDispatcher.handleViewAction({
       type: routeActionTypes.ROUTES_FOR_APP_FETCH,
       appGuid
+    });
+  },
+
+  hideCreateForm() {
+    AppDispatcher.handleUIAction({
+      type: routeActionTypes.ROUTE_CREATE_FORM_HIDE
     });
   },
 
@@ -23,10 +79,34 @@ export default {
     });
   },
 
+  showCreateForm() {
+    AppDispatcher.handleUIAction({
+      type: routeActionTypes.ROUTE_CREATE_FORM_SHOW
+    });
+  },
+
   toggleEdit(routeGuid) {
     AppDispatcher.handleUIAction({
       type: routeActionTypes.ROUTE_TOGGLE_EDIT,
       routeGuid
+    });
+  },
+
+  updateRoute(routeGuid, domainGuid, spaceGuid, route) {
+    AppDispatcher.handleViewAction({
+      type: routeActionTypes.ROUTE_UPDATE,
+      routeGuid,
+      domainGuid,
+      spaceGuid,
+      route
+    });
+  },
+
+  updatedRoute(routeGuid, route) {
+    AppDispatcher.handleServerAction({
+      type: routeActionTypes.ROUTE_UPDATED,
+      routeGuid,
+      route
     });
   }
 };

--- a/static_src/actions/space_actions.js
+++ b/static_src/actions/space_actions.js
@@ -12,16 +12,27 @@ export default {
   fetch(spaceGuid) {
     AppDispatcher.handleViewAction({
       type: spaceActionTypes.SPACE_FETCH,
-      spaceGuid: spaceGuid
+      spaceGuid
     });
+  },
 
-    cfApi.fetchSpace(spaceGuid);
+  fetchAll() {
+    AppDispatcher.handleViewAction({
+      type: spaceActionTypes.SPACES_FETCH
+    });
   },
 
   receivedSpace(space) {
     AppDispatcher.handleServerAction({
       type: spaceActionTypes.SPACE_RECEIVED,
-      space: space
+      space
+    });
+  },
+
+  receivedSpaces(spaces) {
+    AppDispatcher.handleServerAction({
+      type: spaceActionTypes.SPACES_RECEIVED,
+      spaces
     });
   },
 

--- a/static_src/components/action.jsx
+++ b/static_src/components/action.jsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
-import classNames from 'classnames';
 import createStyler from '../util/create_styler';
 
 const BUTTON_STYLES = [
@@ -26,7 +25,7 @@ const propTypes = {
   label: React.PropTypes.string,
   type: React.PropTypes.oneOf(BUTTON_TYPES),
   disabled: React.PropTypes.bool,
-  onClickHandler: React.PropTypes.func
+  clickHandler: React.PropTypes.func
 };
 
 const defaultProps = {
@@ -35,7 +34,7 @@ const defaultProps = {
   label: '',
   type: 'button',
   disabled: false,
-  onClickHandler: () => true
+  clickHandler: () => true
 };
 
 export default class Action extends React.Component {
@@ -43,15 +42,10 @@ export default class Action extends React.Component {
     super(props);
     this.props = props;
     this.styler = createStyler(style);
-    this._handleClick = this._handleClick.bind(this);
-  }
-
-  _handleClick(ev) {
-    return this.props.onClickHandler(ev);
   }
 
   render() {
-    const styleClass = `usa-button-${ this.props.style }`;
+    const styleClass = `usa-button-${this.props.style}`;
     let classes = this.styler(...this.props.classes);
     let content = <div></div>;
 
@@ -61,7 +55,7 @@ export default class Action extends React.Component {
         classList.push('usa-button-disabled');
       } else {
         classList.push('usa-button');
-        classList.push(styleClass)
+        classList.push(styleClass);
       }
       classes = this.styler(...classList);
     }
@@ -71,7 +65,7 @@ export default class Action extends React.Component {
         <a href="#"
           className={ classes }
           title={ this.props.label }
-          onClick={ this._handleClick }
+          onClick={ (ev) => this.props.clickHandler(ev) }
           disabled={ this.props.disabled }
         >
           { this.props.children }
@@ -82,7 +76,7 @@ export default class Action extends React.Component {
         <button
           className={ classes }
           aria-label={ this.props.label }
-          onClick={ this._handleClick }
+          onClick={ (ev) => this.props.clickHandler(ev) }
           disabled={this.props.disabled}
           type={this.props.type}
         >

--- a/static_src/components/activity_log_item.jsx
+++ b/static_src/components/activity_log_item.jsx
@@ -4,6 +4,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
+import formatRoute from '../util/format_route';
 import RouteStore from '../stores/route_store';
 import ServiceInstanceStore from '../stores/service_instance_store';
 
@@ -96,10 +97,13 @@ export default class ActivityLogItem extends React.Component {
 
   get eventContent() {
     let content = `${this.props.item.type} isn't handled`;
+    let url = 'a url';
     const item = this.props.item;
     const metadata = item.metadata;
     const route = RouteStore.get(metadata.route_guid);
-    const url = (route) ? `${route.host}${route.domain}/${route.path}` : 'a url';
+    if (route) {
+      url = formatRoute(route.domain, route.host, route.path);
+    }
     const link = (route) ? (<a href={ `//${url}` }>{ url }</a>) : url;
 
     // TODO: if route is not found, trigger fetch action to get it

--- a/static_src/components/route_form.jsx
+++ b/static_src/components/route_form.jsx
@@ -45,8 +45,11 @@ export default class RouteForm extends React.Component {
   }
 
   get fullUrl() {
-    let url = `${this.state.host}.${this.state.domain}`;
-    if (this.state.path !== '') url += `/${this.state.path}`;
+    const state = this.state;
+    let url = state.domain;
+    if (state.host) url = `${state.host}.${state.domain}`;
+    if (state.path) url = `${url}/${state.path}`;
+
     return url;
   }
 

--- a/static_src/components/route_form.jsx
+++ b/static_src/components/route_form.jsx
@@ -58,7 +58,16 @@ export default class RouteForm extends React.Component {
 
   _onSubmit(event) {
     event.preventDefault();
-    this.props.submitHandler(this.state);
+    const payload = {};
+    Object.keys(this.state).forEach((key) => {
+      let value = this.state[key];
+      // path needs to start with a / per the cf api docs
+      if (key === 'path' && value[0] !== '/' && value !== '') {
+        value = `/${value}`;
+      }
+      payload[key] = value;
+    });
+    this.props.submitHandler(payload);
   }
 
   get fullUrl() {

--- a/static_src/components/route_form.jsx
+++ b/static_src/components/route_form.jsx
@@ -6,6 +6,7 @@ import Action from './action.jsx';
 import PanelActions from './panel_actions.jsx';
 
 import createStyler from '../util/create_styler';
+import formatRoute from '../util/format_route';
 
 import panelCss from '../css/panel.css';
 import routeFormCss from '../css/route_form.css';
@@ -45,12 +46,8 @@ export default class RouteForm extends React.Component {
   }
 
   get fullUrl() {
-    const state = this.state;
-    let url = state.domain;
-    if (state.host) url = `${state.host}.${state.domain}`;
-    if (state.path) url = `${url}/${state.path}`;
-
-    return url;
+    const { domain, host, path } = this.state;
+    return formatRoute(domain, host, path);
   }
 
   get hasChanged() {

--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -49,7 +49,6 @@ export default class RouteList extends React.Component {
     this.styler = createStyler(style);
 
     this._onChange = this._onChange.bind(this);
-    this._createRoute = this._createRoute.bind(this);
     this._createRouteAndAssociate = this._createRouteAndAssociate.bind(this);
     this._addCreateRouteForm = this._addCreateRouteForm.bind(this);
     this._removeCreateRouteForm = this._removeCreateRouteForm.bind(this);
@@ -85,13 +84,6 @@ export default class RouteList extends React.Component {
 
   _removeCreateRouteForm() {
     routeActions.hideCreateForm();
-  }
-
-  _createRoute(route) {
-    const { spaceGuid } = this.state;
-    const domainGuid = route.domain_guid;
-    routeActions.createRoute(domainGuid, spaceGuid, route);
-    // routeActions.createRouteAndBindForApp(appGuid, domainGuid, spaceGuid);
   }
 
   _createRouteAndAssociate(route) {

--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -12,6 +12,7 @@ import RouteForm from './route_form.jsx';
 import RouteStore from '../stores/route_store.js';
 
 import createStyler from '../util/create_styler';
+import formatRoute from '../util/format_route';
 
 function stateSetter(appGuid) {
   const routes = RouteStore.getAll();
@@ -73,10 +74,9 @@ export default class RouteList extends React.Component {
         </PanelHeader>
         { this.state.routes.map((route) => {
           const handler = this._handleRouteAction.bind(this, route.guid);
+          const { domain, host, path } = route;
+          const url = formatRoute(domain, host, path);
           let rowContent;
-          let url = route.domain;
-          if (route.host) url = `${route.host}.${route.domain}`;
-          if (route.path) url = `${url}/${route.path}`;
 
           if (route.editing) {
             rowContent = (

--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -72,11 +72,12 @@ export default class RouteList extends React.Component {
           </PanelActions>
         </PanelHeader>
         { this.state.routes.map((route) => {
-          const fullRoute = (route.path) ?
-            `${route.host}.${route.domain}/${route.path}` :
-            `${route.host}.${route.domain}`;
           const handler = this._handleRouteAction.bind(this, route.guid);
           let rowContent;
+          let url = route.domain;
+          if (route.host) url = `${route.host}.${route.domain}`;
+          if (route.path) url = `${url}/${route.path}`;
+
           if (route.editing) {
             rowContent = (
               <RouteForm route={ route } domains={ domains }
@@ -86,7 +87,7 @@ export default class RouteList extends React.Component {
           } else {
             rowContent = (
               <div>
-                <span>{ fullRoute }</span>
+                <span>{ url }</span>
                 <Action onClickHandler={ handler } label="Edit" type="link">
                   Edit
                 </Action>

--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -2,7 +2,9 @@
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
 
+import AppStore from '../stores/app_store.js';
 import Action from './action.jsx';
+import DomainStore from '../stores/domain_store.js';
 import PanelActions from './panel_actions.jsx';
 import PanelGroup from './panel_group.jsx';
 import PanelHeader from './panel_header.jsx';
@@ -10,49 +12,129 @@ import PanelRow from './panel_row.jsx';
 import routeActions from '../actions/route_actions.js';
 import RouteForm from './route_form.jsx';
 import RouteStore from '../stores/route_store.js';
+import SpaceStore from '../stores/space_store.js';
 
 import createStyler from '../util/create_styler';
 import formatRoute from '../util/format_route';
 
-function stateSetter(appGuid) {
-  const routes = RouteStore.getAll();
-  const appRoutes = routes.filter((route) => route.app_guid === appGuid);
+function stateSetter() {
+  const routes = RouteStore.getAll().map((route) => {
+    const domain = DomainStore.get(route.domain_guid);
+    if (!domain) return route;
+    return Object.assign({}, route, { domain_name: domain.name });
+  });
+  const appGuid = AppStore.currentAppGuid;
+  const appRoutes = routes.filter((route) => route.app_guid === appGuid)
+    .map((route) => {
+      if (route.path && (route.path[0] === '/')) {
+        route.path = route.path.replace('/', '');
+      }
+
+      return route;
+    });
 
   return {
-    routes: appRoutes
+    appGuid,
+    routes: appRoutes,
+    spaceGuid: SpaceStore.currentSpaceGuid,
+    showCreateForm: RouteStore.showCreateRouteForm
   };
 }
-
-window.RouteStore = RouteStore;
 
 export default class RouteList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = stateSetter(props.initialAppGuid);
-    this._onChange = this._onChange.bind(this);
+    this.state = stateSetter();
     this.styler = createStyler(style);
+
+    this._onChange = this._onChange.bind(this);
+    this._createRoute = this._createRoute.bind(this);
+    this._createRouteAndAssociate = this._createRouteAndAssociate.bind(this);
+    this._addCreateRouteForm = this._addCreateRouteForm.bind(this);
+    this._removeCreateRouteForm = this._removeCreateRouteForm.bind(this);
   }
 
   componentDidMount() {
+    DomainStore.addChangeListener(this._onChange);
     RouteStore.addChangeListener(this._onChange);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState(stateSetter(nextProps.initialAppGuid));
+  componentWillReceiveProps() {
+    this.setState(stateSetter());
   }
 
   componentWillUnmount() {
+    DomainStore.removeChangeListener(this._onChange);
     RouteStore.removeChangeListener(this._onChange);
   }
 
   _onChange() {
-    this.setState(stateSetter(this.props.initialAppGuid));
+    this.setState(stateSetter());
   }
 
-  _handleRouteAction(routeGuid, ev) {
-    ev.preventDefault();
+  _toggleEditRoute(routeGuid, event) {
+    event.preventDefault();
     routeActions.toggleEdit(routeGuid);
+  }
+
+  _addCreateRouteForm(event) {
+    if (event) event.preventDefault();
+    routeActions.showCreateForm();
+  }
+
+  _removeCreateRouteForm() {
+    routeActions.hideCreateForm();
+  }
+
+  _createRoute(route) {
+    const { spaceGuid } = this.state;
+    const domainGuid = route.domain_guid;
+    routeActions.createRoute(domainGuid, spaceGuid, route);
+    // routeActions.createRouteAndBindForApp(appGuid, domainGuid, spaceGuid);
+  }
+
+  _createRouteAndAssociate(route) {
+    const { appGuid, spaceGuid } = this.state;
+    const domainGuid = route.domain_guid;
+    routeActions.createRouteAndAssociate(appGuid, domainGuid, spaceGuid, route);
+  }
+
+  _deleteRoute(routeGuid) {
+    routeActions.deleteRoute(routeGuid);
+  }
+
+  _updateRoute(routeGuid, route) {
+    const domainGuid = route.domain_guid;
+    const spaceGuid = this.state.spaceGuid;
+    let path = route.path;
+    if (route.path && (route.path[0] !== '/')) {
+      path = `/${route.path}`;
+    }
+    const updatedRoute = Object.assign({}, route, { path });
+    routeActions.updateRoute(routeGuid, domainGuid, spaceGuid, updatedRoute);
+  }
+
+  get addRouteAction() {
+    if (this.state.showCreateForm) return null;
+    return (
+      <Action clickHandler={ this._addCreateRouteForm }
+        label="Add route" type="link"
+      >
+        Add Route
+      </Action>
+    );
+  }
+
+  get createRouteForm() {
+    if (!this.state.showCreateForm) return null;
+
+    return (
+      <RouteForm domains={ DomainStore.getAll() }
+        cancelHandler={ () => this._removeCreateRouteForm() }
+        submitHandler={ this._createRouteAndAssociate }
+      />
+    );
   }
 
   render() {
@@ -60,35 +142,37 @@ export default class RouteList extends React.Component {
       return (<h4 className="test-none_message">No routes</h4>);
     }
     const routeLimit = (this.props.routeLimit > -1) ? this.props.routeLimit : 'unlimited';
-    const domains = this.state.routes.map((route) => route.domain);
     return (
       <PanelGroup>
         <PanelHeader>
           <strong>Routes</strong>
           <span>{ this.state.routes.length } of { routeLimit }</span>
           <PanelActions>
-            <Action label="Add route" type="link">
-              Add Route
-            </Action>
+            { this.addRouteAction }
           </PanelActions>
         </PanelHeader>
+        { this.createRouteForm }
         { this.state.routes.map((route) => {
-          const handler = this._handleRouteAction.bind(this, route.guid);
-          const { domain, host, path } = route;
-          const url = formatRoute(domain, host, path);
+          const submitHandler = this._updateRoute.bind(this, route.guid);
+          const toggleHandler = this._toggleEditRoute.bind(this, route.guid);
+          const deleteHandler = this._deleteRoute.bind(this, route.guid);
+          const { domain_name, host, path } = route;
+          const url = formatRoute(domain_name, host, path);
           let rowContent;
 
           if (route.editing) {
             rowContent = (
-              <RouteForm route={ route } domains={ domains }
-                handleCancel={ handler }
+              <RouteForm route={ route } domains={ DomainStore.getAll() }
+                cancelHandler={ toggleHandler }
+                submitHandler={ submitHandler }
+                deleteHandler={ deleteHandler }
               />
             );
           } else {
             rowContent = (
               <div>
                 <span>{ url }</span>
-                <Action onClickHandler={ handler } label="Edit" type="link">
+                <Action clickHandler={ toggleHandler } label="Edit" type="link">
                   Edit
                 </Action>
               </div>
@@ -107,7 +191,6 @@ export default class RouteList extends React.Component {
 }
 
 RouteList.propTypes = {
-  initialAppGuid: React.PropTypes.string.isRequired,
   routeLimit: React.PropTypes.number
 };
 

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -45,8 +45,13 @@ const orgActionTypes = keymirror({
 const spaceActionTypes = keymirror({
   // Action to fetch a single space from the server.
   SPACE_FETCH: null,
+  // Action to fetch all spaces (gets different information from single fetch,
+  // such as quotas)
+  SPACES_FETCH: null,
   // Action when a single space is received from the server.
   SPACE_RECEIVED: null,
+  // Action when all spaces are received from the server.
+  SPACES_RECEIVED: null,
   // When the user changes the current space they are looking at.
   SPACE_CHANGE_CURRENT: null
 });

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -150,6 +150,26 @@ const userActionTypes = keymirror({
 });
 
 const routeActionTypes = keymirror({
+  // Action when a route has been associated with an pp
+  ROUTE_APP_ASSOCIATED: null,
+  // Action for creating routes
+  ROUTE_CREATE: null,
+  // Action for receiving the created route
+  ROUTE_CREATED: null,
+  // Action to create a route and associate it with an app
+  ROUTE_CREATE_AND_ASSOCIATE: null,
+  // Action for hiding route creation form
+  ROUTE_CREATE_FORM_HIDE: null,
+  // Action for showing route creation form
+  ROUTE_CREATE_FORM_SHOW: null,
+  // Action for removing a route from an app
+  ROUTE_DELETE: null,
+  // Action when a route has been deleted
+  ROUTE_DELETED: null,
+  // Action for updating a route
+  ROUTE_UPDATE: null,
+  // Action when a route has been updated
+  ROUTE_UPDATED: null,
   ROUTES_FOR_APP_FETCH: null,
   ROUTES_FOR_APP_RECEIVED: null,
   ROUTE_TOGGLE_EDIT: null

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -124,6 +124,7 @@ function checkAuth() {
     uaaApi.fetchUserInfo();
   });
   orgActions.fetchAll();
+  spaceActions.fetchAll();
 }
 
 function notFound() {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -19,6 +19,7 @@ import MainContainer from './components/main_container.jsx';
 import Marketplace from './components/marketplace.jsx';
 import orgActions from './actions/org_actions.js';
 import quotaActions from './actions/quota_actions.js';
+import routeActions from './actions/route_actions.js';
 import spaceActions from './actions/space_actions.js';
 import serviceActions from './actions/service_actions.js';
 import SpaceContainer from './components/space_container.jsx';
@@ -98,6 +99,7 @@ function app(orgGuid, spaceGuid, appGuid) {
   appActions.changeCurrentApp(appGuid);
   appActions.fetch(appGuid);
   appActions.fetchStats(appGuid);
+  routeActions.fetchRoutesForApp(appGuid);
   ReactDOM.render(
     <MainContainer>
       <AppContainer />

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -3,6 +3,7 @@ import 'cloudgov-style/css/base.css';
 import './css/main.css';
 // Icon used in cg-uaa.
 import './img/dashboard-uaa-icon.jpg';
+import 'cloudgov-style/img/favicon.ico';
 
 import { Router } from 'director';
 import React from 'react';

--- a/static_src/stores/domain_store.js
+++ b/static_src/stores/domain_store.js
@@ -1,0 +1,44 @@
+
+/*
+ * Store for domain data. Will store and update domain data on changes from UI and
+ * server.
+ */
+
+import Immutable from 'immutable';
+
+import BaseStore from './base_store.js';
+import cfApi from '../util/cf_api.js';
+import { domainActionTypes } from '../constants.js';
+
+class DomainStore extends BaseStore {
+  constructor() {
+    super();
+    this._data = new Immutable.List();
+    this.subscribe(() => this._registerToActions.bind(this));
+  }
+
+  _registerToActions(action) {
+    switch (action.type) {
+      case domainActionTypes.DOMAIN_FETCH: {
+        cfApi.fetchDomain(action.domainGuid);
+        break;
+      }
+
+      case domainActionTypes.DOMAIN_RECEIVED: {
+        const formattedDomain = this.formatSplitResponse([action.domain])[0];
+
+        this.merge('guid', formattedDomain, (changed) => {
+          if (changed) this.emitChange();
+        });
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+}
+
+const _DomainStore = new DomainStore();
+
+export default _DomainStore;

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -14,11 +14,93 @@ class RouteStore extends BaseStore {
   constructor() {
     super();
     this._data = new Immutable.List();
+    this.showCreateRouteForm = false;
     this.subscribe(() => this._registerToActions.bind(this));
   }
 
   _registerToActions(action) {
     switch (action.type) {
+      case appActionTypes.APP_RECEIVED: {
+        if (!action.app.routes) break;
+        const routes = action.app.routes.map((route) => {
+          const r = {
+            app_guid: action.app.guid,
+            guid: route.guid,
+            host: route.host,
+            path: route.path,
+            domain_guid: route.domain.guid
+          };
+
+          return r;
+        });
+
+        this.mergeMany('domain_guid', routes, (changed) => {
+          if (changed) this.emitChange();
+        });
+
+        break;
+      }
+
+      case routeActionTypes.ROUTE_APP_ASSOCIATED: {
+        const route = this.get(action.routeGuid);
+        const newRoute = Object.assign({}, route, {
+          app_guid: action.appGuid,
+          editing: false
+        });
+        this.merge('guid', newRoute, () => {
+          this.showCreateRouteForm = false;
+          this.emitChange();
+        });
+        break;
+      }
+
+      case routeActionTypes.ROUTE_CREATE: {
+        const { domainGuid, spaceGuid, host, path } = action;
+        cfApi.createRoute(domainGuid, spaceGuid, host, path);
+        break;
+      }
+
+      case routeActionTypes.ROUTE_CREATE_AND_ASSOCIATE: {
+        this.emitChange();
+        const { appGuid, domainGuid, spaceGuid } = action;
+        const { host, path } = action.route;
+        cfApi.createRoute(domainGuid, spaceGuid, host, path).then((res) => {
+          const routeGuid = res.metadata.guid;
+          cfApi.putAppRouteAssociation(appGuid, routeGuid);
+        });
+        break;
+      }
+
+      case routeActionTypes.ROUTE_CREATE_FORM_HIDE: {
+        this.showCreateRouteForm = false;
+        this.emitChange();
+        break;
+      }
+
+      case routeActionTypes.ROUTE_CREATE_FORM_SHOW: {
+        this.showCreateRouteForm = true;
+        this.emitChange();
+        break;
+      }
+
+      case routeActionTypes.ROUTE_CREATED: {
+        const route = this.formatSplitResponse([action.route]).pop();
+        this.merge('guid', route, () => this.emitChange());
+        break;
+      }
+
+      case routeActionTypes.ROUTE_DELETE: {
+        cfApi.deleteRoute(action.routeGuid);
+        break;
+      }
+
+      case routeActionTypes.ROUTE_DELETED: {
+        this.delete(action.routeGuid, () => {
+          this.emitChange();
+        });
+        break;
+      }
+
       case routeActionTypes.ROUTES_FOR_APP_FETCH:
         cfApi.fetchRoutesForApp(action.appGuid);
         break;
@@ -37,7 +119,6 @@ class RouteStore extends BaseStore {
       }
 
       case routeActionTypes.ROUTE_TOGGLE_EDIT: {
-        console.log('action', action);
         const route = this.get(action.routeGuid);
         const newRoute = Object.assign({}, route, {
           editing: !route.editing
@@ -48,46 +129,21 @@ class RouteStore extends BaseStore {
         break;
       }
 
-      case domainActionTypes.DOMAIN_FETCH: {
-        cfApi.fetchDomain(action.domainGuid);
+      case routeActionTypes.ROUTE_UPDATE: {
+        const { routeGuid, domainGuid, spaceGuid, route } = action;
+        cfApi.putRouteUpdate(routeGuid, domainGuid, spaceGuid, route);
         break;
       }
 
-      case domainActionTypes.DOMAIN_RECEIVED: {
-        const formattedDomain = this.formatSplitResponse([action.domain])[0];
-        const domain = Object.assign({}, {
-          domain: formattedDomain.name,
-          domain_guid: formattedDomain.guid
+      case routeActionTypes.ROUTE_UPDATED: {
+        const route = Object.assign({}, action.route, {
+          editing: false
         });
-
-        this.mergeAll('domain_guid', domain, (changed) => {
-          if (changed) this.emitChange();
+        this.merge('guid', route, () => {
+          this.emitChange();
         });
         break;
       }
-
-      case appActionTypes.APP_RECEIVED: {
-        if (!action.app.routes) break;
-        const routes = action.app.routes.map((route) => {
-          const r = {
-            app_guid: action.app.guid,
-            guid: route.guid,
-            host: route.host,
-            path: route.path,
-            domain_guid: route.domain.guid,
-            domain: route.domain.name
-          };
-
-          return r;
-        });
-
-        this.mergeMany('domain_guid', routes, (changed) => {
-          if (changed) this.emitChange();
-        });
-
-        break;
-      }
-
 
       default:
         break;

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -8,7 +8,7 @@ import Immutable from 'immutable';
 
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
-import { appActionTypes, domainActionTypes, routeActionTypes } from '../constants.js';
+import { appActionTypes, routeActionTypes } from '../constants.js';
 
 class RouteStore extends BaseStore {
   constructor() {

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -7,6 +7,7 @@
 import Immutable from 'immutable';
 
 import BaseStore from './base_store.js';
+import cfApi from '../util/cf_api.js';
 import { orgActionTypes, spaceActionTypes } from '../constants.js';
 
 class SpaceStore extends BaseStore {
@@ -36,6 +37,15 @@ class SpaceStore extends BaseStore {
       case spaceActionTypes.SPACE_FETCH: {
         this.fetching = true;
         this.fetched = false;
+        cfApi.fetchSpace(action.spaceGuid);
+        this.emitChange();
+        break;
+      }
+
+      case spaceActionTypes.SPACES_FETCH: {
+        this.fetching = true;
+        this.fetched = false;
+        cfApi.fetchSpaces();
         this.emitChange();
         break;
       }
@@ -45,6 +55,15 @@ class SpaceStore extends BaseStore {
         this.fetched = true;
         this.merge('guid', action.space, () => { });
         this.emitChange();
+        break;
+      }
+
+      case spaceActionTypes.SPACES_RECEIVED: {
+        this.mergeMany('guid', this.formatSplitResponse(action.spaces), () => {
+          this.fetching = false;
+          this.fetched = true;
+          this.emitChange();
+        });
         break;
       }
 

--- a/static_src/test/unit/actions/route_actions.spec.js
+++ b/static_src/test/unit/actions/route_actions.spec.js
@@ -18,8 +18,98 @@ describe('routeActions', function() {
     sandbox.restore();
   });
 
+  describe('associatedApp()', function() {
+    it('should dispatch ROUTE_APP_ASSOCIATED view event & the app/route guids',
+    function () {
+      const appGuid = 'fake-app-guid';
+      const routeGuid = 'fake-route-guid';
+      const expected = {
+        appGuid,
+        routeGuid
+      };
+      const spy = setupViewSpy(sandbox);
+
+      routeActions.associatedApp(routeGuid, appGuid);
+
+      assertAction(spy, routeActionTypes.ROUTE_APP_ASSOCIATED, expected);
+    })
+  });
+
+  describe('createRoute()', function () {
+    it('should dispatch ROUTE_CREATE view event with params', function () {
+      const domainGuid = 'fake-domain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const route = {
+        host: 'fake-host',
+        path: 'fake-path'
+      };
+      const expected = {
+        domainGuid,
+        spaceGuid,
+        host: route.host,
+        path: route.path
+      };
+      const spy = setupViewSpy(sandbox);
+
+      routeActions.createRoute(domainGuid, spaceGuid, route);
+      assertAction(spy, routeActionTypes.ROUTE_CREATE, expected);
+    });
+  });
+
+  describe('createdRoute()', function() {
+    it('should dipsatch ROUTE_CREATED server event with route', function () {
+      const route = { guid: 'fake-route-guid' };
+      const spy = setupServerSpy(sandbox);
+
+      routeActions.createdRoute(route);
+      assertAction(spy, routeActionTypes.ROUTE_CREATED, { route });
+    });
+  });
+
+  describe('createRouteAndAssociate()', function() {
+    it('should dispatch ROUTE_CREATE_AND_ASSOCIATE view event with params', function() {
+      const routeGuid = 'fake-route-guid';
+      const appGuid = 'fake-app-guid';
+      const domainGuid = 'fake-domain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const route = {
+
+      };
+      const expected = {
+        appGuid,
+        domainGuid,
+        spaceGuid,
+        route
+      };
+      const spy = setupViewSpy(sandbox);
+
+      routeActions.createRouteAndAssociate(appGuid, domainGuid, spaceGuid, route);
+      assertAction(spy, routeActionTypes.ROUTE_CREATE_AND_ASSOCIATE, expected);
+    });
+  });
+
+  describe('deleteRoute()', function() {
+    it('should dispatch ROUTE_DELETE view event with route guid', function () {
+      const routeGuid = 'fake-route-guid';
+      const spy = setupViewSpy(sandbox);
+
+      routeActions.deleteRoute(routeGuid);
+      assertAction(spy, routeActionTypes.ROUTE_DELETE, { routeGuid });
+    })
+  })
+
+  describe('deletedRoute()', function() {
+    it('should dispatch ROUTE_DELETED view event with route guid', function () {
+      const routeGuid = 'fake-route-guid';
+      const spy = setupViewSpy(sandbox);
+
+      routeActions.deletedRoute(routeGuid);
+      assertAction(spy, routeActionTypes.ROUTE_DELETED, { routeGuid });
+    })
+  });
+
   describe('fetchRoutesForApp()', function() {
-    it('should dispatch a view event of type routes for app fetch', function() {
+    it('should dispatch ROUTES_FOR_APP_FETCH view event with params', function() {
       var expectedAppGuid = 'asdflkjzzxcv',
           expectedParams = {
             appGuid: expectedAppGuid
@@ -31,6 +121,15 @@ describe('routeActions', function() {
 
       assertAction(spy, routeActionTypes.ROUTES_FOR_APP_FETCH,
                    expectedParams)
+    });
+  });
+
+  describe('hideCreateForm()', function() {
+    it('should dispatch ROUTE_CREATE_FORM_HIDE UI event', function() {
+      const spy = setupUISpy(sandbox);
+
+      routeActions.hideCreateForm();
+      assertAction(spy, routeActionTypes.ROUTE_CREATE_FORM_HIDE);
     });
   });
 
@@ -57,6 +156,15 @@ describe('routeActions', function() {
     });
   });
 
+  describe('showCreateForm()', function() {
+    it('should dispatch ROUTE_CREATE_FORM_HIDE UI event', function() {
+      const spy = setupUISpy(sandbox);
+
+      routeActions.showCreateForm();
+      assertAction(spy, routeActionTypes.ROUTE_CREATE_FORM_SHOW);
+    });
+  });
+
   describe('toggleEdit()', function () {
     it('should dispatch a UI action with a route guid', function () {
       var expectedRouteGuid = 'route-guid',
@@ -68,8 +176,44 @@ describe('routeActions', function() {
 
       routeActions.toggleEdit(expectedRouteGuid);
 
-      assertAction(spy, routeActionTypes.ROUTE_TOGGLE_EDIT,
-                   expectedParams)
+      assertAction(spy, routeActionTypes.ROUTE_TOGGLE_EDIT, expectedParams);
     });
   });
+
+  describe('updateRoute()', function (){
+    it('should dispatch ROUTE_UPDATE view event with params', function() {
+      const routeGuid = 'fake-route-guid';
+      const domainGuid = 'fake-domain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const route = {
+        host: 'fake-host',
+        path: 'fake-path'
+      };
+      const expected = {
+        routeGuid,
+        domainGuid,
+        spaceGuid,
+        route
+      };
+      const spy = setupViewSpy(sandbox);
+
+      routeActions.updateRoute(routeGuid, domainGuid, spaceGuid, route)
+      assertAction(spy, routeActionTypes.ROUTE_UPDATE, expected);
+    });
+  });
+
+  describe('updatedRoute()', function (){
+    it('should dispatch ROUTE_UPDATED server event with params', function() {
+      const routeGuid = 'fake-route-guid';
+      const route = {
+        host: 'fake-host',
+        path: 'fake-path'
+      };
+      const spy = setupServerSpy(sandbox);
+
+      routeActions.updatedRoute(routeGuid, route);
+      assertAction(spy, routeActionTypes.ROUTE_UPDATED, { routeGuid, route });
+    });
+  });
+
 });

--- a/static_src/test/unit/actions/space_actions.spec.js
+++ b/static_src/test/unit/actions/space_actions.spec.js
@@ -2,7 +2,7 @@
 import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
-import { assertAction, setupViewSpy, setupUISpy, setupServerSpy }
+import { assertAction, setupViewSpy, setupUISpy, setupServerSpy, wrapInRes }
   from '../helpers.js';
 import cfApi from '../../../util/cf_api.js';
 import spaceActions from '../../../actions/space_actions.js';
@@ -40,6 +40,17 @@ describe('spaceActions', () => {
     });
   });
 
+  describe('fetchAll()', () => {
+    it('should dispatch a view event to fetch all spaces', () => {
+      let spy = setupViewSpy(sandbox);
+
+      spaceActions.fetchAll();
+
+      let arg = spy.getCall(0).args[0];
+      expect(arg.type).toEqual(spaceActionTypes.SPACES_FETCH);
+    });
+  });
+
   describe('receivedSpace()', () => {
     it('should dispatch server event of type space received', () => {
       var expected = { guid: 'asdf' },
@@ -51,6 +62,22 @@ describe('spaceActions', () => {
       spaceActions.receivedSpace(expected);
 
       assertAction(spy, spaceActionTypes.SPACE_RECEIVED, expectedParams);
+    });
+  });
+
+  describe('receivedSpaces()', () => {
+    it('should dispatch a server event for all spaces received', () => {
+      const expected = wrapInRes([{ guid: 'fake-guid-one' }]);
+      const expectedParams = false;
+      const spy = setupServerSpy(sandbox);
+
+      spaceActions.receivedSpaces(expected);
+
+      let args = spy.getCall(0).args[0];
+      let { type, spaces } = args;
+
+      expect(type).toEqual(spaceActionTypes.SPACES_RECEIVED);
+      expect(spaces).toEqual(expected);
     });
   });
 

--- a/static_src/test/unit/stores/domain_store.spec.js
+++ b/static_src/test/unit/stores/domain_store.spec.js
@@ -1,0 +1,72 @@
+
+import Immutable from 'immutable';
+
+import '../../global_setup.js';
+
+import AppDispatcher from '../../../dispatcher.js';
+import cfApi from '../../../util/cf_api.js';
+import { wrapInRes, unwrapOfRes } from '../helpers.js';
+import DomainStore from '../../../stores/domain_store.js';
+import { domainActionTypes, routeActionTypes } from '../../../constants';
+
+describe('DomainStore', function() {
+  var sandbox;
+
+  beforeEach(() => {
+    DomainStore._data = Immutable.List();
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('constructor()', function() {
+    it('should start data as empty array', function() {
+      expect(DomainStore.getAll()).toBeEmptyArray();
+    });
+  });
+
+  describe('on domain fetch', function () {
+    it('should call call fetchDomain with the domain guid', function () {
+      const spy = sandbox.spy(cfApi, 'fetchDomain');
+      const domainGuid = 'fake-domain-guid';
+
+      AppDispatcher.handleViewAction({
+        type: domainActionTypes.DOMAIN_FETCH,
+        domainGuid
+      });
+
+      const arg = spy.getCall(0).args[0];
+      expect(spy).toHaveBeenCalledOnce();
+      expect(arg).toEqual(domainGuid);
+    });
+  });
+
+  describe('on domain received', function() {
+    it('should merge in the domain', function() {
+      const domain = { guid: 'fake-domain-guid', name: '.gov' };
+
+      AppDispatcher.handleServerAction({
+        type: domainActionTypes.DOMAIN_RECEIVED,
+        domain: wrapInRes([domain])[0]
+      });
+
+      const actual = DomainStore.get(domain.guid);
+
+      expect(actual).toEqual(domain);
+    });
+
+    it('should emit a change event', function() {
+      const spy = sandbox.spy(DomainStore, 'emitChange');
+      const domain = { guid: 'fake-domain-guid', name: '.gov' };
+
+      AppDispatcher.handleServerAction({
+        type: domainActionTypes.DOMAIN_RECEIVED,
+        domain: wrapInRes([domain])[0]
+      });
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -88,34 +88,36 @@ describe('SpaceStore', function() {
     });
   });
 
-  describe('on space change current', function() {
-    it('should emit a change event', function() {
-      const spaceGuid = 'zcxvadsjfcvbnm';
-      const space = {
-        guid: spaceGuid
-      };
-      let spy = sandbox.spy(SpaceStore, 'emitChange');
+  describe('on space actions all spaces received', function() {
+    it('should call mergeMany with spaces from action', function () {
+      const spy = sandbox.spy(SpaceStore, 'mergeMany');
+      const spaces = [{ guid: 'fake-guid-one' }]
+      const res = wrapInRes(spaces);
 
-      spaceActions.changeCurrentSpace(spaceGuid);
-      expect(spy).toHaveBeenCalledOnce();
+      spaceActions.receivedSpaces(res);
 
-      SpaceStore.push(space);
-      spy.reset();
-      spaceActions.changeCurrentSpace(spaceGuid);
       expect(spy).toHaveBeenCalledOnce();
+      expect(spy.getCall(0).args[1]).toEqual(spaces); 
     });
 
-    it('should should change the current space to the passed in guid',
-        function() {
-      const spaceGuid = 'zcxvadsjfcvbnm';
+    it('should set fetching to false and fetched to true', function() {
+      const spaces = wrapInRes([{ guid: 'fake-guid-one' }]);
+      SpaceStore.fetching = true;
+      SpaceStore.fetched = false;
 
-      SpaceStore._currentSpaceGuid = 'adskfjxvb';
+      spaceActions.receivedSpaces(spaces);
 
-      spaceActions.changeCurrentSpace(spaceGuid);
+      expect(SpaceStore.fetching).toEqual(false);
+      expect(SpaceStore.fetched).toEqual(true);
+    });
 
-      const actual = SpaceStore.currentSpaceGuid;
+    it('should emit a change event', function() {
+      const spaces = wrapInRes([{ guid: 'fake-guid-one' }]);
+      const spy = sandbox.spy(SpaceStore, 'emitChange');
 
-      expect(actual).toEqual(spaceGuid);
+      spaceActions.receivedSpaces(spaces);
+
+      expect(spy).toHaveBeenCalledOnce();
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -58,6 +58,80 @@ describe('cfApi', function() {
     expect(spy).toHaveBeenCalledWith(errorFetchRes);
   }
 
+  describe('createRoute()', function() {
+    it('should POST to the versioned /routes endpoint with data', function(done) {
+      const domainGuid = 'fake-domain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const host = 'fake-host';
+      const path = 'fake-path';
+      const expectedPayload = {
+        domain_guid: domainGuid,
+        space_guid: spaceGuid,
+        host,
+        path
+      };
+      const spy = sandbox.stub(http, 'post');
+      spy.returns(createPromise(true, {}));
+
+      cfApi.createRoute(domainGuid, spaceGuid, host, path).then(() => {
+        const args = spy.getCall(0).args;
+        expect(spy).toHaveBeenCalledOnce();
+        expect(args[0]).toMatch('/routes');
+        expect(args[1]).toEqual(expectedPayload);
+        done();
+      });
+    });
+
+    it('should call routeActions.createdRoute with response data', function(done) {
+      const domainGuid = 'fake-domain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const host = 'fake-host';
+      const path = 'fake-path';
+      const data = {
+        domainGuid,
+        spaceGuid
+      };
+      const stub = sandbox.stub(http, 'post');
+      stub.returns(Promise.resolve({ data }));
+      const actionSpy = sandbox.spy(routeActions, 'createdRoute');
+
+      cfApi.createRoute(domainGuid, spaceGuid, host, path).then(() => {
+        const arg = actionSpy.getCall(0).args[0];
+        expect(actionSpy).toHaveBeenCalledOnce();
+        expect(arg).toEqual(data);
+        done();
+      });
+    });
+  });
+
+  describe('deleteRoute()', function() {
+    it('should DELETE to the versioned /routes/:routeGuid endpoint with data', function() {
+      const routeGuid = 'fake-route-guid';
+      const spy = sandbox.stub(http, 'delete');
+      spy.returns(Promise.resolve());
+
+      cfApi.deleteRoute(routeGuid);
+
+      const args = spy.getCall(0).args;
+      expect(spy).toHaveBeenCalledOnce();
+      expect(args[0]).toMatch(`/routes/${routeGuid}`);
+    });
+
+    it('should call routeActions.deletedRoute with response data', function(done) {
+      const routeGuid = 'fake-route-guid';
+      const stub = sandbox.stub(http, 'delete');
+      const spy = sandbox.spy(routeActions, 'deletedRoute');
+      stub.returns(Promise.resolve({}));
+
+      cfApi.deleteRoute(routeGuid).then(() => {
+        const arg = spy.getCall(0).args[0];
+        expect(spy).toHaveBeenCalledOnce();
+        expect(arg).toEqual(routeGuid);
+        done();
+      });
+    });
+  });
+
   describe('fetchOne()', function() {
     it('should call an http get request with the versioned url', function() {
       var stub = sandbox.stub(http, 'get'),
@@ -960,6 +1034,99 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp('service_bindings'));
       actual = spy.getCall(0).args[1];
       expect(actual).toEqual(serviceActions.receivedServiceBindings);
+    });
+  });
+
+  describe('putAppRouteAssociation()', function() {
+    it('should PUT to the versioned /routes/:routeGuid/apps/:appGuid', function() {
+      const appGuid = 'fake-app-guid';
+      const routeGuid = 'fake-route-guid';
+
+      const spy = sandbox.stub(http, 'put');
+      spy.returns(Promise.resolve());
+
+      cfApi.putAppRouteAssociation(appGuid, routeGuid);
+
+      const args = spy.getCall(0).args;
+      expect(spy).toHaveBeenCalledOnce();
+      expect(args[0]).toMatch(`/routes/${routeGuid}/apps/${appGuid}`);
+    });
+
+    it('should call routeActions.associatedApp() with the routeGuid and appGuid', function(done) {
+      const appGuid = 'fake-app-guid';
+      const routeGuid = 'fake-route-guid';
+
+      const stub = sandbox.stub(http, 'put');
+      const spy = sandbox.spy(routeActions, 'associatedApp');
+      stub.returns(Promise.resolve({}));
+
+      cfApi.putAppRouteAssociation(appGuid, routeGuid).then(() => {
+        const args = spy.getCall(0).args;
+        expect(spy).toHaveBeenCalledOnce();
+        expect(args[0]).toEqual(routeGuid);
+        expect(args[1]).toEqual(appGuid);
+        done();
+      });
+    });
+  });
+
+  describe('putRouteUpdate()', function() {
+    it('should PUT to the versioned /routes/:routeGuid with payload', function() {
+      const routeGuid = 'fake-route-guid';
+      const domainGuid = 'fake-dommain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const host = 'fake-host';
+      const path = 'fake-path';
+      const route = {
+        host,
+        path
+      };
+      const expected = {
+        domain_guid: domainGuid,
+        space_guid: spaceGuid,
+        host,
+        path
+      };
+
+      const spy = sandbox.stub(http, 'put');
+      spy.returns(Promise.resolve());
+
+      cfApi.putRouteUpdate(routeGuid, domainGuid, spaceGuid, route);
+
+      const args = spy.getCall(0).args;
+      expect(spy).toHaveBeenCalledOnce();
+      expect(args[0]).toMatch(`/routes/${routeGuid}`);
+      expect(args[1]).toMatch(expected);
+    });
+
+    it('should call routeActions.updatedRoute() with the routeGuid and route', function(done) {
+      const routeGuid = 'fake-route-guid';
+      const domainGuid = 'fake-dommain-guid';
+      const spaceGuid = 'fake-space-guid';
+      const host = 'fake-host';
+      const path = 'fake-path';
+      const route = {
+        host,
+        path
+      };
+      const expected = {
+        domain_guid: domainGuid,
+        space_guid: spaceGuid,
+        host,
+        path
+      };
+
+      const stub = sandbox.stub(http, 'put');
+      const spy = sandbox.spy(routeActions, 'updatedRoute');
+      stub.returns(Promise.resolve({}));
+
+      cfApi.putRouteUpdate(routeGuid, domainGuid, spaceGuid, route).then(() => {
+        const args = spy.getCall(0).args;
+        expect(spy).toHaveBeenCalledOnce();
+        expect(args[0]).toEqual(routeGuid);
+        expect(args[1]).toEqual(route);
+        done();
+      });
     });
   });
 });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -376,6 +376,36 @@ describe('cfApi', function() {
     });
   });
 
+  describe('fetchSpaces()', function () {
+    it('calls fetch for the spaces endpoint', function () {
+      const stub = sandbox.stub(http, 'get');
+      const expected = [{ guid: 'fake-guid-one' }];
+      let testPromise = createPromise(wrapInRes(expected));
+      stub.returns(testPromise);
+
+      cfApi.fetchSpaces();
+
+      expect(stub).toHaveBeenCalledOnce();
+      let actual = stub.getCall(0).args[0];
+      expect(actual).toMatch(new RegExp('spaces'));
+    });
+
+    it('calls spaceActions.receivedSpaces action', function (done) {
+      const stub = sandbox.stub(http, 'get');
+      const actionSpy = sandbox.spy(spaceActions, 'receivedSpaces');
+      const expected = wrapInRes([{ guid: 'fake-guid-one' }]);
+      let testPromise = createPromise({ data: { resources: expected } });
+      stub.returns(testPromise);
+
+      cfApi.fetchSpaces().then(() => {
+        const args = actionSpy.getCall(0).args[0];
+        expect(args).toEqual(expected);
+        expect(actionSpy).toHaveBeenCalledOnce();
+        done();
+      });
+    });
+  });
+
   describe('fetchSpaceEvents()', function () {
     it('calls fetch all pages with space guid', function () {
       var spaceGuid = 'yyyybba1',

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -105,16 +105,17 @@ describe('cfApi', function() {
   });
 
   describe('deleteRoute()', function() {
-    it('should DELETE to the versioned /routes/:routeGuid endpoint with data', function() {
+    it('should DELETE to the versioned /routes/:routeGuid endpoint with data', function(done) {
       const routeGuid = 'fake-route-guid';
       const spy = sandbox.stub(http, 'delete');
       spy.returns(Promise.resolve());
 
-      cfApi.deleteRoute(routeGuid);
-
-      const args = spy.getCall(0).args;
-      expect(spy).toHaveBeenCalledOnce();
-      expect(args[0]).toMatch(`/routes/${routeGuid}`);
+      cfApi.deleteRoute(routeGuid).then(() => {
+        const args = spy.getCall(0).args;
+        expect(spy).toHaveBeenCalledOnce();
+        expect(args[0]).toMatch(`/routes/${routeGuid}`);
+        done();
+      });
     });
 
     it('should call routeActions.deletedRoute with response data', function(done) {
@@ -1038,18 +1039,20 @@ describe('cfApi', function() {
   });
 
   describe('putAppRouteAssociation()', function() {
-    it('should PUT to the versioned /routes/:routeGuid/apps/:appGuid', function() {
+    it('should PUT to the versioned /routes/:routeGuid/apps/:appGuid', function(done) {
       const appGuid = 'fake-app-guid';
       const routeGuid = 'fake-route-guid';
 
       const spy = sandbox.stub(http, 'put');
-      spy.returns(Promise.resolve());
+      const testPromise = createPromise({status: true});
+      spy.returns(testPromise);
 
-      cfApi.putAppRouteAssociation(appGuid, routeGuid);
-
-      const args = spy.getCall(0).args;
-      expect(spy).toHaveBeenCalledOnce();
-      expect(args[0]).toMatch(`/routes/${routeGuid}/apps/${appGuid}`);
+      cfApi.putAppRouteAssociation(appGuid, routeGuid).then(() => {
+        const args = spy.getCall(0).args;
+        expect(spy).toHaveBeenCalledOnce();
+        expect(args[0]).toMatch(`/routes/${routeGuid}/apps/${appGuid}`);
+        done();
+      });
     });
 
     it('should call routeActions.associatedApp() with the routeGuid and appGuid', function(done) {
@@ -1058,7 +1061,8 @@ describe('cfApi', function() {
 
       const stub = sandbox.stub(http, 'put');
       const spy = sandbox.spy(routeActions, 'associatedApp');
-      stub.returns(Promise.resolve({}));
+      const testPromise = createPromise({status: true});
+      stub.returns(testPromise);
 
       cfApi.putAppRouteAssociation(appGuid, routeGuid).then(() => {
         const args = spy.getCall(0).args;
@@ -1071,7 +1075,7 @@ describe('cfApi', function() {
   });
 
   describe('putRouteUpdate()', function() {
-    it('should PUT to the versioned /routes/:routeGuid with payload', function() {
+    it('should PUT to the versioned /routes/:routeGuid with payload', function(done) {
       const routeGuid = 'fake-route-guid';
       const domainGuid = 'fake-dommain-guid';
       const spaceGuid = 'fake-space-guid';
@@ -1091,12 +1095,13 @@ describe('cfApi', function() {
       const spy = sandbox.stub(http, 'put');
       spy.returns(Promise.resolve());
 
-      cfApi.putRouteUpdate(routeGuid, domainGuid, spaceGuid, route);
-
-      const args = spy.getCall(0).args;
-      expect(spy).toHaveBeenCalledOnce();
-      expect(args[0]).toMatch(`/routes/${routeGuid}`);
-      expect(args[1]).toMatch(expected);
+      cfApi.putRouteUpdate(routeGuid, domainGuid, spaceGuid, route).then(() => {
+        const args = spy.getCall(0).args;
+        expect(spy).toHaveBeenCalledOnce();
+        expect(args[0]).toMatch(`/routes/${routeGuid}`);
+        expect(args[1]).toMatch(expected);
+        done();
+      });
     });
 
     it('should call routeActions.updatedRoute() with the routeGuid and route', function(done) {

--- a/static_src/test/unit/util/format_route.spec.js
+++ b/static_src/test/unit/util/format_route.spec.js
@@ -1,0 +1,33 @@
+
+import '../../global_setup.js';
+
+import formatRoute from '../../../util/format_route';
+
+describe('format_route util', () => {
+  it('should show a properly formatted route with only a domain', () => {
+    const route = {
+      domain: 'fake-domain.com'
+    };
+    const actual = formatRoute(route.domain, route.host, route.path);
+    expect(actual).toEqual(route.domain);
+  });
+
+  it('should show a properly formatted route with a domain and host', () => {
+    const route = {
+      domain: 'fake-domain.com',
+      host: 'gopher'
+    };
+    const actual = formatRoute(route.domain, route.host, route.path);
+    expect(actual).toEqual(`${route.host}.${route.domain}`);
+  });
+
+  it('should show a properly formatted route with a domain, host & path', () => {
+    const route = {
+      domain: 'fake-domain.com',
+      host: 'gopher',
+      path: 'about.html'
+    };
+    const actual = formatRoute(route.domain, route.host, route.path);
+    expect(actual).toEqual(`${route.host}.${route.domain}/${route.path}`);
+  });
+});

--- a/static_src/test/unit/util/format_route.spec.js
+++ b/static_src/test/unit/util/format_route.spec.js
@@ -30,4 +30,15 @@ describe('format_route util', () => {
     const actual = formatRoute(route.domain, route.host, route.path);
     expect(actual).toEqual(`${route.host}.${route.domain}/${route.path}`);
   });
+
+  it('should show a blank string if domain undefined', () => {
+    const route = {
+      domain: undefined
+      host: 'gopher',
+      path: 'about.html'
+    };
+    const actual = formatRoute(route.domain, route.host, route.path);
+
+    expect(actual).toEqual(`${route.host}./${route.path}`);
+  });
 });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -312,17 +312,63 @@ export default {
 
   fetchRoutesForApp(appGuid) {
     return this.fetchMany(`/apps/${appGuid}/routes`,
-        routeActions.receivedRoutesForApp,
-        appGuid);
+      routeActions.receivedRoutesForApp,
+      appGuid);
+  },
+
+  // http://apidocs.cloudfoundry.org/241/routes/creating_a_route.html
+  createRoute(domainGuid, spaceGuid, host, path) {
+    const payload = {
+      domain_guid: domainGuid,
+      space_guid: spaceGuid,
+      host,
+      path
+    };
+    return http.post(`${APIV}/routes`, payload).then((res) => {
+      routeActions.createdRoute(res.data);
+      return res.data;
+    }).catch((err) => errorActions.errorPost(err));
+  },
+
+  // http://apidocs.cloudfoundry.org/241/routes/delete_a_particular_route.html
+  deleteRoute(routeGuid) {
+    const url = `${APIV}/routes/${routeGuid}?recursive=true`;
+    return http.delete(url).then(() => {
+      routeActions.deletedRoute(routeGuid);
+    }).catch((err) => {
+      errorActions.errorDelete(err);
+    });
+  },
+
+  // http://apidocs.cloudfoundry.org/241/apps/associate_route_with_the_app.html
+  putAppRouteAssociation(appGuid, routeGuid) {
+    const url = `${APIV}/routes/${routeGuid}/apps/${appGuid}`;
+    return http.put(url).then(() => {
+      routeActions.associatedApp(routeGuid, appGuid);
+    }).catch((err) => errorActions.errorPut(err));
+  },
+
+  // http://apidocs.cloudfoundry.org/241/routes/update_a_route.html
+  putRouteUpdate(routeGuid, domainGuid, spaceGuid, route) {
+    const url = `${APIV}/routes/${routeGuid}`;
+    const payload = {
+      domain_guid: domainGuid,
+      space_guid: spaceGuid,
+      host: route.host,
+      path: route.path
+    };
+    return http.put(url, payload).then(() => {
+      routeActions.updatedRoute(routeGuid, route);
+    }).catch((err) => errorActions.errorPut(err));
   },
 
   fetchDomain(domainGuid) {
     return this.fetchOne(`/private_domains/${domainGuid}`,
-                         domainActions.receivedDomain);
+      domainActions.receivedDomain);
   },
 
   fetchServiceBindings(appGuid) {
     return this.fetchOne(`/apps/${appGuid}/service_bindings`,
-                         serviceActions.receivedServiceBindings);
+      serviceActions.receivedServiceBindings);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -137,6 +137,14 @@ export default {
                               quotaActions.receivedQuotasForAllSpaces);
   },
 
+  fetchSpaces() {
+    return http.get(`${APIV}/spaces`).then((res) => {
+      spaceActions.receivedSpaces(res.data.resources);
+    }).catch((err) => {
+      errorActions.errorFetch(err);
+    });
+  },
+
   fetchSpace(spaceGuid) {
     return this.fetchOne(`/spaces/${spaceGuid}/summary`,
                          spaceActions.receivedSpace);

--- a/static_src/util/format_route.js
+++ b/static_src/util/format_route.js
@@ -1,6 +1,6 @@
 export default function formatRoute(domain, host, path) {
   let url = domain;
-  if (host) url = `${host}.${domain}`;
+  if (host) url = `${host}.${domain || ''}`;
   if (path) url = `${url}/${path}`;
 
   return url;

--- a/static_src/util/format_route.js
+++ b/static_src/util/format_route.js
@@ -1,0 +1,7 @@
+export default function formatRoute(domain, host, path) {
+  let url = domain;
+  if (host) url = `${host}.${domain}`;
+  if (path) url = `${url}/${path}`;
+
+  return url;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ const config = {
           'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]')
       },
       {
-        test: /\.(svg|png|gif|jpe?g)$/,
+        test: /\.(svg|ico|png|gif|jpe?g)$/,
         loader: 'url-loader?limit=1024&name=img/[name].[ext]'
       },
       { test: /\.(ttf|woff2?|eot)$/,


### PR DESCRIPTION
Adds some UI so that users can create routes (which are subsequently bound to the application), update routes, or delete routes.

There are some weird aspects of the UI right now. For example, there is a count of routes in the panel header. The "of" number is derived from the space quota (the org quota if there is no space quota) `total_routes`. However, it is weird to provide this in the application context because that number isn't necessarily reserved for the application, but for all the apps in the space. Indeed, if the user has a space quota route limit of 10, and has 9 unbound routes created in the space, the user can actually only create one more route for the app even though the UI makes it look like they can create 10.

To get around this we should figure out how to show all the routes for the space (those that are bound to other apps and those that aren't bound at all)

The tests are also breaking for me locally but I'm unclear why at the moment.

Refs #560