### PR TITLE
Fetch shared and private domains separately

### DIFF
--- a/static_src/stores/domain_store.js
+++ b/static_src/stores/domain_store.js
@@ -20,7 +20,7 @@ class DomainStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case domainActionTypes.DOMAIN_FETCH: {
-        cfApi.fetchDomain(action.domainGuid);
+        cfApi.fetchPrivateDomain(action.domainGuid);
         break;
       }
 

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -112,7 +112,11 @@ class RouteStore extends BaseStore {
         this.mergeMany('guid', routes, (changed) => {
           if (changed) this.emitChange();
           routes.forEach((route) => {
-            cfApi.fetchDomain(route.domain_guid);
+            if (/shared_domains/.test(route.domain_url)) {
+              cfApi.fetchSharedDomain(route.domain_guid);
+            } else {
+              cfApi.fetchPrivateDomain(route.domain_guid);
+            }
           });
         });
         break;

--- a/static_src/test/unit/stores/domain_store.spec.js
+++ b/static_src/test/unit/stores/domain_store.spec.js
@@ -29,7 +29,7 @@ describe('DomainStore', function() {
 
   describe('on domain fetch', function () {
     it('should call call fetchDomain with the domain guid', function () {
-      const spy = sandbox.spy(cfApi, 'fetchDomain');
+      const spy = sandbox.spy(cfApi, 'fetchPrivateDomain');
       const domainGuid = 'fake-domain-guid';
 
       AppDispatcher.handleViewAction({

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -6,7 +6,7 @@ import '../../global_setup.js';
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
 import { wrapInRes, unwrapOfRes } from '../helpers.js';
-import routeActions '../../../actions/route_actions.js';
+import routeActions from '../../../actions/route_actions.js';
 import RouteStore from '../../../stores/route_store.js';
 import { domainActionTypes, routeActionTypes } from '../../../constants';
 

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -6,6 +6,7 @@ import '../../global_setup.js';
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
 import { wrapInRes, unwrapOfRes } from '../helpers.js';
+import routeActions '../../../actions/route_actions.js';
 import RouteStore from '../../../stores/route_store.js';
 import { domainActionTypes, routeActionTypes } from '../../../constants';
 
@@ -274,6 +275,32 @@ describe('RouteStore', function() {
 
       expect(spy).toHaveBeenCalledOnce();
       expect(spy).toHaveBeenCalledWith('guid');
+    });
+
+    it('should fetch shared or private domain for each route', function() {
+      const sharedDomainGuid = 'zxcvzxcvzcxv23';
+      const privateDomainGuid = '23fdvskdcxv25';
+      const spyShared = sandbox.spy(cfApi, 'fetchSharedDomain');
+      const spyPrivate = sandbox.spy(cfApi, 'fetchPrivateDomain');
+      const routeA = {
+        metadata: { guid: 'aldfjzxcbkvzxcb' },
+        entity: {
+          domain_guid: sharedDomainGuid,
+          domain_url: 'shared_domains'
+        }
+      };
+      const routeB = {
+        metadata: { guid: 'aldf23vx32xcb' },
+        entity: {
+          domain_guid: privateDomainGuid,
+          domain_url: 'private_domains'
+        }
+      };
+
+      routeActions.receivedRoutesForApp([routeA, routeB]);
+
+      expect(privateDomainGuid).toHaveBeenCalledOnce();
+      expect(sharedDomainGuid).toHaveBeenCalledOnce();
     });
   });
 

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -299,8 +299,8 @@ describe('RouteStore', function() {
 
       routeActions.receivedRoutesForApp([routeA, routeB]);
 
-      expect(privateDomainGuid).toHaveBeenCalledOnce();
-      expect(sharedDomainGuid).toHaveBeenCalledOnce();
+      expect(spyShared).toHaveBeenCalledOnce();
+      expect(spyPrivate).toHaveBeenCalledOnce();
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -977,17 +977,33 @@ describe('cfApi', function() {
     });
   });
 
-  describe('fetchDomain()', function() {
+  describe('fetchPrivateDomain()', function() {
     it('should fetch domain with the domain guid', function() {
       var expected = 'xcvxyyb1',
           spy = sandbox.stub(cfApi, 'fetchOne');
 
-      cfApi.fetchDomain(expected);
+      cfApi.fetchPrivateDomain(expected);
 
       expect(spy).toHaveBeenCalledOnce();
       let actual = spy.getCall(0).args[0];
       expect(actual).toMatch(new RegExp(expected));
-      expect(actual).toMatch(new RegExp('domain'));
+      expect(actual).toMatch(new RegExp('private_domains'));
+      actual = spy.getCall(0).args[1];
+      expect(actual).toEqual(domainActions.receivedDomain);
+    });
+  });
+
+  describe('fetchSharedDomain()', function() {
+    it('should fetch domain with the domain guid', function() {
+      var expected = 'xcvxyyb1',
+          spy = sandbox.stub(cfApi, 'fetchOne');
+
+      cfApi.fetchSharedDomain(expected);
+
+      expect(spy).toHaveBeenCalledOnce();
+      let actual = spy.getCall(0).args[0];
+      expect(actual).toMatch(new RegExp(expected));
+      expect(actual).toMatch(new RegExp('shared_domains'));
       actual = spy.getCall(0).args[1];
       expect(actual).toEqual(domainActions.receivedDomain);
     });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -362,8 +362,13 @@ export default {
     }).catch((err) => errorActions.errorPut(err));
   },
 
-  fetchDomain(domainGuid) {
+  fetchPrivateDomain(domainGuid) {
     return this.fetchOne(`/private_domains/${domainGuid}`,
+      domainActions.receivedDomain);
+  },
+
+  fetchSharedDomain(domainGuid) {
+    return this.fetchOne(`/shared_domains/${domainGuid}`,
       domainActions.receivedDomain);
   },
 


### PR DESCRIPTION
The main domain action defaults to "private" as this isn't used yet.
The route store will check if the route uses a shared domain route or
a private domain route in the domain url and then uses the appropriate
cf api method. This fixes the bug where shared domains would never be
fetched, such as `apps.cloud.gov` domains.