### PR TITLE
Route creation fails when no path

### DIFF
--- a/static_src/components/route_form.jsx
+++ b/static_src/components/route_form.jsx
@@ -61,7 +61,9 @@ export default class RouteForm extends React.Component {
     Object.keys(this.state).forEach((key) => {
       let value = this.state[key];
       // path needs to start with a / per the cf api docs
-      if (key === 'path' && value[0] !== '/' && value !== '') {
+      if (key === 'path' && !value) {
+        value = '';
+      } else if (key === 'path' && value[0] !== '/' && value !== '') {
         value = `/${value}`;
       }
       payload[key] = value;


### PR DESCRIPTION
Because the code is assuming theres a value and it's an array with
something in it, but in reality, if you don't set the path, then
the path is undefined, which is now checked for in a if statement.

I created this as a separate branch of the if statement because the
current one was getting log and confusing and would default to the
path having a `/` which is invalid in cf if you set the path to just
a `/`.