### PR TITLE
When no routes message is off

### DIFF
--- a/static_src/components/route_list.jsx
+++ b/static_src/components/route_list.jsx
@@ -132,7 +132,11 @@ export default class RouteList extends React.Component {
 
   render() {
     if (this.state.routes.length === 0) {
-      return (<h4 className="test-none_message">No routes</h4>);
+      return (
+        <PanelRow>
+          <h4 className="test-none_message">No routes</h4>
+        </PanelRow>
+      );
     }
     const routeLimit = (this.props.routeLimit > -1) ? this.props.routeLimit : 'unlimited';
     return (


### PR DESCRIPTION
When there are no routes, the "no routes" message has no padding.

Simply wrapping it in a panel row fixes the padding issue with the
least amount of code.

Not required for release