### PR TITLE
Exit tests when webpack build fails

### DIFF
--- a/static_src/test/webpack-karma-warnings-plugin.js
+++ b/static_src/test/webpack-karma-warnings-plugin.js
@@ -1,0 +1,35 @@
+// Source: https://gist.github.com/mvgijssel/d3b121ad50e34c09a124
+
+/*
+ * This plugin makes sure karma doesn't run any specs when there's a
+ * compilation error in a module by including a module even if the module has errors.
+ *
+ * Webpack's normal behaviour is to not include modules which have errors,
+ * which causes Karma to run all the tests without the failed spec.
+ *
+ * Some links to where this magic actually happens in Webpack:
+ *
+ * The module will be removed from the dependency:
+ * https://github.com/webpack/webpack/blob/v1.12.14/lib/Compilation.js#L646-L649
+ *
+ * and dependencies without a module won't be included in the module map:
+ * https://github.com/webpack/webpack/blob/v1.12.14/lib/ContextModule.js#L87-L89
+ *
+ * Setting the module._source to a javascript error is copied from:
+ * https://github.com/webpack/webpack/blob/v1.12.14/lib/NormalModule.js#L127
+ */
+var WebpackKarmaWarningsPlugin = function() {};
+var RawSource = require("webpack/lib/RawSource");
+
+WebpackKarmaWarningsPlugin.prototype.apply = function(compiler) {
+  compiler.plugin("compilation", function(compilation) {
+    compilation.plugin("failed-module", function(module) {
+      var moduleErrorMessage = module.error.error.toString()
+      module._source = new RawSource(`throw new Error(${JSON.stringify(moduleErrorMessage)});`);
+      module.error = null;
+      throw new Error(JSON.stringify(moduleErrorMessage));
+    });
+  });
+};
+
+module.exports = WebpackKarmaWarningsPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,8 @@ const path = require('path');
 const webpack = require('webpack');
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const WebpackKarmaWarningsPlugin = require(
+  './static_src/test/webpack-karma-warnings-plugin.js');
 
 const PRODUCTION = (process.env.NODE_ENV === 'prod');
 const CG_STYLE_PATH = process.env.CG_STYLE_PATH;
@@ -11,6 +13,8 @@ const srcDir = './static_src';
 const compiledDir = './static/assets';
 
 const config = {
+  bail: true,
+
   entry: [
     'babel-polyfill',
     `${srcDir}/main.js`
@@ -74,7 +78,8 @@ const config = {
   },
 
   plugins: [
-    new ExtractTextPlugin('style.css', { allChunks: true })
+    new ExtractTextPlugin('style.css', { allChunks: true }),
+    new WebpackKarmaWarningsPlugin()
   ],
 
   publicPath: './static'


### PR DESCRIPTION
Otherwise all tests in the file that has a syntax error will just
not be run, leading to incomplete tests.

This was a problem for our dev team as we had 60 tests not
running without us even knowing.