### PR TITLE
Add a basic code climate config and corresponding badge to the README

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,26 @@
+---
+engines:
+
+  duplication:
+    enabled: false
+  govet:
+    enabled: true
+  golint:
+    enabled: true
+  nodesecurity:
+    enabled: true
+  eslint:
+    enabled: true
+  fixme:
+    enabled: false
+
+ratings:
+  paths:
+  - "**.go"
+  - "**.js"
+
+exclude_paths:
+  - static_src/test/*
+  - helpers/*
+  - acceptance/*
+  - "**/*_test.go"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 18F Cloud Foundry Dashboard
 
 [![CircleCI](https://circleci.com/gh/18F/cg-dashboard.svg?style=svg)](https://circleci.com/gh/18F/cg-dashboard)
+[![Code Climate](https://codeclimate.com/github/18F/cg-dashboard/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-dashboard)
 
 Environments: [Production](https://dashboard.cloud.gov)
 [Master](https://dashboard-master.apps.cloud.gov)


### PR DESCRIPTION
As part of the Fedramp effort, we are required to ensure static code analysis is run on all 18F developed code that is part of the cloud.gov platform:  https://github.com/18F/cg-product/issues/260

In support of this effort, this PR adds a basic code climate configuration and badge to the README.