### PR TITLE
Add bash command to check for branched cg-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "description": "A web dashboard for managing Cloud Foundry apps",
   "main": "null",
   "scripts": {
-    "build": "npm run clean && node_modules/webpack/bin/webpack.js",
+    "build": "npm run clean && npm run check-style && node_modules/webpack/bin/webpack.js",
+    "build-style": "cd node_modules/cloudgov-style && npm install && npm run build",
+    "check-style": "/bin/bash -c '[[ $(npm ls cloudgov-style) =~ \"github.com\" ]] && npm run build-style || exit 0'",
     "clean": "rm -rf ./static/assets/*",
     "lint": "eslint -c .eslintrc ./static_src",
     "test": "npm run lint && karma start --single-run",


### PR DESCRIPTION
So we can use a cg-style branch and still deploy a piece of code. This is useful if a feature is still in development, so it's styling code is in cg-style and hasn't been released yet. If we want to put this ongoing feature to be put on staging to show designers for final sign-off, it won't work because cg-style won't be linked when deployed. 

This adds scripting to check if cg-style is being pulled from github branch and then builds it if so. This allows you to deploy the dashboard using an unreleased cg-style branch.

Unfortunately adds a few minutes to the build because the npm ls command requires a network connection.