### PR TITLE
Allow service instance to be bound to more then one app

### DIFF
--- a/static_src/components/service_instance.jsx
+++ b/static_src/components/service_instance.jsx
@@ -5,7 +5,6 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import Action from './action.jsx';
 import ConfirmationBox from './confirmation_box.jsx';
-import PanelActions from './panel_actions.jsx';
 import ServicePlanStore from '../stores/service_plan_store.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 import serviceActions from '../actions/service_actions.js';
@@ -41,7 +40,11 @@ export default class ServiceInstance extends React.Component {
 
   unbindConfirmedHandler(ev) {
     ev.preventDefault();
-    serviceActions.unbindService(this.props.serviceInstance.serviceBinding);
+    // TODO single-binding
+    const appBinding = ServiceInstanceStore.getServiceBindingForApp(
+      this.props.currentAppGuid,
+      this.props.serviceInstance);
+    serviceActions.unbindService(appBinding);
   }
 
   unbindCancelHandler(ev) {

--- a/static_src/components/service_instance.jsx
+++ b/static_src/components/service_instance.jsx
@@ -40,7 +40,6 @@ export default class ServiceInstance extends React.Component {
 
   unbindConfirmedHandler(ev) {
     ev.preventDefault();
-    // TODO single-binding
     const appBinding = ServiceInstanceStore.getServiceBindingForApp(
       this.props.currentAppGuid,
       this.props.serviceInstance);

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -71,6 +71,25 @@ class ServiceInstanceStore extends BaseStore {
     return OPERATION_STATES[state];
   }
 
+  getServiceBindingForApp(appGuid, serviceInstance) {
+    if (!serviceInstance.serviceBindings.length) return null;
+    return serviceInstance.serviceBindings.find((serviceBinding) =>
+      serviceBinding.app_guid === appGuid
+    );
+  }
+
+  isInstanceBound(serviceInstance, serviceBindings) {
+    if (!serviceInstance.serviceBindings.length) return false;
+    let isBound = false;
+    serviceInstance.serviceBindings.forEach((instanceBinding) => {
+      isBound = serviceBindings.find((serviceBinding) =>
+        instanceBinding.guid === serviceBinding.guid
+      );
+    });
+
+    return isBound;
+  }
+
   _registerToActions(action) {
     switch (action.type) {
       case serviceActionTypes.SERVICE_INSTANCES_FETCH: {

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -88,6 +88,61 @@ describe('ServiceInstanceStore', function() {
     });
   });
 
+  describe('getServiceBindingForApp()', function() {
+    it('should return null if no service bindings', function() {
+      const instance = { serviceBindings: []};
+
+      const actual = ServiceInstanceStore.getServiceBindingForApp('', instance);
+
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return binding object if matches app guid passed in', function() {
+      const appGuid = 'zcvn238vnma';
+      const binding = { guid: 'zcxv', app_guid: appGuid };
+      const instance = { serviceBindings: [binding] };
+
+      const actual = ServiceInstanceStore.getServiceBindingForApp(appGuid,
+        instance);
+
+      expect(actual).toEqual(binding);
+    });
+  });
+
+  describe('isInstanceBound()', function() {
+    it('should return false if no service bindings on instance passed in',
+      function() {
+      const instance = { serviceBindings: []};
+
+      const actual = ServiceInstanceStore.isInstanceBound(instance);
+
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false if none of bindings passed in found on instance',
+      function() {
+      const instance = { serviceBindings: [{ guid: 'adsf'}]};
+      const binding = { guid: '230984' };
+      const bindings = [binding];
+
+      const actual = ServiceInstanceStore.isInstanceBound(instance, bindings);
+
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return true if bindings passed in found on instance', function() {
+      const bindingGuid = 'zxklvcj234czxb';
+      const instance = { serviceBindings: [{ guid: bindingGuid}]};
+      const binding = { guid: bindingGuid };
+      const bindings = [binding];
+
+      const actual = ServiceInstanceStore.isInstanceBound(instance, bindings);
+
+      expect(actual).toBeTruthy();
+
+    });
+  });
+
   describe('on service instances fetch', function() {
     it('should set fetching to true, fetched to false', function() {
       ServiceInstanceStore.fetching = false;


### PR DESCRIPTION
As this is an actual use case so we should allow it in the app. Added
some utility methods to store for when a service is bound to a list
of possible bindings or getting the service binding for a particular
app.