### PR TITLE
Loading actions for routes and services

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -13,7 +13,7 @@ import (
 // If the user decides to refresh or if the client is polling, multiple requests might build up. This timecaps them.
 // This constant is also used in the acceptance testing "delayForRendering" for any pages that may take a long time to render.
 // (Some of those pages use APIs that take a long time)
-var TimeoutConstant = time.Second * 5
+var TimeoutConstant = time.Second * 20
 
 // GetValidToken is a helper function that returns a token struct only if it finds a non expired token for the session.
 func GetValidToken(req *http.Request, settings *Settings) *oauth2.Token {

--- a/static_src/components/loading.jsx
+++ b/static_src/components/loading.jsx
@@ -52,7 +52,7 @@ class Loading extends React.Component {
   showLoader() {
     if (this._timer) {
       window.clearTimeout(this._timer);
-      this.setState({ waitTimer: false })
+      this.setState({ waitTimer: false });
     }
   }
 
@@ -60,14 +60,39 @@ class Loading extends React.Component {
     let content = <div></div>;
 
     if (this.props.active && !this.state.waitTimer) {
+      const classes = this.props.style === 'cover' ?
+        this.styler('loading', 'loading-relative') :
+        this.styler('loading-inline');
       content = (
-        <div className={ this.styler('loading', 'loading-relative') }
+        <div className={ classes }
           role="alertdialog"
           ariaLive="assertive"
           ariaBusy={ this.props.active }
         >
-          <img className={ this.styler('loading-indicator') }
-            src={ `/assets/${loadingImg}` } alt={ this.props.text } />
+        {(() => {
+          switch (this.props.style) {
+            case 'cover': {
+              return (
+              <img className={ this.styler('loading-indicator') }
+                src={ `/assets/${loadingImg}` } alt={ this.props.text }
+              />
+              );
+            }
+            case 'inline': {
+              return (
+              <div>
+                <span className={ this.styler('loading-inline-dot') }>•</span>
+                <span className={ this.styler('loading-inline-dot') }>•</span>
+                <span className={ this.styler('loading-inline-dot') }>•</span>
+                <span className={ this.styler('loading-inline-text') }>
+                  { this.props.text }
+                </span>
+              </div>
+              );
+            }
+            default: return null;
+          }
+        })()}
         </div>
       );
     }

--- a/static_src/components/loading.jsx
+++ b/static_src/components/loading.jsx
@@ -7,16 +7,23 @@ import createStyler from '../util/create_styler';
 
 const LOADING_TIME = 300;
 
+const STYLES = [
+  'inline',
+  'cover'
+];
+
 const propTypes = {
   text: React.PropTypes.string,
   active: React.PropTypes.bool,
-  loadingDelayMS: React.PropTypes.number
+  loadingDelayMS: React.PropTypes.number,
+  style: React.PropTypes.oneOf(STYLES)
 };
 
 const defaultProps = {
   text: 'Loading',
   active: true,
-  loadingDelayMS: LOADING_TIME
+  loadingDelayMS: LOADING_TIME,
+  style: 'cover'
 };
 
 class Loading extends React.Component {

--- a/static_src/components/route.jsx
+++ b/static_src/components/route.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Action from './action.jsx';
 import ConfirmationBox from './confirmation_box.jsx';
 import DomainStore from '../stores/domain_store.js';
+import Loading from './loading.jsx';
 import PanelActions from './panel_actions.jsx';
 import PanelRowError from './panel_row_error.jsx';
 import RouteForm from './route_form.jsx';
@@ -116,6 +117,16 @@ export default class Route extends React.Component {
     const route = this.props.route;
     if (!route) return actions;
 
+    if (route.loading) {
+      return (
+        <Loading
+          text={ route.loading }
+          loadingDelayMS={ 100 }
+          style="inline"
+        />
+      );
+    }
+
     if (!RouteStore.isRouteBoundToApp(route)) {
       actions.push(this.deleteAction);
     } else {
@@ -139,6 +150,7 @@ export default class Route extends React.Component {
         <PanelRowError message={route.error.description} />
       );
     }
+    return null;
   }
 
   render() {
@@ -156,8 +168,7 @@ export default class Route extends React.Component {
             submitHandler={ this._updateHandler }
           />
         );
-      }
-      else if (route.removing) {
+      } else if (route.removing) {
         const currentAction = RouteStore.isRouteBoundToApp(route) ? 'unbind' :
           'delete';
         const confirmHandler = RouteStore.isRouteBoundToApp(route) ?
@@ -176,7 +187,7 @@ export default class Route extends React.Component {
       } else {
         let displayUrl = <span>{ url }</span>;
         if (!RouteStore.isRouteBoundToApp(route)) {
-          displayUrl = <a href={ url } title="See app route">{ url }</a>
+          displayUrl = <a href={ url } title="See app route">{ url }</a>;
         }
         content = (
           <div>

--- a/static_src/components/service_instance.jsx
+++ b/static_src/components/service_instance.jsx
@@ -97,7 +97,15 @@ export default class ServiceInstance extends React.Component {
   get actions() {
     let content;
 
-    if (this.props.bound) {
+    if (this.props.serviceInstance.loading) {
+      content = (
+        <Loading
+          text={ this.props.serviceInstance.loading }
+          loadingDelayMS={ 100 }
+          style="inline"
+        />
+      );
+    } else if (this.props.bound) {
       content = (
         <Action
           clickHandler={ this.unbindHandler }
@@ -107,14 +115,6 @@ export default class ServiceInstance extends React.Component {
         >
           Unbind
         </Action>
-      );
-    } else if (this.props.serviceInstance.loading) {
-      content = (
-        <Loading
-          text={ this.props.serviceInstance.loading }
-          loadingDelayMS={ 100 }
-          style="inline"
-        />
       );
     } else {
       content = (

--- a/static_src/components/service_instance.jsx
+++ b/static_src/components/service_instance.jsx
@@ -5,6 +5,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import Action from './action.jsx';
 import ConfirmationBox from './confirmation_box.jsx';
+import Loading from './loading.jsx';
 import PanelActions from './panel_actions.jsx';
 import PanelRowError from './panel_row_error.jsx';
 import ServicePlanStore from '../stores/service_plan_store.js';
@@ -102,16 +103,26 @@ export default class ServiceInstance extends React.Component {
           clickHandler={ this.unbindHandler }
           label="Unbind"
           style="warning"
-          type="link">
+          type="link"
+        >
           Unbind
         </Action>
+      );
+    } else if (this.props.serviceInstance.loading) {
+      content = (
+        <Loading
+          text={ this.props.serviceInstance.loading }
+          loadingDelayMS={ 100 }
+          style="inline"
+        />
       );
     } else {
       content = (
         <Action
           clickHandler={ this.bindHandler }
           label="Bind"
-          type="outline">
+          type="outline"
+        >
           Bind
         </Action>
       );

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -50,6 +50,11 @@ class RouteStore extends BaseStore {
 
       case routeActionTypes.ROUTE_APP_ASSOCIATE: {
         cfApi.putAppRouteAssociation(action.appGuid, action.routeGuid);
+        const route = this.get(action.routeGuid);
+        if (route) {
+          const newRoute = Object.assign({}, route, { loading: 'Binding' });
+          this.merge('guid', newRoute, () => this.emitChange());
+        }
         break;
       }
 
@@ -58,6 +63,7 @@ class RouteStore extends BaseStore {
         const newRoute = Object.assign({}, route, {
           app_guid: action.appGuid,
           editing: false,
+          loading: false,
           error: null
         });
         this.merge('guid', newRoute, () => {

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -188,13 +188,20 @@ class RouteStore extends BaseStore {
       case routeActionTypes.ROUTE_UPDATE: {
         const { routeGuid, domainGuid, spaceGuid, route } = action;
         cfApi.putRouteUpdate(routeGuid, domainGuid, spaceGuid, route);
+        const currentRoute = this.get(routeGuid);
+        if (currentRoute) {
+          const newRoute = Object.assign({}, currentRoute,
+            { loading: 'Editing' });
+          this.merge('guid', newRoute, () => this.emitChange());
+        }
         break;
       }
 
       case routeActionTypes.ROUTE_UPDATED: {
         const route = Object.assign({}, action.route, {
           editing: false,
-          error: null
+          error: null,
+          loading: false
         });
         this.merge('guid', route, () => {
           this.emitChange();

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -76,6 +76,11 @@ class RouteStore extends BaseStore {
 
       case routeActionTypes.ROUTE_APP_UNASSOCIATE: {
         cfApi.deleteAppRouteAssociation(action.appGuid, action.routeGuid);
+        const route = this.get(action.routeGuid);
+        if (route) {
+          const newRoute = Object.assign({}, route, { loading: 'Unbinding' });
+          this.merge('guid', newRoute, () => this.emitChange());
+        }
         break;
       }
 
@@ -83,7 +88,7 @@ class RouteStore extends BaseStore {
         const route = this.get(action.routeGuid);
         if (route) {
           const newRoute = Object.assign({}, route, { app_guid: null,
-            removing: false });
+            loading: false, removing: false });
           this.merge('guid', newRoute, () => this.emitChange());
         }
         break;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -206,6 +206,25 @@ class ServiceInstanceStore extends BaseStore {
         break;
       }
 
+      case serviceActionTypes.SERVICE_BIND: {
+        const instance = this.get(action.serviceInstanceGuid);
+        if (instance) {
+          const newInstance = Object.assign({}, instance, { loading: 'Binding' });
+          this.merge('guid', newInstance, () => this.emitChange());
+        }
+        break;
+      }
+
+      case serviceActionTypes.SERVICE_UNBIND: {
+        const instance = this.get(action.serviceBinding.service_instance_guid);
+        if (instance) {
+          const newInstance = Object.assign({}, instance,
+            { loading: 'Unbinding' });
+          this.merge('guid', newInstance, () => this.emitChange());
+        }
+        break;
+      }
+
       case serviceActionTypes.SERVICE_BOUND:
       case serviceActionTypes.SERVICE_UNBOUND: {
         let binding;
@@ -218,7 +237,8 @@ class ServiceInstanceStore extends BaseStore {
         if (!instance) break; // TODO throw error
         const updatedInstance = Object.assign({}, instance, {
           changing: false,
-          error: false
+          error: false,
+          loading: false
         });
         this.merge('guid', updatedInstance, () => this.emitChange());
         break;

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -30,7 +30,7 @@ describe('RouteStore', function() {
     });
   });
 
-  describe('routeActionTypes.ROUTE_APP_ASSOCIATED', function () {
+  describe('routeActionTypes.ROUTE_APP_ASSOCIATE', function () {
     it('should call put ap route assocaation with app, route guid', function() {
       const appGuid = 'zxvnalsf25gh9';
       const routeGuid = 'xvxvcmnsdjfkh3jdf';
@@ -133,6 +133,29 @@ describe('RouteStore', function() {
       expect(args[0]).toEqual(appGuid);
       expect(args[1]).toEqual(routeGuid);
     });
+
+    it('should set loading on route to Unbinding', function() {
+      const routeGuid = 'xvx2342nsdsdf234df';
+      const route = { guid: routeGuid };
+
+      RouteStore.push(route);
+      routeActions.unassociateApp(routeGuid, 'alsdkjf');
+
+      const actual = RouteStore.get(routeGuid);
+      expect(actual.loading).toEqual('Unbinding');
+    });
+
+    it('should emit a change event', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid };
+
+      RouteStore.push(route);
+
+      const spy = sandbox.spy(RouteStore, 'emitChange');
+      routeActions.unassociateApp(routeGuid, 'alsdkjf');
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
   });
 
   describe('on route app unnassociated', function() {
@@ -157,6 +180,17 @@ describe('RouteStore', function() {
       routeActions.unassociatedApp(routeGuid, appGuid);
 
       expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should clear loading', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid, loading: 'Unbinding' };
+
+      RouteStore.push(route);
+      routeActions.unassociatedApp(routeGuid, 'alsdkjf');
+
+      const actual = RouteStore.get(routeGuid);
+      expect(actual.loading).toBeFalsy();
     });
   });
 

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -43,6 +43,29 @@ describe('RouteStore', function() {
       expect(args[0]).toEqual(appGuid);
       expect(args[1]).toEqual(routeGuid);
     });
+
+    it('should set loading on route to Binding', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid };
+
+      RouteStore.push(route);
+      routeActions.associateApp(routeGuid, 'alsdkjf');
+
+      const actual = RouteStore.get(routeGuid);
+      expect(actual.loading).toEqual('Binding');
+    });
+
+    it('should emit a change event', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid };
+
+      RouteStore.push(route);
+
+      const spy = sandbox.spy(RouteStore, 'emitChange');
+      routeActions.associateApp(routeGuid, 'alsdkjf');
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
   });
 
   describe('routeActionTypes.ROUTE_APP_ASSOCIATED', function () {
@@ -81,6 +104,17 @@ describe('RouteStore', function() {
       expect(RouteStore.showCreateRouteForm).toEqual(false);
       expect(RouteStore.error).toEqual(null);
       expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should set loading to false', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid, loading: 'Binding' };
+
+      RouteStore.push(route);
+      routeActions.associatedApp(routeGuid, 'alsdkjf');
+
+      const actual = RouteStore.get(routeGuid);
+      expect(actual.loading).toBeFalsy();
     });
   });
 

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -45,7 +45,7 @@ describe('RouteStore', function() {
     });
 
     it('should set loading on route to Binding', function() {
-      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const routeGuid = 'xvx2342nsdjfkh3jdf';
       const route = { guid: routeGuid };
 
       RouteStore.push(route);
@@ -526,6 +526,29 @@ describe('RouteStore', function() {
       expect(spy).toHaveBeenCalledWith();
       expect(args).toEqual([routeGuid, domainGuid, spaceGuid, route]);
     });
+
+    it('should set loading on route to Editing', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid };
+
+      RouteStore.push(route);
+      routeActions.updateRoute(routeGuid, 'sdfaz', 'dsfbvc', route);
+
+      const actual = RouteStore.get(routeGuid);
+      expect(actual.loading).toEqual('Editing');
+    });
+
+    it('should emit a change event', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid };
+
+      RouteStore.push(route);
+
+      const spy = sandbox.spy(RouteStore, 'emitChange');
+      routeActions.updateRoute(routeGuid, 'sdfaz', 'dsfbvc', route);
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
   });
 
   describe('routeActionTypes.ROUTE_UPDATED', function () {
@@ -544,6 +567,17 @@ describe('RouteStore', function() {
       expect(RouteStore.get(routeGuid).foo).toEqual('bar');
       expect(RouteStore.get(routeGuid).editing).toEqual(false);
       expect(RouteStore.get(routeGuid).err).toBeFalsy();
+    });
+
+    it('should clear loading property', function() {
+      const routeGuid = 'xvxvcmnsdjfkh3jdf';
+      const route = { guid: routeGuid, loading: 'Editing' };
+
+      RouteStore.push(route);
+      routeActions.updatedRoute(routeGuid, route);
+
+      const actual = RouteStore.get(routeGuid);
+      expect(actual.loading).toBeFalsy();
     });
 
     it('should emitChange()', function () {

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -549,6 +549,24 @@ describe('ServiceInstanceStore', function() {
 
       expect(spy).toHaveBeenCalledOnce();
     });
+
+    it('should unset loading', function() {
+      const testInstance = {
+        guid: testGuid,
+        loading: 'Binding'
+      };
+      ServiceInstanceStore._data = Immutable.fromJS([testInstance]);
+
+      const binding = {
+        metadata: { guid: 'zxc' },
+        entity: { service_instance_guid: testGuid }
+      };
+
+      serviceActions.boundService(binding);
+
+      const actual = ServiceInstanceStore.get(testGuid);
+      expect(actual.loading).toBeFalsy();
+    });
   });
 
   describe('on service instance change check', function() {
@@ -643,6 +661,64 @@ describe('ServiceInstanceStore', function() {
       serviceActions.instanceError(instanceGuid, err);
 
       expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('on service bind', function() {
+    it('should emit a change event', function() {
+      const serviceInstanceGuid = 'zxvcadsf23bv';
+      const instance = { guid: serviceInstanceGuid };
+
+      ServiceInstanceStore.push(instance);
+
+      const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
+      serviceActions.bindService('zvcx', serviceInstanceGuid);
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should set loading to Binding', function() {
+      const serviceInstanceGuid = 'zxvcadsf23bv';
+      const instance = { guid: serviceInstanceGuid };
+
+      ServiceInstanceStore.push(instance);
+
+      serviceActions.bindService('zvcx', serviceInstanceGuid);
+
+      const actual = ServiceInstanceStore.get(serviceInstanceGuid);
+
+      expect(actual.loading).toEqual('Binding');
+    });
+  });
+
+  describe('on service unbind', function() {
+    it('should emit a change event', function() {
+      const serviceInstanceGuid = 'zxvcadsf23bv';
+      const instance = { guid: serviceInstanceGuid };
+      const binding = { guid: 'zxcvzxc',
+        service_instance_guid: serviceInstanceGuid };
+
+      ServiceInstanceStore.push(instance);
+
+      const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
+      serviceActions.unbindService(binding);
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it('should set loading to Binding', function() {
+      const serviceInstanceGuid = 'zxvcadsf23bv';
+      const instance = { guid: serviceInstanceGuid };
+      const binding = { guid: 'zxcvzxc',
+        service_instance_guid: serviceInstanceGuid };
+
+      ServiceInstanceStore.push(instance);
+
+      serviceActions.unbindService(binding);
+
+      const actual = ServiceInstanceStore.get(serviceInstanceGuid);
+
+      expect(actual.loading).toEqual('Unbinding');
     });
   });
 });


### PR DESCRIPTION
Uses the `loading` property on the route and instances to display the new inline loader when an action for them is currently happening. So when binding or editing is being requested and waiting for response on server, will show loading like the UI.

Requires https://github.com/18F/cg-style/pull/161
Ref https://github.com/18F/cg-dashboard/issues/637