### PR TITLE
Use inert to serve static assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint -c .eslintrc ./static_src",
     "test": "npm run lint && karma start --single-run",
     "testing-server": "node ./static_src/test/server/server.js",
+    "watch-server": "npm run testing-server & npm run watch",
     "watch-test": "karma start --browsers Chrome",
     "watch": "webpack --watch"
   },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "flux": "^2.0.3",
     "immutable": "^3.8.1",
     "imports-loader": "^0.6.4",
+    "inert": "^4.0.2",
     "jasmine-core": "^2.3.4",
     "jasmine-sinon": "^0.4.0",
     "json-loader": "^0.5.4",
@@ -96,8 +97,5 @@
     "url-loader": "^0.5.7",
     "watch": "^0.16.0",
     "webpack": "^1.13.2"
-  },
-  "devDependencies": {
-    "inert": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
     "url-loader": "^0.5.7",
     "watch": "^0.16.0",
     "webpack": "^1.13.2"
+  },
+  "devDependencies": {
+    "inert": "^4.0.2"
   }
 }

--- a/static_src/test/server/server.js
+++ b/static_src/test/server/server.js
@@ -1,5 +1,7 @@
 var path = require('path');
 
+var hapi = require('hapi');
+var inert = require('inert');
 var smocks = require('smocks');
 
 var authstatus = require('./authstatus');
@@ -12,19 +14,40 @@ authstatus(smocks);
 // add all api routes
 api(smocks);
 
-// serve static assets from /static
-smocks.route({
-  id: 'app',
-  label: 'Front end assets',
+// now start the server
+var server = new hapi.Server();
+server.connection({
+  port: 8000,
+  host: 'localhost'
+});
+
+
+// configure smocks as a hapi plugin
+var smocksplugin = require('smocks/hapi').toPlugin();
+smocksplugin.attributes = {
+  pkg: require('../../../package.json')
+};
+
+server.register([
+  inert,
+  smocksplugin
+]);
+
+// serve static assets
+server.route({
+  method: 'get',
   path: '/{p*}',
-  handler: function (req, reply) {
-    var url = (req.params.p) ? req.params.p : 'index.html';
-    reply.file(path.resolve(__dirname, '../../../static', url));
+  handler: {
+    directory: {
+      path: 'static'
+    }
   }
 });
 
-// now start the server
-require('smocks/hapi').start({
-  port: 8000,
-  host: 'localhost'
+server.start(function (err) {
+  if (err) {
+    throw err;
+  }
+
+  console.log('started smocks server on ' + server.info.port + '.  visit ' + server.info.uri + '/_admin to configure');
 });


### PR DESCRIPTION
Fixes #633

smocks provides a [respondWithFile and respondWithFileHandler](http://jhudson8.github.io/fancydocs/index.html#project/jhudson8/smocks/method/Variant/respondWithFile) but it's not as flexible as we need it to be like handling `index.html` or figuring out mime types. Since we're really just trying to serve static assets, we should just use hapi's `inert` to do that.

It does add a bit of boilerplate to configure hapi, but overall feels like the right solution.