### PR TITLE
"Deck" to "Dashboard" in page title, and related small metadata updates

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3,12 +3,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="cloud.gov is a Platform-as-a-Service
-      based on Cloud Foundry offered by 18F Infrastructure enabling agile teams
-      to deploy software as fast as they can iterate.">
+    <meta name="description" content="cloud.gov is a Platform as a Service
+      that enables government teams to deploy software as fast as they can iterate.">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="cloud.gov deck">
-    <meta property="og:url" content="https://console.cloud.gov/">
+    <meta property="og:title" content="cloud.gov Dashboard">
+    <meta property="og:url" content="https://dashboard.cloud.gov/">
 
     <script>
       if (window.location.host === 'dashboard.cloud.gov') {
@@ -27,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="assets/style.css">
     <link rel="shortcut icon" type="image/png" href="assets/img/favicon.ico" />
 
-    <title>Cloud.gov Deck</title>
+    <title>cloud.gov Dashboard</title>
   </head>
   <body>
     <div class="js-app"></div>


### PR DESCRIPTION
Small `<head>` section updates since I noticed that the `<title>` is still displaying "Cloud.gov Deck".