### PR TITLE
Refactor response splitting

### DIFF
--- a/static_src/stores/activity_store.js
+++ b/static_src/stores/activity_store.js
@@ -87,7 +87,7 @@ class ActivityStore extends BaseStore {
       case activityActionTypes.EVENTS_RECEIVED:
         this._eventsFetching = false;
         this._eventsFetched = true;
-        activity = this.formatSplitResponse(action.events).map((event) => {
+        activity = action.events.map((event) => {
           const item = Object.assign({}, event, {
             activity_type: 'event'
           });

--- a/static_src/stores/domain_store.js
+++ b/static_src/stores/domain_store.js
@@ -25,9 +25,7 @@ class DomainStore extends BaseStore {
       }
 
       case domainActionTypes.DOMAIN_RECEIVED: {
-        const formattedDomain = this.formatSplitResponse([action.domain])[0];
-
-        this.merge('guid', formattedDomain, (changed) => {
+        this.merge('guid', action.domain, (changed) => {
           if (changed) this.emitChange();
         });
         break;

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -50,7 +50,7 @@ class OrgStore extends BaseStore {
       }
 
       case orgActionTypes.ORGS_RECEIVED: {
-        const updates = this.formatSplitResponse(action.orgs).map((d) => {
+        const updates = action.orgs.map((d) => {
           if (d.spaces) {
             return d;
           }

--- a/static_src/stores/quota_store.js
+++ b/static_src/stores/quota_store.js
@@ -26,7 +26,7 @@ class QuotaStore extends BaseStore {
 
       case quotaActionTypes.ORGS_QUOTAS_RECEIVED: {
         const quotas = action.quotas.map((quota) => {
-          const guid = quota.metadata.guid;
+          const guid = quota.guid;
           return Object.assign({}, quota.entity, { guid });
         });
         this.mergeMany('guid', quotas, (changed) => {
@@ -42,7 +42,7 @@ class QuotaStore extends BaseStore {
 
       case quotaActionTypes.SPACES_QUOTAS_RECEIVED: {
         const quotas = action.quotas.map((quota) => {
-          const guid = quota.metadata.guid;
+          const guid = quota.guid;
           return Object.assign({}, quota.entity, { guid });
         });
         this.mergeMany('guid', quotas, (changed) => {

--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -43,7 +43,7 @@ class RouteStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case routeActionTypes.ROUTES_RECEIVED: {
-        const routes = this.formatSplitResponse(action.routes);
+        const routes = action.routes;
         this.mergeRoutes(routes);
         break;
       }
@@ -134,7 +134,7 @@ class RouteStore extends BaseStore {
       }
 
       case routeActionTypes.ROUTE_CREATED: {
-        const route = this.formatSplitResponse([action.route]).pop();
+        const route = action.route;
         this.merge('guid', route, () => this.emitChange());
         break;
       }
@@ -160,7 +160,7 @@ class RouteStore extends BaseStore {
         break;
 
       case routeActionTypes.ROUTES_FOR_APP_RECEIVED: {
-        const routes = this.formatSplitResponse(action.routes).map((route) =>
+        const routes = action.routes.map((route) =>
           Object.assign({}, route, { app_guid: action.appGuid })
         );
         this.mergeRoutes(routes);

--- a/static_src/stores/service_binding_store.js
+++ b/static_src/stores/service_binding_store.js
@@ -33,7 +33,7 @@ class ServiceBindingStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_BINDINGS_RECEIVED: {
-        const bindings = this.formatSplitResponse(action.serviceBindings);
+        const bindings = action.serviceBindings;
         this.mergeMany('guid', bindings, () => { });
         this.fetching = false;
         this.fetched = true;
@@ -52,7 +52,7 @@ class ServiceBindingStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_BOUND: {
-        const binding = this.formatSplitResponse([action.serviceBinding]).pop();
+        const binding = action.serviceBinding;
         this.merge('guid', binding, () => this.emitChange());
         break;
       }

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -104,8 +104,7 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_RECEIVED: {
-        const instance = this.formatSplitResponse(
-          [action.serviceInstance])[0];
+        const instance = action.serviceInstance;
 
         if (!this.waitingOnRequests) {
           this.fetching = false;
@@ -119,7 +118,7 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
-        const services = this.formatSplitResponse(action.serviceInstances);
+        const services = action.serviceInstances;
         this.mergeMany('guid', services, () => {
           this.fetching = false;
           this.fetched = true;
@@ -153,7 +152,7 @@ class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATED: {
-        cfApi.fetchServiceInstance(action.serviceInstance.metadata.guid);
+        cfApi.fetchServiceInstance(action.serviceInstance.guid);
         this._createInstanceForm = null;
         this.emitChange();
         break;
@@ -232,7 +231,7 @@ class ServiceInstanceStore extends BaseStore {
       case serviceActionTypes.SERVICE_UNBOUND: {
         let binding;
         if (action.type === serviceActionTypes.SERVICE_BOUND) {
-          binding = this.formatSplitResponse([action.serviceBinding]).pop();
+          binding = action.serviceBinding;
         } else {
           binding = action.serviceBinding;
         }

--- a/static_src/stores/service_plan_store.js
+++ b/static_src/stores/service_plan_store.js
@@ -51,7 +51,7 @@ class ServicePlanStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case serviceActionTypes.SERVICES_RECEIVED: {
-        const services = this.formatSplitResponse(action.services);
+        const services = action.services;
         this.fetching = true;
         this.fetched = false;
         this.emitChange();
@@ -72,7 +72,7 @@ class ServicePlanStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
-        const instances = this.formatSplitResponse(action.serviceInstances);
+        const instances = action.serviceInstances;
         this.fetched = false;
         this.fetching = true;
         this.emitChange();
@@ -107,7 +107,7 @@ class ServicePlanStore extends BaseStore {
 
       case serviceActionTypes.SERVICE_PLAN_RECEIVED: {
         const servicePlan = this.parseJson(
-          this.formatSplitResponse([action.servicePlan])[0], 'extra');
+          action.servicePlan, 'extra');
         this.merge('guid', servicePlan, () => {
           this.emitChange();
         });
@@ -116,7 +116,7 @@ class ServicePlanStore extends BaseStore {
 
       case serviceActionTypes.SERVICE_PLANS_RECEIVED: {
         if (action.servicePlans) {
-          let servicePlans = this.formatSplitResponse(action.servicePlans);
+          let servicePlans = action.servicePlans;
           servicePlans = this.parseAllJson(servicePlans, 'extra');
 
           if (!this.waitingOnRequests) {

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -30,7 +30,7 @@ class ServiceStore extends BaseStore {
 
       case serviceActionTypes.SERVICES_RECEIVED: {
         AppDispatcher.waitFor([ServicePlanStore.dispatchToken]);
-        const services = this.formatSplitResponse(action.services);
+        const services = action.services;
         this.mergeMany('guid', services, () => { });
         this.fetching = false;
         this.fetched = true;

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -1,4 +1,3 @@
-
 /*
  * Store for space data. Will store and update space data on changes from UI and
  * server.
@@ -59,7 +58,7 @@ class SpaceStore extends BaseStore {
       }
 
       case spaceActionTypes.SPACES_RECEIVED: {
-        this.mergeMany('guid', this.formatSplitResponse(action.spaces), () => {
+        this.mergeMany('guid', action.spaces, () => {
           this.fetching = false;
           this.fetched = true;
           this.emitChange();

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -64,7 +64,7 @@ class UserStore extends BaseStore {
       case userActionTypes.ORG_USER_ROLES_RECEIVED: {
         this.fetching = false;
         this.fetched = true;
-        const updates = this.formatSplitResponse(action.orgUserRoles);
+        const updates = action.orgUserRoles;
         if (updates.length) {
           this.mergeMany('guid', updates, () => { });
         }
@@ -152,7 +152,7 @@ class UserStore extends BaseStore {
 
       case userActionTypes.SPACE_USERS_RECEIVED:
       case userActionTypes.ORG_USERS_RECEIVED: {
-        let updates = this.formatSplitResponse(action.users);
+        let updates = action.users;
         updates = updates.map((update) => {
           const updateCopy = Object.assign({}, update);
           if (action.orgGuid) {

--- a/static_src/test/unit/stores/activity_store.spec.js
+++ b/static_src/test/unit/stores/activity_store.spec.js
@@ -5,7 +5,6 @@ import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import ActivityStore from '../../../stores/activity_store.js';
 import { activityActionTypes } from '../../../constants';
 
@@ -83,7 +82,7 @@ describe('ActivityStore', function() {
 
       AppDispatcher.handleServerAction({
         type: activityActionTypes.EVENTS_RECEIVED,
-        events: wrapInRes(activity)
+        events: activity
       });
 
 
@@ -101,7 +100,7 @@ describe('ActivityStore', function() {
 
       AppDispatcher.handleServerAction({
         type: activityActionTypes.EVENTS_RECEIVED,
-        events: wrapInRes(activity)
+        events: activity
       });
 
       expect(ActivityStore._eventsFetched).toEqual(true);

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -253,31 +253,6 @@ describe('BaseStore', () => {
     });
   });
 
-  describe('formatSplitResponse()', function() {
-    var testRezs;
-
-    beforeEach(function() {
-      testRezs = [
-        { entity: { name: 'e1' }, metadata: { guid: 'mmmmmn' }},
-        { entity: { name: 'e2' }, metadata: { guid: 'mmmmmo' }}
-      ];
-    });
-
-    it('should merge entity with metadata for each resource', function() {
-      var actual = store.formatSplitResponse(testRezs);
-
-      expect(actual[0]).toEqual({ name: 'e1', guid: 'mmmmmn'});
-    });
-
-    it('should not modify the original data', function() {
-      var clone = testRezs.slice(0);
-
-      store.formatSplitResponse(testRezs);
-
-      expect(clone).toEqual(testRezs);
-    });
-  });
-
   describe('merge()', function() {
     var existingEntityA = {
       guid: 'zznbmbz',

--- a/static_src/test/unit/stores/domain_store.spec.js
+++ b/static_src/test/unit/stores/domain_store.spec.js
@@ -49,7 +49,7 @@ describe('DomainStore', function() {
 
       AppDispatcher.handleServerAction({
         type: domainActionTypes.DOMAIN_RECEIVED,
-        domain: wrapInRes([domain])[0]
+        domain
       });
 
       const actual = DomainStore.get(domain.guid);

--- a/static_src/test/unit/stores/org_store.spec.js
+++ b/static_src/test/unit/stores/org_store.spec.js
@@ -5,7 +5,6 @@ import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import OrgStore from '../../../stores/org_store.js';
 import { orgActionTypes } from '../../../constants';
 
@@ -74,7 +73,7 @@ describe('OrgStore', () => {
 
   describe('on orgs received', () => {
     it('should set data to passed in orgs', () => {
-      var expected = wrapInRes([{guid: '1as'}, {guid: '2as'}]);
+      var expected = [{guid: '1as'}, {guid: '2as'}];
       expect(OrgStore.getAll()).toBeArray();
 
       AppDispatcher.handleViewAction({
@@ -83,11 +82,11 @@ describe('OrgStore', () => {
       });
 
       expect(OrgStore.getAll().length).toEqual(2);
-      expect(OrgStore.getAll()).toEqual(unwrapOfRes(expected));
+      expect(OrgStore.getAll()).toEqual(expected);
     });
 
     it('should set fetching to false', () => {
-      var expected = wrapInRes([{guid: '1as'}, {guid: '2as'}]);
+      var expected = [{guid: '1as'}, {guid: '2as'}];
 
       AppDispatcher.handleViewAction({
         type: orgActionTypes.ORGS_RECEIVED,
@@ -98,8 +97,8 @@ describe('OrgStore', () => {
     });
 
     it('should merge data with existing orgs', () => {
-      var updates = wrapInRes([{guid: 'aaa1', name: 'sue'},
-            {guid: 'aaa2', name: 'see'}]),
+      var updates = [{guid: 'aaa1', name: 'sue'},
+            {guid: 'aaa2', name: 'see'}],
           current = [{guid: 'aaa1', memory: 1024}];
 
       OrgStore._data = Immutable.fromJS(current);

--- a/static_src/test/unit/stores/quota_store.spec.js
+++ b/static_src/test/unit/stores/quota_store.spec.js
@@ -5,7 +5,6 @@ import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import QuotaStore from '../../../stores/quota_store.js';
 import { quotaActionTypes } from '../../../constants';
 

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -5,7 +5,6 @@ import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import routeActions from '../../../actions/route_actions.js';
 import RouteStore from '../../../stores/route_store.js';
 import { domainActionTypes, routeActionTypes } from '../../../constants';
@@ -324,7 +323,7 @@ describe('RouteStore', function() {
   describe('routeActionTypes.ROUTE_CREATED', function () {
     it('should add route and emitChange()', function () {
       const routeGuid = 'fake-route-guid';
-      const route = wrapInRes([ { guid: routeGuid } ])[0];
+      const route = { guid: routeGuid };
       const spy = sandbox.spy(RouteStore, 'emitChange');
 
       AppDispatcher.handleServerAction({
@@ -425,7 +424,7 @@ describe('RouteStore', function() {
       AppDispatcher.handleViewAction({
         type: routeActionTypes.ROUTES_FOR_APP_RECEIVED,
         appGuid: appGuid,
-        routes: wrapInRes([ { guid: 'adsfa' } ])
+        routes: [ { guid: 'adsfa' } ]
       });
 
       expect(spy).toHaveBeenCalledOnce();
@@ -439,7 +438,7 @@ describe('RouteStore', function() {
       AppDispatcher.handleServerAction({
         type: routeActionTypes.ROUTES_FOR_APP_RECEIVED,
         appGuid: sharedGuid,
-        routes: wrapInRes([ routeA ])
+        routes: [ routeA ]
       });
 
       let actual = RouteStore.get(routeA.guid);
@@ -460,7 +459,7 @@ describe('RouteStore', function() {
       AppDispatcher.handleServerAction({
         type: routeActionTypes.ROUTES_FOR_APP_RECEIVED,
         appGuid: sharedGuid,
-        routes: wrapInRes([newRoute])
+        routes: [newRoute]
       });
 
       expect(spy).toHaveBeenCalledOnce();
@@ -473,18 +472,14 @@ describe('RouteStore', function() {
       const spyShared = sandbox.spy(cfApi, 'fetchSharedDomain');
       const spyPrivate = sandbox.spy(cfApi, 'fetchPrivateDomain');
       const routeA = {
-        metadata: { guid: 'aldfjzxcbkvzxcb' },
-        entity: {
-          domain_guid: sharedDomainGuid,
-          domain_url: 'shared_domains'
-        }
+        guid: 'aldfjzxcbkvzxcb',
+        domain_guid: sharedDomainGuid,
+        domain_url: 'shared_domains'
       };
       const routeB = {
-        metadata: { guid: 'aldf23vx32xcb' },
-        entity: {
-          domain_guid: privateDomainGuid,
-          domain_url: 'private_domains'
-        }
+        guid: 'aldf23vx32xcb',
+        domain_guid: privateDomainGuid,
+        domain_url: 'private_domains'
       };
 
       routeActions.receivedRoutesForApp([routeA, routeB]);

--- a/static_src/test/unit/stores/service_binding_store.spec.js
+++ b/static_src/test/unit/stores/service_binding_store.spec.js
@@ -5,7 +5,6 @@ import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import ServiceBindingStore from '../../../stores/service_binding_store.js';
 import serviceActions from '../../../actions/service_actions.js';
 import { serviceActionTypes } from '../../../constants.js';
@@ -140,16 +139,12 @@ describe('ServiceBindingStore', function() {
   describe('on service bound', function() {
     const bindingGuid = 'xcvm,n32980cvxn';
     const testBinding = {
-      metadata: {
-        guid: bindingGuid
-      },
-      entity: {
-        app_guid: 'zcxv32',
-        service_instance_guid: 'xxcv2133'
-      }
+      guid: bindingGuid,
+      app_guid: 'zcxv32',
+      service_instance_guid: 'xxcv2133'
     };
 
-    it('should add the new binding to the store, unwrapping', function() {
+    it('should add the new binding to the store', function() {
       const bindingGuid = 'xcvm,n32980cvxn';
       const expected = testBinding;
 
@@ -158,7 +153,7 @@ describe('ServiceBindingStore', function() {
       const actual = ServiceBindingStore.get(bindingGuid);
 
       expect(actual).toBeTruthy();
-      expect(actual).toEqual(unwrapOfRes([expected]).pop());
+      expect(actual).toEqual(expected);
     });
 
     it('should emit a change', function() {

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -5,7 +5,6 @@ import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import ServiceInstanceStore from '../../../stores/service_instance_store.js';
 import serviceActions from '../../../actions/service_actions.js';
 import { serviceActionTypes } from '../../../constants.js';
@@ -176,14 +175,10 @@ describe('ServiceInstanceStore', function() {
     it('should merge in the service instance', function() {
       const spy = sandbox.spy(ServiceInstanceStore, 'merge');
       const instance = {
-        metadata: {
-          guid: 'zxmcvn23vlkxmcvn'
-        },
-        entity: {
-          name: 'testa'
-        }
+        guid: 'zxmcvn23vlkxmcvn',
+        name: 'testa'
       };
-      const expected = unwrapOfRes([instance])[0];
+      const expected = instance;
 
       serviceActions.receivedInstance(instance);
 
@@ -196,14 +191,10 @@ describe('ServiceInstanceStore', function() {
 
     it('should set fetched to true, fetched to false', function() {
       const instance = {
-        metadata: {
-          guid: 'zxmcvn23vlkxmcvn'
-        },
-        entity: {
-          name: 'testa'
-        }
+        guid: 'zxmcvn23vlkxmcvn',
+        name: 'testa'
       };
-      const expected = unwrapOfRes([instance])[0];
+      const expected = instance;
 
       serviceActions.receivedInstance(instance);
 
@@ -214,14 +205,10 @@ describe('ServiceInstanceStore', function() {
     it('should emit a change event', function() {
       const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
       const instance = {
-        metadata: {
-          guid: 'zxmcvn23vlkxmcvn'
-        },
-        entity: {
-          name: 'testa'
-        }
+        guid: 'zxmcvn23vlkxmcvn',
+        name: 'testa'
       };
-      const expected = unwrapOfRes([instance])[0];
+      const expected = instance;
 
       serviceActions.receivedInstance(instance);
 
@@ -242,14 +229,14 @@ describe('ServiceInstanceStore', function() {
       expect(ServiceInstanceStore.fetched).toEqual(true);
     });
 
-    it('should set data to unwrapped, passed in instances', function() {
+    it('should set data  passed in instances', function() {
       var expected = [
         {
           guid: 'adfa',
           type: 'postgres'
         }
       ];
-      let testRes = wrapInRes(expected);
+      let testRes = expected;
       AppDispatcher.handleServerAction({
         type: serviceActionTypes.SERVICE_INSTANCES_RECEIVED,
         serviceInstances: testRes
@@ -344,12 +331,12 @@ describe('ServiceInstanceStore', function() {
     });
   });
 
-  describe('on sevice instance created', function() {
+  describe('on service instance created', function() {
     it('should fetch the created instance with guid', function() {
       const spy = sandbox.spy(cfApi, 'fetchServiceInstance');
       const expectedGuid = 'akdfjzxcv32dfmnv23';
 
-      serviceActions.createdInstance({ metadata: {guid: expectedGuid }});
+      serviceActions.createdInstance({guid: expectedGuid });
 
       expect(spy).toHaveBeenCalledOnce();
       let arg = spy.getCall(0).args[0];
@@ -359,7 +346,7 @@ describe('ServiceInstanceStore', function() {
     it('emits a change event', function() {
       var spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
 
-      serviceActions.createdInstance({ metadata: {guid: 'adsfavzxc' }});
+      serviceActions.createdInstance({guid: 'adsfavzxc' });
 
       expect(spy).toHaveBeenCalledOnce();
     });
@@ -368,7 +355,7 @@ describe('ServiceInstanceStore', function() {
       ServiceInstanceStore._createInstanceForm = { service: {} };
       expect(ServiceInstanceStore.createInstanceForm).toBeTruthy();
       serviceActions.createdInstance(
-        { metadata: { guid: 'asdf9a8fasss', name: 'nameA' }});
+        { guid: 'asdf9a8fasss', name: 'nameA' });
 
       expect(ServiceInstanceStore.createInstanceForm).toBeFalsy();
     });
@@ -523,8 +510,8 @@ describe('ServiceInstanceStore', function() {
       ServiceInstanceStore._data = Immutable.fromJS([testInstance]);
 
       const binding = {
-        metadata: { guid: 'zxc' },
-        entity: { service_instance_guid: testGuid }
+        guid: 'zxc' ,
+        service_instance_guid: testGuid
       };
 
       serviceActions.boundService(binding);
@@ -541,8 +528,8 @@ describe('ServiceInstanceStore', function() {
       const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
 
       const binding = {
-        metadata: { guid: 'zxc' },
-        entity: { service_instance_guid: testGuid }
+        guid: 'zxc' ,
+        service_instance_guid: testGuid
       };
 
       serviceActions.boundService(binding);
@@ -558,8 +545,8 @@ describe('ServiceInstanceStore', function() {
       ServiceInstanceStore._data = Immutable.fromJS([testInstance]);
 
       const binding = {
-        metadata: { guid: 'zxc' },
-        entity: { service_instance_guid: testGuid }
+        guid: 'zxc',
+        service_instance_guid: testGuid
       };
 
       serviceActions.boundService(binding);

--- a/static_src/test/unit/stores/service_plan_store.spec.js
+++ b/static_src/test/unit/stores/service_plan_store.spec.js
@@ -5,7 +5,6 @@ import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import ServicePlanStore from '../../../stores/service_plan_store.js';
 import serviceActions from '../../../actions/service_actions.js';
 import { serviceActionTypes } from '../../../constants.js';
@@ -146,7 +145,7 @@ describe('ServicePlanStore', function() {
 
   describe('on services received', function() {
     it('should set fetching to true, fetched to false', function() {
-      const services = wrapInRes([{ guid: '3981f', name: 'adlfskzxcv' }]);
+      const services = [{ guid: '3981f', name: 'adlfskzxcv' }];
       ServicePlanStore.fetching = false;
       serviceActions.receivedServices(services);
 
@@ -185,7 +184,7 @@ describe('ServicePlanStore', function() {
       ];
       let existing = { guid: 'alkdjsfzxcv' };
 
-      let testRes = wrapInRes(expected);
+      let testRes = expected;
       ServicePlanStore.push(existing);
 
       serviceActions.receivedPlans(testRes);
@@ -206,7 +205,7 @@ describe('ServicePlanStore', function() {
         extra: JSON.stringify(expected)
       };
 
-      let testRes = wrapInRes([plan]);
+      let testRes = [plan];
 
       serviceActions.receivedPlans(testRes);
 
@@ -231,7 +230,7 @@ describe('ServicePlanStore', function() {
     it('should set fetching to false, fetched to true', function() {
       ServicePlanStore.fetching = true;
       ServicePlanStore.waitingOnRequests = false;
-      serviceActions.receivedPlans(wrapInRes([{ guid: 'adfklj' }]));
+      serviceActions.receivedPlans([{ guid: 'adfklj' }]);
 
       expect(ServicePlanStore.fetching).toEqual(false);
       expect(ServicePlanStore.fetched).toEqual(true);

--- a/static_src/test/unit/stores/service_store.spec.js
+++ b/static_src/test/unit/stores/service_store.spec.js
@@ -5,7 +5,6 @@ import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import ServiceStore from '../../../stores/service_store.js';
 import serviceActions from '../../../actions/service_actions.js';
 import { serviceActionTypes } from '../../../constants.js';
@@ -54,7 +53,7 @@ describe('ServiceStore', function() {
 
   describe('on services received', function() {
     it('should set fetching to false, fetched to true', function() {
-      let testRes = wrapInRes([{ guid: '3981f', name: 'adlfskzxcv' }]);
+      let testRes = [{ guid: '3981f', name: 'adlfskzxcv' }];
       ServiceStore.fetching = true;
       ServiceStore.fetched = false;
 
@@ -71,7 +70,7 @@ describe('ServiceStore', function() {
         { guid: sharedGuid, name: 'adlfskzxcv' }
       ];
 
-      let testRes = wrapInRes(expected);
+      let testRes = expected;
       ServiceStore._data = Immutable.fromJS([{ guid: sharedGuid }]);
 
 
@@ -85,7 +84,7 @@ describe('ServiceStore', function() {
     it('should emit a change event', function() {
       var spy = sandbox.spy(ServiceStore, 'emitChange');
 
-      serviceActions.receivedServices(wrapInRes([{ guid: 'adfklj' }]));
+      serviceActions.receivedServices([{ guid: 'adfklj' }]);
 
       expect(spy).toHaveBeenCalledOnce();
     });

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -4,7 +4,6 @@ import '../../global_setup.js';
 import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import orgActions from '../../../actions/org_actions.js';
 import spaceActions from '../../../actions/space_actions.js';
 import SpaceStore from '../../../stores/space_store.js';
@@ -92,16 +91,16 @@ describe('SpaceStore', function() {
     it('should call mergeMany with spaces from action', function () {
       const spy = sandbox.spy(SpaceStore, 'mergeMany');
       const spaces = [{ guid: 'fake-guid-one' }]
-      const res = wrapInRes(spaces);
+      const res = spaces;
 
       spaceActions.receivedSpaces(res);
 
       expect(spy).toHaveBeenCalledOnce();
-      expect(spy.getCall(0).args[1]).toEqual(spaces); 
+      expect(spy.getCall(0).args[1]).toEqual(spaces);
     });
 
     it('should set fetching to false and fetched to true', function() {
-      const spaces = wrapInRes([{ guid: 'fake-guid-one' }]);
+      const spaces = [{ guid: 'fake-guid-one' }];
       SpaceStore.fetching = true;
       SpaceStore.fetched = false;
 
@@ -112,7 +111,7 @@ describe('SpaceStore', function() {
     });
 
     it('should emit a change event', function() {
-      const spaces = wrapInRes([{ guid: 'fake-guid-one' }]);
+      const spaces = [{ guid: 'fake-guid-one' }];
       const spy = sandbox.spy(SpaceStore, 'emitChange');
 
       spaceActions.receivedSpaces(spaces);

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -5,7 +5,6 @@ import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import { wrapInRes, unwrapOfRes } from '../helpers.js';
 import UserStore from '../../../stores/user_store.js';
 import userActions from '../../../actions/user_actions.js';
 import { userActionTypes } from '../../../constants';
@@ -117,7 +116,7 @@ describe('UserStore', function() {
 
       AppDispatcher.handleViewAction({
         type: userActionTypes.SPACE_USERS_RECEIVED,
-        users: wrapInRes([{ guid: 'adsfa' }])
+        users: [{ guid: 'adsfa' }]
       });
 
       expect(UserStore.fetching).toEqual(false);
@@ -150,7 +149,7 @@ describe('UserStore', function() {
 
       AppDispatcher.handleServerAction({
         type: userActionTypes.SPACE_USERS_RECEIVED,
-        users: wrapInRes([newUser])
+        users: [newUser]
       });
 
       let actual = UserStore.get(sharedGuid);
@@ -167,7 +166,7 @@ describe('UserStore', function() {
 
       AppDispatcher.handleServerAction({
         type: userActionTypes.SPACE_USERS_RECEIVED,
-        users: wrapInRes([user]),
+        users: [user],
         orgGuid: expectedGuid
       });
 
@@ -183,7 +182,7 @@ describe('UserStore', function() {
 
       AppDispatcher.handleViewAction({
         type: userActionTypes.ORG_USER_ROLES_RECEIVED,
-        orgUserRoles: wrapInRes([{ guid: 'adsfa' }])
+        orgUserRoles: [{ guid: 'adsfa' }]
       });
 
       expect(spy).toHaveBeenCalledOnce();
@@ -196,7 +195,7 @@ describe('UserStore', function() {
 
       AppDispatcher.handleViewAction({
         type: userActionTypes.ORG_USER_ROLES_RECEIVED,
-        orgUserRoles: wrapInRes([{ guid: 'adsfa' }])
+        orgUserRoles: [{ guid: 'adsfa' }]
       });
 
       expect(UserStore.fetching).toEqual(false);
@@ -214,7 +213,7 @@ describe('UserStore', function() {
 
       AppDispatcher.handleViewAction({
         type: userActionTypes.ORG_USER_ROLES_RECEIVED,
-        orgUserRoles: wrapInRes([newUser])
+        orgUserRoles: [newUser]
       });
       let actual = UserStore.get(sharedGuid);
       let expected = Object.assign({}, existingUser, newUser);

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -58,6 +58,48 @@ describe('cfApi', function() {
     expect(spy).toHaveBeenCalledWith(errorFetchRes);
   }
 
+  describe('formatSplitResponse()', function() {
+    it('should combine sepaarate entity and metadata to one object', function() {
+      const resource = {
+        metadata: { guid: 'xzcvzc' },
+        entity: { name: 'blah' }
+      };
+
+      const actual = cfApi.formatSplitResponse(resource);
+
+      expect(actual.guid).toBeTruthy();
+      expect(actual.name).toBeTruthy();
+      expect(actual.metadata).toBeFalsy();
+      expect(actual.entity).toBeFalsy();
+    });
+  });
+
+  describe('formatSplitResponse()', function() {
+    var testRezs;
+
+    beforeEach(function() {
+      testRezs = [
+        { entity: { name: 'e1' }, metadata: { guid: 'mmmmmn' }},
+        { entity: { name: 'e2' }, metadata: { guid: 'mmmmmo' }}
+      ];
+    });
+
+    it('should merge entity with metadata for each resource', function() {
+      var actual = cfApi.formatSplitResponses(testRezs);
+
+      expect(actual[0]).toEqual({ name: 'e1', guid: 'mmmmmn'});
+    });
+
+    it('should not modify the original data', function() {
+      var clone = testRezs.slice(0);
+
+      cfApi.formatSplitResponses(testRezs);
+
+      expect(clone).toEqual(testRezs);
+    });
+  });
+
+
   describe('createRoute()', function() {
     it('should POST to the versioned /routes endpoint with data', function(done) {
       const domainGuid = 'fake-domain-guid';

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -34,6 +34,14 @@ function handleError(err, errHandler = errorActions.errorFetch) {
 export default {
   version: APIV,
 
+  formatSplitResponse(resource) {
+    return Object.assign({}, resource.entity, resource.metadata);
+  },
+
+  formatSplitResponses(resources) {
+    return resources.map((r) => this.formatSplitResponse(r));
+  },
+
   fetch(url, action, multiple, ...params) {
     return http.get(APIV + url).then((res) => {
       if (!multiple) {

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -147,7 +147,7 @@ export default {
 
   fetchOrgsSummaries(guids) {
     return Promise.all(guids.map((guid) => this.fetchOrgSummary(guid)))
-    .then((res) => orgActions.receivedOrgsSummaries(this.formatSplitResponses(res)))
+    .then((res) => orgActions.receivedOrgsSummaries(res))
     .catch((err) => {
       handleError(err);
     });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -66,8 +66,9 @@ export default {
     return http.get(APIV + url).then((res) => {
       const urls = [];
 
-      if (!res.data.next_url) return action(
-        this.formatSplitResponses(res.data.resources));
+      if (!res.data.next_url) {
+        return action(this.formatSplitResponses(res.data.resources));
+      }
 
       for (let i = 2; i <= res.data.total_pages; i++) {
         urls.push(`${APIV}${url}?page=${i}`);

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -45,9 +45,17 @@ export default {
   fetch(url, action, multiple, ...params) {
     return http.get(APIV + url).then((res) => {
       if (!multiple) {
-        action(this.formatSplitResponse(res.data), ...params);
+        let data = res.data;
+        if (!/summary/.test(url)) {
+          data = this.formatSplitResponse(data);
+        }
+        action(data, ...params);
       } else {
-        action(this.formatSplitResponses(res.data.resources), ...params);
+        let data = res.data.resources;
+        if (!/summary/.test(url)) {
+          data = this.formatSplitResponses(data);
+        }
+        action(data, ...params);
       }
     }).catch((err) => {
       handleError(err);
@@ -121,7 +129,7 @@ export default {
       let quota = {};
       quota = Object.assign(quota, ...res);
       fullOrg.quota = quota;
-      orgActions.receivedOrg(this.formatSplitResponse(fullOrg));
+      orgActions.receivedOrg(fullOrg);
     }, (err) => {
       errorActions.errorFetch(err);
     });


### PR DESCRIPTION
Changes the data part of the code so all the formatting of the cloud foundry API responses is done in one place: in the `cf_api` code.

### Explanation of problem

The cloud foundry API almost always returns data in the following format:

```js
{
  metadata: {
    guid: 'test',
    ...
  },
  entity: {
    name: 'test
    ...
  }
}
```

This format is harder to use in the UI components, so code was added in each store to transform that data to look like this:

```js
{
  guid: 'test',
  name: 'test
  ...
}
```

Because this was done separately in each store, there was a lack of consistency, as some data returned from the API was not in this format, such as any data returned from a `summary` API call. 

### Solution

Because all API responses are initiated in the `cf_api`, it makes more sense for this formatting transformation to occur there. so as soon as the data comes in it's transformed, and it's life-cycle through the app is in the new format. All the stores and API calls were changed to format the data in `cf_api`.

### Notes
- Any `summary` API call from Cloud Foundry does not return the data in the metadata/entity format, therefore, theres a separate check for this in the re-usable `cf_api` methods.
- Have separate methods for formatting a single response vs an array of them, which was something we required before anyway.