### PR TITLE
Add note about GovCloud URL

### DIFF
--- a/static_src/components/home.jsx
+++ b/static_src/components/home.jsx
@@ -38,6 +38,8 @@ export default class Home extends React.Component {
               <li><strong>Marketplace:</strong> Use your org’s <a href="https://docs.cloud.gov/apps/managed-services/">marketplace</a> to create <a href="https://docs.cloud.gov/intro/pricing/rates/">service instances</a> for spaces in that org.
               </li>
             </ul>
+            <h4>Environments</h4>
+            <p>If your org <a href="https://docs.cloud.gov/apps/govcloud/">is in GovCloud</a>, use <a href="https://dashboard.fr.cloud.gov/"><code>https://dashboard.fr.cloud.gov/</code></a> to see it.</p>
           </section>
           <section className={ this.styler('usa-width-one-half') }
             style={{marginTop: '-4rem'}}>


### PR DESCRIPTION
Some of our customers have orgs in GovCloud, so if they look at https://dashboard.cloud.gov/, they won't see their orgs and may be confused or worried. Here's a tiny change to direct them to visit https://dashboard.fr.cloud.gov/ instead.

I haven't tested this change locally since the local demo setup isn't working for me, and I'm sure it's not pretty - just trying to have something here. :) Feel free to replace this with something better.

Related GovCloud docs update: https://github.com/18F/cg-docs/pull/463