### PR TITLE
Added page-dek object for page descriptions

### DIFF
--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -3,6 +3,8 @@
  */
 
 import React from 'react';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+import createStyler from '../util/create_styler';
 
 import CreateServiceInstance from './create_service_instance.jsx';
 import Loading from './loading.jsx';
@@ -37,6 +39,7 @@ export default class Marketplace extends React.Component {
     this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {
@@ -83,7 +86,7 @@ export default class Marketplace extends React.Component {
         <div>
           <div>
             { marketplace }
-            <p><em>Use this marketplace to create service instances for spaces in this org. Then bind service instances to apps using the command line. <a href="https://docs.cloud.gov/apps/managed-services/">Learn about using service instances and marketplaces</a>.</em></p>
+            <p className={ this.styler('page-dek') }>Use this marketplace to create service instances for spaces in this org. Then bind service instances to apps using the command line. <a href="https://docs.cloud.gov/apps/managed-services/">Learn about using service instances and marketplaces</a>.</p>
           </div>
           { list }
           { form }

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import AppList from '../components/app_list.jsx';
 import OrgStore from '../stores/org_store.js';
@@ -8,6 +9,8 @@ import SpaceStore from '../stores/space_store.js';
 import Users from './users.jsx';
 import Tabnav from './tabnav.jsx';
 import TabnavItem from './tabnav_item.jsx';
+import createStyler from '../util/create_styler';
+
 
 const PAGES = {
   'apps': AppList,
@@ -36,6 +39,7 @@ export default class SpaceContainer extends React.Component {
     this.state = stateSetter();
     this._onChange = this._onChange.bind(this);
     this.spaceUrl = this.spaceUrl.bind(this);
+    this.styler = createStyler(style);
   }
 
   componentDidMount() {
@@ -83,6 +87,14 @@ export default class SpaceContainer extends React.Component {
     return this.state.currentOrg || '0';
   }
 
+  get defaultClasses() {
+    return [
+      this.styler('nav'),
+      this.styler('nav-tabs'),
+      this.styler('nav-justified')
+    ];
+  }
+
   render() {
     let Content = this.currentContent;
     let tabNav = <div></div>;
@@ -100,9 +112,9 @@ export default class SpaceContainer extends React.Component {
           <h2>
             <strong>{this.state.space.name}</strong> space in your <strong>{ this.currentOrgName }</strong> organization
           </h2>
-          <p><em>
+          <p className={ this.styler('page-dek') }>
             Each <a href="https://docs.cloud.gov/getting-started/concepts/">space</a> provides an environment for related applications (<a href="https://docs.cloud.gov/intro/overview/using-cloudgov-paas/">example use</a>).
-          </em></p>
+          </p>
         </div>
         { tabNav }
         <div>

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -87,14 +87,6 @@ export default class SpaceContainer extends React.Component {
     return this.state.currentOrg || '0';
   }
 
-  get defaultClasses() {
-    return [
-      this.styler('nav'),
-      this.styler('nav-tabs'),
-      this.styler('nav-justified')
-    ];
-  }
-
   render() {
     let Content = this.currentContent;
     let tabNav = <div></div>;

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -95,9 +95,9 @@ export default class SpaceList extends React.Component {
       <div>
         <div>
           <h2>All spaces in your <strong>{this.title}</strong> organization</h2>
-          <p><em>
+          <p className={ this.styler('page-dek') }>
           Each organization is a <a href="https://docs.cloud.gov/intro/terminology/pricing-terminology/">system</a> (<a href="https://docs.cloud.gov/getting-started/concepts/">shared perimeter</a>) that contains <a href="https://docs.cloud.gov/intro/pricing/system-stuffing/">related spaces holding related applications</a>.
-          </em></p>
+          </p>
         </div>
         <div className={ this.styler('tableWrapper') }>
           { content }


### PR DESCRIPTION
Added a new text element to style the description of the content of a page.

This requires the new styles here: https://github.com/18F/cg-style/pull/164

- - -

![screen shot 2016-10-14 at 9 08 17 am](https://cloud.githubusercontent.com/assets/11464021/19394383/d1cd0418-91ed-11e6-87ed-d90b611c3ed9.png)
