### PR TITLE
Suggestion for updating navigation link names and links

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -87,7 +87,7 @@ and the `testSpace01` space.
   - Click edit again.
   - Click "Delete route".
   - Ensure the route is deleted.
-1. Click on the `Overview` link in the sidenav and ensure the homepage appears.
+1. Click on the `Guide` link in the sidenav and ensure the homepage appears.
 
 ## Tagging
 

--- a/static_src/components/header.jsx
+++ b/static_src/components/header.jsx
@@ -25,7 +25,7 @@ export default class Header extends React.Component {
     <header className={ this.styler('header') }>
       <div className={ this.styler('header-wrap') }>
         <div className={ this.styler('header-title') }>
-          <a href="/" className={ this.styler('logo') } title="Home">
+          <a href="https://cloud.gov/" className={ this.styler('logo') } title="Home">
             <svg className={ this.styler('logo') }>
               <use
                 xlinkHref={ this.getImagePath('logo') }>
@@ -37,7 +37,7 @@ export default class Header extends React.Component {
         <nav className={ this.styler('header-side') }>
           <ul className={ this.styler('nav') }>
             <li className={ this.styler('nav-link') }>
-              <a href="https://cloud.gov/#about">About</a>
+              <a href="https://cloud.gov/overview/">Overview</a>
             </li>
             <li className={ this.styler('nav-link') }>
               <a href="https://docs.cloud.gov">Documentation</a>

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -93,7 +93,7 @@ export class Nav extends React.Component {
       <div className={ this.styler('test-nav-primary') }>
         <ul className={ mainList }>
           <li key="overview" className={ this.styler('sidenav-entity') }>
-            <a href="/#" onClick={this._handleOverviewClick}>Overview</a>
+            <a href="/#" onClick={this._handleOverviewClick}>Guide</a>
           </li>
           <li key="organizations" className={ this.styler('sidenav-header') }>
             <span className={ this.styler('sidenav-header-text') }>


### PR DESCRIPTION
This is a suggestion for a few navigation link changes, to help the Dashboard sync up with the other sections of cloud.gov. It'd be ok for the Dashboard crew to decide you all don't want to integrate some of these (or do this a different way) - just putting this up as a proposal for one way to do this.
- I updated the header navigation "About" link (https://cloud.gov/#about) to "Overview" (https://cloud.gov/overview/), to match the current homepage style. (Also filed a PR for cg-docs for this - https://github.com/18F/cg-docs/pull/466)
- That means this page no longer has an easy link to the cloud.gov homepage, so I updated the cloud.gov logo to link to the cloud.gov homepage. This is a bit of a tricky decision. I remember @thisisdano has insight into this kind of decision - tagging him here for his thoughts. :)
- Now we have two links on this page called "Overview", since the Dashboard-local homepage is called "Overview" in the Dashboard sidebar. It's best to not have two things named the same thing, so I renamed the Dashboard-local homepage to "Guide". I'm not sure if that's a better name. As a team we could also discuss the name of the new "Overview" section some more - see https://github.com/18F/cg-docs/issues/332 where we had that discussion. (We also had the option of "Introduction", for example.)
- Since I renamed the "Overview" link, I also renamed it in the testing steps.

cc @jameshupp @berndverst for copy + customer-help thoughts as well.
