### PR TITLE
Refactor for loading status

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -26,8 +26,8 @@ function stateSetter() {
     currentAppGuid,
     currentOrgName: OrgStore.currentOrgName,
     currentSpaceName: SpaceStore.currentSpaceName,
-    empty: AppStore.fetched && !appReady(app),
-    loading: AppStore.fetching
+    empty: !AppStore.loading && !appReady(app),
+    loading: AppStore.loading
   };
 }
 

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -22,8 +22,8 @@ function stateSetter() {
     apps: apps,
     currentOrgGuid,
     currentSpaceGuid,
-    loading: SpaceStore.fetching,
-    empty: SpaceStore.fetched && !apps.length
+    loading: SpaceStore.loading,
+    empty: !SpaceStore.loading && !apps.length
   };
 }
 

--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -16,7 +16,7 @@ import ServiceInstanceStore from '../stores/service_instance_store.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
 
 function stateSetter() {
-  const loading = ServiceStore.fetching || ServicePlanStore.loading;
+  const loading = ServiceStore.loading || ServicePlanStore.loading;
   const services = ServiceStore.getAll().map((service) => {
     const plan = ServicePlanStore.getAllFromService(service.guid);
     return { ...service, servicePlans: plan };

--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -16,7 +16,7 @@ import ServiceInstanceStore from '../stores/service_instance_store.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
 
 function stateSetter() {
-  const loading = ServiceStore.fetching || ServicePlanStore.fetching;
+  const loading = ServiceStore.fetching || ServicePlanStore.loading;
   const services = ServiceStore.getAll().map((service) => {
     const plan = ServicePlanStore.getAllFromService(service.guid);
     return { ...service, servicePlans: plan };

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -21,8 +21,8 @@ function stateSetter() {
   return {
     serviceInstances,
     currentSpaceGuid,
-    loading: ServiceInstanceStore.fetching,
-    empty: ServiceInstanceStore.fetched && !serviceInstances.length
+    loading: ServiceInstanceStore.loading,
+    empty: !ServiceInstanceStore.loading && !serviceInstances.length
   };
 }
 

--- a/static_src/components/service_instance_panel.jsx
+++ b/static_src/components/service_instance_panel.jsx
@@ -66,8 +66,8 @@ function stateSetter() {
     !ServiceInstanceStore.isInstanceBound(serviceInstance, appServiceBindings)
   );
 
-  const loading = ServiceInstanceStore.fetching ||
-    ServicePlanStore.fetching ||
+  const loading = ServiceInstanceStore.loading ||
+    ServicePlanStore.loading ||
     ServiceBindingStore.fetching;
 
   return {

--- a/static_src/components/service_instance_panel.jsx
+++ b/static_src/components/service_instance_panel.jsx
@@ -27,12 +27,12 @@ const defaultProps = {
 
 
 function boundReady(instances) {
-  return ServiceInstanceStore.fetched && ServicePlanStore.fetched &&
-      ServiceBindingStore.fetched && !instances.length;
+  return !ServiceInstanceStore.loading && !ServicePlanStore.loading &&
+      !ServiceBindingStore.loading && !instances.length;
 }
 
 function unboundReady(instances) {
-  return ServiceInstanceStore.fetched && ServicePlanStore.fetched &&
+  return !ServiceInstanceStore.loading && !ServicePlanStore.loading &&
     !instances.length;
 }
 
@@ -68,7 +68,7 @@ function stateSetter() {
 
   const loading = ServiceInstanceStore.loading ||
     ServicePlanStore.loading ||
-    ServiceBindingStore.fetching;
+    ServiceBindingStore.loading;
 
   return {
     currentAppGuid,

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -14,7 +14,7 @@ function stateSetter(props) {
   const services = props.initialServices;
 
   return {
-    empty: ServiceStore.fetched && !services.length,
+    empty: !ServiceStore.loading && !services.length,
     services
   }
 }

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -16,7 +16,7 @@ function stateSetter(serviceGuid) {
 
   return {
     servicePlans,
-    empty: ServicePlanStore.fetched && !servicePlans.length
+    empty: !ServicePlanStore.loading && !servicePlans.length
   };
 }
 

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -38,8 +38,8 @@ function stateSetter() {
     currentOrgGuid,
     currentSpaceGuid,
     currentTab,
-    loading: UserStore.fetching,
-    empty: UserStore.fetched && !users.length,
+    loading: UserStore.loading,
+    empty: !UserStore.loading && !users.length,
     users
   };
 }

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -21,9 +21,7 @@ class AppStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case appActionTypes.APP_FETCH:
-        cfApi.fetchApp(action.appGuid);
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchApp(action.appGuid)]);
         this.emitChange();
         break;
 
@@ -32,8 +30,6 @@ class AppStore extends BaseStore {
         break;
 
       case appActionTypes.APP_RECEIVED:
-        this.fetching = false;
-        this.fetched = true;
         this.merge('guid', action.app, () => { });
         this.emitChange();
         break;
@@ -47,16 +43,12 @@ class AppStore extends BaseStore {
       }
 
       case appActionTypes.APP_ALL_FETCH: {
-        cfApi.fetchAppAll(action.appGuid);
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchAppAll(action.appGuid)]);
         this.emitChange();
         break;
       }
 
       case appActionTypes.APP_ALL_RECEIVED: {
-        this.fetching = false;
-        this.fetched = true;
         this.emitChange();
         break;
       }

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -23,26 +23,20 @@ class OrgStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case orgActionTypes.ORG_FETCH: {
-        cfApi.fetchOrg(action.orgGuid);
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchOrg(action.orgGuid)]);
         this.emitChange();
         break;
       }
 
       case orgActionTypes.ORGS_FETCH: {
         AppDispatcher.waitFor([LoginStore.dispatchToken]);
-        cfApi.fetchOrgs();
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchOrgs()]);
         this.emitChange();
         break;
       }
 
       case orgActionTypes.ORG_RECEIVED: {
         if (action.org) {
-          this.fetching = false;
-          this.fetched = true;
           this.merge('guid', action.org, () => { });
           this.emitChange();
         }
@@ -74,8 +68,6 @@ class OrgStore extends BaseStore {
             this.mergeMany('guid', orgUpdates, () => {});
           }
         });
-        this.fetched = true;
-        this.fetching = false;
         this.emitChange();
         break;
       }

--- a/static_src/stores/service_binding_store.js
+++ b/static_src/stores/service_binding_store.js
@@ -25,9 +25,7 @@ class ServiceBindingStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case serviceActionTypes.SERVICE_BINDINGS_FETCH: {
-        cfApi.fetchServiceBindings(action.appGuid);
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchServiceBindings(action.appGuid)]);
         this.emitChange();
         break;
       }
@@ -35,8 +33,6 @@ class ServiceBindingStore extends BaseStore {
       case serviceActionTypes.SERVICE_BINDINGS_RECEIVED: {
         const bindings = action.serviceBindings;
         this.mergeMany('guid', bindings, () => { });
-        this.fetching = false;
-        this.fetched = true;
         this.emitChange();
         break;
       }

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -8,7 +8,6 @@ import Immutable from 'immutable';
 import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
-import LoadingStatus from '../util/loading_status.js';
 import { serviceActionTypes } from '../constants.js';
 import ServiceStore from './service_store.js';
 import ServicePlanStore from './service_plan_store.js';
@@ -34,9 +33,6 @@ class ServiceInstanceStore extends BaseStore {
     this._data = new Immutable.List();
     this._createInstanceForm = null;
     this._createError = null;
-    this.loadingStatus = new LoadingStatus();
-    this.loadingStatus.on('loading', () => this.emitChange());
-    this.loadingStatus.on('loaded', () => this.emitChange());
   }
 
   get createInstanceForm() {
@@ -45,10 +41,6 @@ class ServiceInstanceStore extends BaseStore {
 
   get createError() {
     return this._createError;
-  }
-
-  get loading() {
-    return !this.loadingStatus.isLoaded;
   }
 
   getAllBySpaceGuid(spaceGuid) {
@@ -103,7 +95,7 @@ class ServiceInstanceStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case serviceActionTypes.SERVICE_INSTANCES_FETCH: {
-        this.loadingStatus.load([cfApi.fetchServiceInstances(action.spaceGuid)]);
+        this.load([cfApi.fetchServiceInstances(action.spaceGuid)]);
         this.emitChange();
         break;
       }

--- a/static_src/stores/service_plan_store.js
+++ b/static_src/stores/service_plan_store.js
@@ -9,7 +9,6 @@ import Immutable from 'immutable';
 import AppDispatcher from '../dispatcher';
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
-import LoadingStatus from '../util/loading_status.js';
 import { serviceActionTypes } from '../constants.js';
 import ServiceStore from './service_store.js';
 
@@ -18,13 +17,6 @@ class ServicePlanStore extends BaseStore {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
     this._data = new Immutable.List();
-    this.loadingStatus = new LoadingStatus();
-    this.loadingStatus.on('loading', () => this.emitChange());
-    this.loadingStatus.on('loaded', () => this.emitChange());
-  }
-
-  get loading() {
-    return !this.loadingStatus.isLoaded;
   }
 
   getAllFromService(serviceGuid) {
@@ -59,15 +51,14 @@ class ServicePlanStore extends BaseStore {
     switch (action.type) {
       case serviceActionTypes.SERVICES_RECEIVED: {
         const services = action.services;
-        this.loadingStatus.load(services.map(service => cfApi.fetchAllServicePlans(service.guid)));
+        this.load(services.map(service => cfApi.fetchAllServicePlans(service.guid)));
         this.emitChange();
         break;
       }
 
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
         const instances = action.serviceInstances;
-        this.loadingStatus.load(instances.map(instance =>
-          cfApi.fetchServicePlan(instance.service_plan_guid)));
+        this.load(instances.map(instance => cfApi.fetchServicePlan(instance.service_plan_guid)));
         this.emitChange();
         break;
       }

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -22,9 +22,7 @@ class ServiceStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case serviceActionTypes.SERVICES_FETCH: {
-        this.fetching = true;
-        this.fetched = false;
-        cfApi.fetchAllServices(action.orgGuid);
+        this.load([cfApi.fetchAllServices(action.orgGuid)]);
         break;
       }
 
@@ -32,8 +30,6 @@ class ServiceStore extends BaseStore {
         AppDispatcher.waitFor([ServicePlanStore.dispatchToken]);
         const services = action.services;
         this.mergeMany('guid', services, () => { });
-        this.fetching = false;
-        this.fetched = true;
         this.emitChange();
         break;
       }

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -34,24 +34,18 @@ class SpaceStore extends BaseStore {
       }
 
       case spaceActionTypes.SPACE_FETCH: {
-        this.fetching = true;
-        this.fetched = false;
-        cfApi.fetchSpace(action.spaceGuid);
+        this.load([cfApi.fetchSpace(action.spaceGuid)]);
         this.emitChange();
         break;
       }
 
       case spaceActionTypes.SPACES_FETCH: {
-        this.fetching = true;
-        this.fetched = false;
-        cfApi.fetchSpaces();
+        this.load([cfApi.fetchSpaces()]);
         this.emitChange();
         break;
       }
 
       case spaceActionTypes.SPACE_RECEIVED: {
-        this.fetching = false;
-        this.fetched = true;
         this.merge('guid', action.space, () => { });
         this.emitChange();
         break;
@@ -59,8 +53,6 @@ class SpaceStore extends BaseStore {
 
       case spaceActionTypes.SPACES_RECEIVED: {
         this.mergeMany('guid', action.spaces, () => {
-          this.fetching = false;
-          this.fetched = true;
           this.emitChange();
         });
         break;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -38,32 +38,24 @@ class UserStore extends BaseStore {
   _registerToActions(action) {
     switch (action.type) {
       case userActionTypes.ORG_USERS_FETCH: {
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchOrgUsers(action.orgGuid)]);
         this.emitChange();
-        cfApi.fetchOrgUsers(action.orgGuid);
         break;
       }
 
       case userActionTypes.ORG_USER_ROLES_FETCH: {
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchOrgUserRoles(action.orgGuid)]);
         this.emitChange();
-        cfApi.fetchOrgUserRoles(action.orgGuid);
         break;
       }
 
       case userActionTypes.SPACE_USERS_FETCH: {
-        this.fetching = true;
-        this.fetched = false;
+        this.load([cfApi.fetchSpaceUsers(action.spaceGuid)]);
         this.emitChange();
-        cfApi.fetchSpaceUsers(action.spaceGuid);
         break;
       }
 
       case userActionTypes.ORG_USER_ROLES_RECEIVED: {
-        this.fetching = false;
-        this.fetched = true;
         const updates = action.orgUserRoles;
         if (updates.length) {
           this.mergeMany('guid', updates, () => { });
@@ -165,16 +157,12 @@ class UserStore extends BaseStore {
         });
         if (updates.length) {
           this.mergeMany('guid', updates, (changed) => {
-            this.fetching = false;
-            this.fetched = true;
             if (changed) {
               this._error = null;
             }
             this.emitChange();
           });
         } else {
-          this.fetching = false;
-          this.fetched = true;
           this.emitChange();
         }
         break;

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -16,8 +16,6 @@ describe('AppStore', function() {
   beforeEach(() => {
     AppStore._data = Immutable.List();
     AppStore._currentAppGuid = null;
-    AppStore._fetching = false;
-    AppStore._fetched = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -76,7 +74,7 @@ describe('AppStore', function() {
       expect(spy).toHaveBeenCalledOnce();
       let arg = spy.getCall(0).args[0];
       expect(arg).toEqual(expectedGuid);
-      expect(AppStore.fetching).toEqual(true);
+      expect(AppStore.loading).toEqual(true);
     });
   });
 
@@ -127,20 +125,6 @@ describe('AppStore', function() {
           instances: [{ guid: 'dfs' }] });
     });
 
-    it('should set fetched to true, fetching to false', function() {
-      var app = { guid: 'asdf' };
-
-      AppStore.push(app);
-
-      AppDispatcher.handleViewAction({
-        type: appActionTypes.APP_RECEIVED,
-        app: {}
-      });
-
-      expect(AppStore.fetching).toBeFalsy();
-      expect(AppStore.fetched).toBeTruthy();
-    });
-
     it('should add app to data if it doesn\'t already exist', function() {
       var expectedGuid = 'adcasdc',
           expected = { guid: expectedGuid, name: 'asdf' };
@@ -156,19 +140,14 @@ describe('AppStore', function() {
   });
 
   describe('on app all received', function() {
-    it('should change fetching to false fetched to true & emit change',
-        function() {
+    it('should emit change', function() {
       var spy = sandbox.spy(AppStore, 'emitChange');
-      AppStore._fetching = true;
-      AppStore._fetched = false;
 
       AppDispatcher.handleViewAction({
         type: appActionTypes.APP_ALL_RECEIVED,
         appGuid: 'asdf'
       });
 
-      expect(AppStore.fetching).toEqual(false);
-      expect(AppStore.fetched).toEqual(true);
       expect(spy).toHaveBeenCalledOnce();
     });
   });

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -199,60 +199,6 @@ describe('BaseStore', () => {
     });
   });
 
-  describe('fetching', function() {
-    it('should initially be false', function() {
-      expect(store.fetching).toEqual(false);
-    });
-
-    it('should be able to be set to true', function () {
-      store.fetching = true;
-      expect(store.fetching).toEqual(true);
-    });
-
-    it('should cast all values to booleans', function () {
-      store.fetching = 'true';
-      expect(store.fetching).toEqual(true);
-
-      store.fetching = undefined;
-      expect(store.fetching).toEqual(false);
-    });
-
-    it('should not emit change', function () {
-      var spy = sandbox.spy();
-
-      store.on('CHANGE', spy);
-      store.fetching = false;
-      expect(spy).not.toHaveBeenCalledOnce();
-    });
-  });
-
-  describe('fetched', function() {
-    it('should initially be false', function() {
-      expect(store.fetched).toEqual(false);
-    });
-
-    it('should be able to be set to true', function () {
-      store.fetched = true;
-      expect(store.fetched).toEqual(true);
-    });
-
-    it('should cast all values to booleans', function () {
-      store.fetched = 'true';
-      expect(store.fetched).toEqual(true);
-
-      store.fetched = undefined;
-      expect(store.fetched).toEqual(false);
-    });
-
-    it('should not emit change if the value is the same', function () {
-      var spy = sandbox.spy();
-
-      store.on('CHANGE', spy);
-      store.fetched = false;
-      expect(spy).not.toHaveBeenCalledOnce();
-    });
-  });
-
   describe('merge()', function() {
     var existingEntityA = {
       guid: 'zznbmbz',
@@ -384,6 +330,56 @@ describe('BaseStore', () => {
         expect(second.green).toEqual(true);
         expect(third.green).toEqual(true);
         expect(changed).toEqual(true);
+      });
+    });
+  });
+
+  describe('load()', function () {
+    describe('when called', function () {
+      let spy;
+
+      beforeEach(function (done) {
+        spy = sinon.spy();
+        store.on('CHANGE', spy);
+
+        // unresolved promise
+        const promise = new Promise(function () { });
+
+        store.load([promise]);
+        setImmediate(done);
+      });
+
+      it('sets loading true', function () {
+        expect(store.loading).toBe(true);
+      });
+
+      it('emits change', function () {
+        expect(spy).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe('when request is resolved', function () {
+      let request, spy;
+
+      beforeEach(function (done) {
+        spy = sinon.spy();
+        store.on('CHANGE', spy);
+
+        const promise = new Promise(function (resolve, reject) {
+          request = { resolve, reject };
+        });
+
+        store.load([promise]);
+        request.resolve();
+        setImmediate(done);
+      });
+
+      it('sets loading false', function () {
+        expect(store.loading).toBe(false);
+      });
+
+      it('emits change', function () {
+        expect(spy).toHaveBeenCalledTwice();
       });
     });
   });

--- a/static_src/test/unit/stores/org_store.spec.js
+++ b/static_src/test/unit/stores/org_store.spec.js
@@ -13,8 +13,6 @@ describe('OrgStore', () => {
 
   beforeEach(() => {
     OrgStore._currentOrgGuid = null;
-    OrgStore._fetching = false;
-    OrgStore._fetched = false;
     OrgStore._data = Immutable.List();
     sandbox = sinon.sandbox.create();
   });
@@ -85,17 +83,6 @@ describe('OrgStore', () => {
       expect(OrgStore.getAll()).toEqual(expected);
     });
 
-    it('should set fetching to false', () => {
-      var expected = [{guid: '1as'}, {guid: '2as'}];
-
-      AppDispatcher.handleViewAction({
-        type: orgActionTypes.ORGS_RECEIVED,
-        orgs: expected
-      });
-
-      expect(OrgStore.fetching).toEqual(false);
-    });
-
     it('should merge data with existing orgs', () => {
       var updates = [{guid: 'aaa1', name: 'sue'},
             {guid: 'aaa2', name: 'see'}],
@@ -116,16 +103,13 @@ describe('OrgStore', () => {
   });
 
   describe('on org fetch', function() {
-    it('should set fetching to true, fetched to false', function() {
-      expect(OrgStore.fetching).toEqual(false);
-
+    it('should set loading to true', function() {
       AppDispatcher.handleViewAction({
         type: orgActionTypes.ORG_FETCH,
         orgGuid: 'orgGuid'
       });
 
-      expect(OrgStore.fetching).toEqual(true);
-      expect(OrgStore.fetched).toEqual(false);
+      expect(OrgStore.loading).toEqual(true);
     });
 
     it('should call the api org fetch function', function() {

--- a/static_src/test/unit/stores/service_binding_store.spec.js
+++ b/static_src/test/unit/stores/service_binding_store.spec.js
@@ -14,8 +14,6 @@ describe('ServiceBindingStore', function() {
 
   beforeEach(() => {
     ServiceBindingStore._data = Immutable.List();
-    ServiceBindingStore._fetching = false;
-    ServiceBindingStore._fetched = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -42,19 +40,18 @@ describe('ServiceBindingStore', function() {
       expect(arg).toEqual(expectedAppGuid);
     });
 
-    it('should set fetching to true, fetched to false', function() {
-      ServiceBindingStore.fetching = false;
+    it('should set loading to true', function() {
       serviceActions.fetchServiceBindings('zxncvz8xcvhn32');
 
-      expect(ServiceBindingStore.fetching).toEqual(true);
-      expect(ServiceBindingStore.fetched).toEqual(false);
+      expect(ServiceBindingStore.loading).toEqual(true);
     });
 
     it('should emit a change', function() {
       const spy = sandbox.spy(ServiceBindingStore, 'emitChange');
       serviceActions.fetchServiceBindings('zxncvz8xcvhn32');
 
-      expect(spy).toHaveBeenCalledOnce();
+      // change is emitted twice, once on the action, once for loading status
+      expect(spy).toHaveBeenCalled();
     });
   });
 
@@ -79,14 +76,6 @@ describe('ServiceBindingStore', function() {
     const fakeBindings = [
       { metadata: { guid: 'adsfa' }, entity: { service_instance_guid: 'zcv'} }
     ];
-
-    it('should set fetching to false, fetched to true', function() {
-      ServiceBindingStore.fetching = true;
-      serviceActions.receivedServiceBindings(fakeBindings);
-
-      expect(ServiceBindingStore.fetching).toEqual(false);
-      expect(ServiceBindingStore.fetched).toEqual(true);
-    });
 
     it('should emit a change', function() {
       const spy = sandbox.spy(ServiceBindingStore, 'emitChange');

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -17,8 +17,6 @@ describe('ServiceInstanceStore', function() {
   beforeEach(() => {
     ServiceInstanceStore._data = Immutable.List();
     ServiceInstanceStore._createError = null;
-    ServiceInstanceStore._fetching = false;
-    ServiceInstanceStore._fetched = false;
     ServiceInstanceStore.waitingOnRequests = false;
     sandbox = sinon.sandbox.create();
   });
@@ -143,17 +141,13 @@ describe('ServiceInstanceStore', function() {
   });
 
   describe('on service instances fetch', function() {
-    it('should set fetching to true, fetched to false', function() {
-      ServiceInstanceStore.fetching = false;
-      ServiceInstanceStore.fetched = true;
-
+    it('should be loading', function() {
       AppDispatcher.handleViewAction({
         type: serviceActionTypes.SERVICE_INSTANCES_FETCH,
         spaceGuid: 'fakeguid'
       });
 
-      expect(ServiceInstanceStore.fetching).toEqual(true);
-      expect(ServiceInstanceStore.fetched).toEqual(false);
+      expect(ServiceInstanceStore.loading).toEqual(true);
     });
 
     it('should fetch service instances from api with space guid', function() {
@@ -189,19 +183,6 @@ describe('ServiceInstanceStore', function() {
       expect(arg2).toEqual(expected);
     });
 
-    it('should set fetched to true, fetched to false', function() {
-      const instance = {
-        guid: 'zxmcvn23vlkxmcvn',
-        name: 'testa'
-      };
-      const expected = instance;
-
-      serviceActions.receivedInstance(instance);
-
-      expect(ServiceInstanceStore.fetching).toEqual(false);
-      expect(ServiceInstanceStore.fetched).toEqual(true);
-    });
-
     it('should emit a change event', function() {
       const spy = sandbox.spy(ServiceInstanceStore, 'emitChange');
       const instance = {
@@ -217,18 +198,6 @@ describe('ServiceInstanceStore', function() {
   });
 
   describe('on service instances received', function() {
-    it('should set fetching to false, fetched to true', function() {
-      ServiceInstanceStore.fetching = true;
-
-      AppDispatcher.handleViewAction({
-        type: serviceActionTypes.SERVICE_INSTANCES_RECEIVED,
-        serviceInstances: []
-      });
-
-      expect(ServiceInstanceStore.fetching).toEqual(false);
-      expect(ServiceInstanceStore.fetched).toEqual(true);
-    });
-
     it('should set data  passed in instances', function() {
       var expected = [
         {

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -17,7 +17,6 @@ describe('ServiceInstanceStore', function() {
   beforeEach(() => {
     ServiceInstanceStore._data = Immutable.List();
     ServiceInstanceStore._createError = null;
-    ServiceInstanceStore.waitingOnRequests = false;
     sandbox = sinon.sandbox.create();
   });
 

--- a/static_src/test/unit/stores/service_plan_store.spec.js
+++ b/static_src/test/unit/stores/service_plan_store.spec.js
@@ -14,8 +14,6 @@ describe('ServicePlanStore', function() {
 
   beforeEach(() => {
     ServicePlanStore._data = Immutable.List();
-    ServicePlanStore._fetching = false;
-    ServicePlanStore._fetched = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -92,25 +90,18 @@ describe('ServicePlanStore', function() {
         }
       }
     ];
-    it('should set fetched to false, fetching to true', function() {
+
+    it('should set loading to true if there are instances', function() {
       serviceActions.receivedInstances(fakeInstances);
-
-      expect(ServicePlanStore.fetching).toEqual(true);
-      expect(ServicePlanStore.fetched).toEqual(false);
-    });
-
-    it('should set waiting on requests to true if there are instances',
-        function() {
-      serviceActions.receivedInstances(fakeInstances);
-
-      expect(ServicePlanStore.waitingOnRequests).toEqual(true);
+      expect(ServicePlanStore.loading).toEqual(true);
     });
 
     it('should emit a change', function() {
       const spy = sandbox.spy(ServicePlanStore, 'emitChange');
       serviceActions.receivedInstances(fakeInstances);
 
-      expect(spy).toHaveBeenCalledOnce();
+      // change will be called once on the event, again from the loading status
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should fetch service plans with each instance plan guid', function() {
@@ -144,13 +135,10 @@ describe('ServicePlanStore', function() {
   });
 
   describe('on services received', function() {
-    it('should set fetching to true, fetched to false', function() {
+    it('should set loading to true', function() {
       const services = [{ guid: '3981f', name: 'adlfskzxcv' }];
-      ServicePlanStore.fetching = false;
       serviceActions.receivedServices(services);
-
-      expect(ServicePlanStore.fetching).toEqual(true);
-      expect(ServicePlanStore.fetched).toEqual(false);
+      expect(ServicePlanStore.loading).toEqual(true);
     });
   });
 
@@ -167,12 +155,9 @@ describe('ServicePlanStore', function() {
       expect(arg).toEqual(expectedServiceGuid);
     });
 
-    it('should set fetching to true, fetched to false', function() {
-      ServicePlanStore.fetching = false;
+    it('should set loading to true', function() {
       serviceActions.fetchAllPlans('zxncvz8xcvhn32');
-
-      expect(ServicePlanStore.fetching).toEqual(true);
-      expect(ServicePlanStore.fetched).toEqual(false);
+      expect(ServicePlanStore.loading).toEqual(true);
     });
   });
 
@@ -225,15 +210,6 @@ describe('ServicePlanStore', function() {
 
       expect(spy).not.toHaveBeenCalled();
       expect(ServicePlanStore.getAll().length).toEqual(1);
-    });
-
-    it('should set fetching to false, fetched to true', function() {
-      ServicePlanStore.fetching = true;
-      ServicePlanStore.waitingOnRequests = false;
-      serviceActions.receivedPlans([{ guid: 'adfklj' }]);
-
-      expect(ServicePlanStore.fetching).toEqual(false);
-      expect(ServicePlanStore.fetched).toEqual(true);
     });
   });
 });

--- a/static_src/test/unit/stores/service_store.spec.js
+++ b/static_src/test/unit/stores/service_store.spec.js
@@ -14,8 +14,6 @@ describe('ServiceStore', function() {
 
   beforeEach(() => {
     ServiceStore._data = [];
-    ServiceStore._fetched = false;
-    ServiceStore._fetching = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -30,13 +28,10 @@ describe('ServiceStore', function() {
   });
 
   describe('on services fetch', function() {
-    it('should set fetching to true, fetched to false', function() {
-      ServiceStore.fetching = false;
-
+    it('should set loading to true', function() {
       serviceActions.fetchAllServices('zxncvz8xcvhn32');
 
-      expect(ServiceStore.fetching).toEqual(true);
-      expect(ServiceStore.fetched).toEqual(false);
+      expect(ServiceStore.loading).toEqual(true);
     });
 
     it('should call the cf api for all services belonging to the org', function() {
@@ -52,17 +47,6 @@ describe('ServiceStore', function() {
   });
 
   describe('on services received', function() {
-    it('should set fetching to false, fetched to true', function() {
-      let testRes = [{ guid: '3981f', name: 'adlfskzxcv' }];
-      ServiceStore.fetching = true;
-      ServiceStore.fetched = false;
-
-      serviceActions.receivedServices(testRes);
-
-      expect(ServiceStore.fetching).toEqual(false);
-      expect(ServiceStore.fetched).toEqual(true);
-    });
-
     it('should merge in services to current data', function() {
       const sharedGuid = 'adxvcbxv';
       const expected = [

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -73,20 +73,6 @@ describe('SpaceStore', function() {
     });
   });
 
-  describe('on space actions space received', function() {
-    it('should change fetching to false fetched to true', function () {
-      let space = { guid: 'testSpaceGuid' };
-
-      SpaceStore.fetching = true;
-      SpaceStore._data = Immutable.fromJS([space]);
-
-      spaceActions.receivedSpace(space);
-
-      expect(SpaceStore.fetching).toEqual(false);
-      expect(SpaceStore.fetched).toEqual(true);
-    });
-  });
-
   describe('on space actions all spaces received', function() {
     it('should call mergeMany with spaces from action', function () {
       const spy = sandbox.spy(SpaceStore, 'mergeMany');
@@ -97,17 +83,6 @@ describe('SpaceStore', function() {
 
       expect(spy).toHaveBeenCalledOnce();
       expect(spy.getCall(0).args[1]).toEqual(spaces);
-    });
-
-    it('should set fetching to false and fetched to true', function() {
-      const spaces = [{ guid: 'fake-guid-one' }];
-      SpaceStore.fetching = true;
-      SpaceStore.fetched = false;
-
-      spaceActions.receivedSpaces(spaces);
-
-      expect(SpaceStore.fetching).toEqual(false);
-      expect(SpaceStore.fetched).toEqual(true);
     });
 
     it('should emit a change event', function() {

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -15,8 +15,6 @@ describe('UserStore', function() {
   beforeEach(() => {
     UserStore._data = Immutable.List();
     UserStore._currentUserGuid = null;
-    UserStore._fetching = false;
-    UserStore._fetched = false;
     sandbox = sinon.sandbox.create();
   });
 
@@ -51,17 +49,15 @@ describe('UserStore', function() {
       expect(arg).toEqual(expectedGuid);
     });
 
-    it('should set fetching to true and fetched to false', function() {
+    it('should set loading', function() {
       const expectedGuid = 'axckzvjxcov';
-      UserStore._fetched = true;
 
       AppDispatcher.handleViewAction({
         type: userActionTypes.SPACE_USERS_FETCH,
         spaceGuid: expectedGuid
       });
 
-      expect(UserStore.fetching).toEqual(true);
-      expect(UserStore.fetched).toEqual(false);
+      expect(UserStore.loading).toEqual(true);
     });
   });
 
@@ -82,16 +78,13 @@ describe('UserStore', function() {
   });
 
   describe('on org user roles fetch', function() {
-    it('should set fetching to true and fetched to false', function() {
-      UserStore._fetched = true;
-
+    it('should set loading to true', function() {
       AppDispatcher.handleViewAction({
         type: userActionTypes.ORG_USER_ROLES_FETCH,
         orgGuid: 'axckzvjxcov'
       });
 
-      expect(UserStore.fetching).toEqual(true);
-      expect(UserStore.fetched).toEqual(false);
+      expect(UserStore.loading).toEqual(true);
     });
 
     it('should fetch org user roles through api', function() {
@@ -110,33 +103,6 @@ describe('UserStore', function() {
   });
 
   describe('on space or org users received', function() {
-    it('should set fetching to false, fetched to true on SPACE_USERS_RECEIVED',
-        function() {
-      UserStore.fetching = true;
-
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.SPACE_USERS_RECEIVED,
-        users: [{ guid: 'adsfa' }]
-      });
-
-      expect(UserStore.fetching).toEqual(false);
-      expect(UserStore.fetched).toEqual(true);
-    });
-
-    it('should set fetching to false, fetched to true on ORG_USERS_RECEIVED',
-        function() {
-      UserStore.fetching = true;
-      UserStore.fetched = false;
-
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.ORG_USERS_RECEIVED,
-        users: []
-      });
-
-      expect(UserStore.fetching).toEqual(false);
-      expect(UserStore.fetched).toEqual(true);
-    });
-
     it('should merge and update new users with existing users in data',
         function() {
       var sharedGuid = 'wpqoifesadkzcvn';
@@ -186,20 +152,6 @@ describe('UserStore', function() {
       });
 
       expect(spy).toHaveBeenCalledOnce();
-    });
-
-    it('should set fetching to false, fetched to true on ORG_USERS_RECEIVED',
-        function() {
-      UserStore.fetching = true;
-      UserStore.fetched = false;
-
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
-        orgUserRoles: [{ guid: 'adsfa' }]
-      });
-
-      expect(UserStore.fetching).toEqual(false);
-      expect(UserStore.fetched).toEqual(true);
     });
 
     it('should merge and update new users with existing users in data',

--- a/static_src/test/unit/util/loading_status.spec.js
+++ b/static_src/test/unit/util/loading_status.spec.js
@@ -91,13 +91,65 @@ describe('LoadingStatus', function () {
       });
     });
 
-    it('only counds a promise once', function (done) {
+    it('only counts a promise once', function (done) {
       first.resolve();
       first.resolve();
 
       setImmediate(function() {
         expect(loadingStatus.isLoaded).toBe(false);
         done();
+      });
+    });
+  });
+
+  describe('events', function () {
+    let request, promise, loading, loaded;
+
+    beforeEach(function (done) {
+      loadingStatus = new LoadingStatus();
+      promise = new Promise(function (resolve, reject) {
+        request = {resolve, reject};
+      });
+
+      loading = sinon.spy();
+      loaded = sinon.spy();
+
+      loadingStatus.on('loading', loading);
+      loadingStatus.on('loaded', loaded);
+
+      loadingStatus.load([promise]);
+      setImmediate(done);
+    });
+
+    describe('load function', function () {
+      it('emits `loading`', function () {
+        expect(loading).toHaveBeenCalledOnce();
+      });
+
+      it('has not emitted `loaded`', function () {
+        expect(loaded).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the request resolves', function () {
+      beforeEach(function (done) {
+        promise.then(done);
+        request.resolve();
+      });
+
+      it('emits `loaded`', function () {
+        expect(loaded).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe('when the request is rejected', function () {
+      beforeEach(function (done) {
+        promise.catch(() => done());
+        request.reject();
+      });
+
+      it('emits `loaded`', function () {
+        expect(loaded).toHaveBeenCalledOnce();
       });
     });
   });

--- a/static_src/test/unit/util/loading_status.spec.js
+++ b/static_src/test/unit/util/loading_status.spec.js
@@ -103,53 +103,77 @@ describe('LoadingStatus', function () {
   });
 
   describe('events', function () {
-    let request, promise, loading, loaded;
+    describe('with no requests', function () {
+      let loading, loaded;
 
-    beforeEach(function (done) {
-      loadingStatus = new LoadingStatus();
-      promise = new Promise(function (resolve, reject) {
-        request = {resolve, reject};
+      beforeEach(function (done) {
+        loadingStatus = new LoadingStatus();
+
+        loading = sinon.spy();
+        loaded = sinon.spy();
+
+        loadingStatus.on('loading', loading);
+        loadingStatus.on('loaded', loaded);
+
+        loadingStatus.load([]);
+        setImmediate(done);
       });
 
-      loading = sinon.spy();
-      loaded = sinon.spy();
-
-      loadingStatus.on('loading', loading);
-      loadingStatus.on('loaded', loaded);
-
-      loadingStatus.load([promise]);
-      setImmediate(done);
-    });
-
-    describe('load function', function () {
-      it('emits `loading`', function () {
-        expect(loading).toHaveBeenCalledOnce();
-      });
-
-      it('has not emitted `loaded`', function () {
+      it('does not emit any events', function () {
+        expect(loading).not.toHaveBeenCalled();
         expect(loaded).not.toHaveBeenCalled();
       });
     });
 
-    describe('when the request resolves', function () {
+    describe('with a request', function () {
+      let request, promise, loading, loaded;
+
       beforeEach(function (done) {
-        promise.then(done);
-        request.resolve();
+        loadingStatus = new LoadingStatus();
+        promise = new Promise(function (resolve, reject) {
+          request = {resolve, reject};
+        });
+
+        loading = sinon.spy();
+        loaded = sinon.spy();
+
+        loadingStatus.on('loading', loading);
+        loadingStatus.on('loaded', loaded);
+
+        loadingStatus.load([promise]);
+        setImmediate(done);
       });
 
-      it('emits `loaded`', function () {
-        expect(loaded).toHaveBeenCalledOnce();
-      });
-    });
+      describe('load function', function () {
+        it('emits `loading`', function () {
+          expect(loading).toHaveBeenCalledOnce();
+        });
 
-    describe('when the request is rejected', function () {
-      beforeEach(function (done) {
-        promise.catch(() => done());
-        request.reject();
+        it('has not emitted `loaded`', function () {
+          expect(loaded).not.toHaveBeenCalled();
+        });
       });
 
-      it('emits `loaded`', function () {
-        expect(loaded).toHaveBeenCalledOnce();
+      describe('when the request resolves', function () {
+        beforeEach(function (done) {
+          promise.then(done);
+          request.resolve();
+        });
+
+        it('emits `loaded`', function () {
+          expect(loaded).toHaveBeenCalledOnce();
+        });
+      });
+
+      describe('when the request is rejected', function () {
+        beforeEach(function (done) {
+          promise.catch(() => done());
+          request.reject();
+        });
+
+        it('emits `loaded`', function () {
+          expect(loaded).toHaveBeenCalledOnce();
+        });
       });
     });
   });

--- a/static_src/test/unit/util/loading_status.spec.js
+++ b/static_src/test/unit/util/loading_status.spec.js
@@ -1,0 +1,160 @@
+
+import '../../global_setup.js';
+
+import LoadingStatus from '../../../util/loading_status';
+
+describe('LoadingStatus', function () {
+  let loadingStatus;
+
+  describe('initial state', function () {
+    beforeEach(function () {
+      loadingStatus = new LoadingStatus();
+    });
+
+    it('is not initialized', function () {
+      expect(loadingStatus._initialized).toBe(false);
+    });
+
+    it('has zero requests in flight', function () {
+      expect(loadingStatus._requests).toBe(0);
+    });
+
+    it('is not loaded', function () {
+      expect(loadingStatus.isLoaded).toBe(false);
+    });
+  });
+
+  describe('given some requests', function () {
+    let first, second;
+
+    beforeEach(function () {
+      loadingStatus = new LoadingStatus();
+
+      const promises = [
+        new Promise(function(resolve, reject) {
+          // Save for later
+          first = {resolve, reject};
+        }),
+        new Promise(function(resolve, reject) {
+          // Save for later
+          second = {resolve, reject};
+        })
+      ];
+
+      loadingStatus.load(promises);
+    });
+
+    it('is initialized', function () {
+      expect(loadingStatus._initialized).toBe(true);
+    });
+
+    it('has two requests in flight', function () {
+      expect(loadingStatus._requests).toBe(2);
+    });
+
+    it('is not loaded after the first promise', function (done) {
+      first.resolve();
+
+      setImmediate(function () {
+        expect(loadingStatus.isLoaded).toBe(false);
+        done();
+      });
+    });
+
+    it('is loaded after the second promise', function (done) {
+      first.resolve();
+      second.resolve();
+
+      setImmediate(function () {
+        expect(loadingStatus.isLoaded).toBe(true);
+        done();
+      });
+    });
+
+    it('is independent of order', function (done) {
+      second.resolve();
+      first.resolve();
+
+      setImmediate(function () {
+        expect(loadingStatus.isLoaded).toBe(true);
+        done();
+      });
+    });
+
+    it('is loaded even on failed requests', function (done) {
+      first.resolve();
+      second.reject();
+
+      setImmediate(function () {
+        expect(loadingStatus.isLoaded).toBe(true);
+        done();
+      });
+    });
+
+    it('only counds a promise once', function (done) {
+      first.resolve();
+      first.resolve();
+
+      setImmediate(function() {
+        expect(loadingStatus.isLoaded).toBe(false);
+        done();
+      });
+    });
+  });
+
+  describe('chaining promises', function () {
+    let request, promise;
+
+    beforeEach(function () {
+
+      loadingStatus = new LoadingStatus();
+      promise = new Promise(function (resolve, reject) {
+        request = {resolve, reject};
+      });
+
+      loadingStatus.load([promise]);
+    });
+
+    describe('given request is resolved', function () {
+      let sentinel, fulfillment;
+
+      beforeEach(function (done) {
+        sentinel = {};
+        fulfillment = sinon.spy();
+        promise.then(fulfillment);
+        promise.then(() => done());
+
+        request.resolve(sentinel);
+      });
+
+      it('is loaded', function () {
+        expect(loadingStatus.isLoaded).toBe(true);
+      });
+
+      it('calls fulfillment with result of the request', function () {
+        expect(fulfillment).toHaveBeenCalledWithExactly(sentinel);
+      });
+    });
+
+    describe('given request is rejected', function () {
+      let sentinel, rejection;
+
+      beforeEach(function (done) {
+        sentinel = {};
+        rejection = sinon.spy();
+        promise.catch(rejection);
+        promise.catch(() => done());
+
+        request.reject(sentinel);
+      });
+
+      it('is loaded', function () {
+        expect(loadingStatus.isLoaded).toBe(true);
+      });
+
+      it('calls rejection with result of the request', function () {
+        expect(rejection).toHaveBeenCalledWithExactly(sentinel);
+      });
+    });
+  });
+});

--- a/static_src/util/loading_status.js
+++ b/static_src/util/loading_status.js
@@ -38,7 +38,9 @@ class LoadingStatus extends EventEmitter {
     });
 
     this._initialized = true;
-    this.emit('loading');
+    if (promises.length) {
+      this.emit('loading');
+    }
   }
 }
 

--- a/static_src/util/loading_status.js
+++ b/static_src/util/loading_status.js
@@ -1,0 +1,33 @@
+// Use a semaphore to track requests in flight
+// https://en.wikipedia.org/wiki/Semaphore_(programming)
+class LoadingStatus {
+  constructor() {
+    this._requests = 0; // Our semaphore
+    this._initialized = false; // Initialize on first load
+  }
+
+  get isLoaded() {
+    // We are loaded when we are initialized and no requests are in flight
+    return this._initialized && !this._requests;
+  }
+
+  _addRequest(promise) {
+    // Increment the semaphore, requests in flight
+    this._requests++;
+
+    // On complete, decrement the semaphore
+    const onComplete = () => this._requests--;
+    promise.then(onComplete, onComplete);
+  }
+
+  load(promises) {
+    promises.forEach(promise => {
+      this._addRequest(promise);
+    });
+
+    this._initialized = true;
+  }
+}
+
+
+export default LoadingStatus;

--- a/static_src/util/loading_status.js
+++ b/static_src/util/loading_status.js
@@ -1,7 +1,10 @@
 // Use a semaphore to track requests in flight
 // https://en.wikipedia.org/wiki/Semaphore_(programming)
-class LoadingStatus {
+import { EventEmitter } from 'events';
+
+class LoadingStatus extends EventEmitter {
   constructor() {
+    super();
     this._requests = 0; // Our semaphore
     this._initialized = false; // Initialize on first load
   }
@@ -16,7 +19,16 @@ class LoadingStatus {
     this._requests++;
 
     // On complete, decrement the semaphore
-    const onComplete = () => this._requests--;
+    const onComplete = (result) => {
+      this._requests--;
+
+      if (this.isLoaded) {
+        this.emit('loaded');
+      }
+
+      return result;
+    };
+
     promise.then(onComplete, onComplete);
   }
 
@@ -26,6 +38,7 @@ class LoadingStatus {
     });
 
     this._initialized = true;
+    this.emit('loading');
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/18F/cg-dashboard/issues/630

This introduces a semaphore for tracking in-flight requests built into the base store. If you want the requests tracked, use `this.load()` in your store. As requests are made, we increment a counter. When those requests resolve (or error), we decrement the count.

We combine `fetched` and `fetching` by keeping track of initialization. The loading status is considered loading until the first batch of requests are made _and_ completed.

### Future improvements

There's still some room for improvement. The `ActivityStore` is tracking two datasets to determine loading status. It can be moved to this load strategy, but requires some extra work.

This also introduces some extra change events but I believe react/redux is smart enough to handle that without much performance impact? The reason for this is that `LoadingStatus` hooks into the requests via promises and these happen async outside of the receive action, within the promise resolve.