### PR TITLE
Set HttpOnly & Secure flags on session cookies; Remove Session Key from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ In each space that you plan on deploying, you need to create a `user-provided-se
 Run:
 ```
 # For applications without New Relic monitoring
-cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret"}'
+cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret", "SESSION_KEY": "a-really-long-secure-value"}'
 
 # For applications with New Relic monitoring
-cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret","CONSOLE_NEW_RELIC_LICENSE":"your-new-relic-license"}'
+cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret","CONSOLE_NEW_RELIC_LICENSE":"your-new-relic-license", "SESSION_KEY": "a-really-long-secure-value"}'
 ```
 
 ### Create a Client with UAAC

--- a/env.sample
+++ b/env.sample
@@ -29,3 +29,6 @@ export CONSOLE_LOG_URL=https://loggregator.cloud.gov
 # <optional> The absolute path to your `cg-style` repo. If set, will use a local
 # copy of `cloudgov-style` to build the front end application.
 # export CG_STYLE_PATH=
+
+# <optional> If set to `true` or `1`, will set the `secure` flag on session cookies
+# export SECURE_COOKIES=true

--- a/helpers/env_vars.go
+++ b/helpers/env_vars.go
@@ -29,6 +29,10 @@ var (
 	BuildInfoEnvVar = "BUILD_INFO"
 	// NewRelicLicenseEnvVar is the New Relic License key so it can collect data.
 	NewRelicLicenseEnvVar = "CONSOLE_NEW_RELIC_LICENSE"
+	// SecureCookiesEnvVar is set to true or 1, then set the Secure flag be set on session coookies
+	SecureCookiesEnvVar = "SECURE_COOKIES"
+	// SessionKeyEnvVar is the secret key used to protect session data
+	SessionKeyEnvVar = "SESSION_KEY"
 )
 
 // EnvVars holds all the environment variable values that a non-test server should have.
@@ -43,4 +47,6 @@ type EnvVars struct {
 	PProfEnabled    string
 	BuildInfo       string
 	NewRelicLicense string
+	SecureCookies   string
+	SessionKey      string
 }

--- a/manifests/govcloud/manifest-region-base.yml
+++ b/manifests/govcloud/manifest-region-base.yml
@@ -5,3 +5,4 @@ env:
   CONSOLE_UAA_URL: https://uaa.fr.cloud.gov/
   CONSOLE_API_URL: https://api.fr.cloud.gov/
   CONSOLE_LOG_URL: https://loggregator.fr.cloud.gov/
+  SECURE_COOKIES: true

--- a/server.go
+++ b/server.go
@@ -31,6 +31,12 @@ func loadEnvVars() helpers.EnvVars {
 	envVars.PProfEnabled = os.Getenv(helpers.PProfEnabledEnvVar)
 	envVars.BuildInfo = os.Getenv(helpers.BuildInfoEnvVar)
 	envVars.NewRelicLicense = os.Getenv(helpers.NewRelicLicenseEnvVar)
+	envVars.SecureCookies = os.Getenv(helpers.SecureCookiesEnvVar)
+	envVars.SessionKey = os.Getenv(helpers.SessionKeyEnvVar)
+	// set a default session key if one isn't provided
+	if envVars.SessionKey == "" {
+		envVars.SessionKey = "some key"
+	}
 	return envVars
 }
 
@@ -47,6 +53,8 @@ func replaceEnvVar(envVars *helpers.EnvVars, envVar string, value interface{}) {
 			envVars.ClientSecret = stringValue
 		case helpers.NewRelicLicenseEnvVar:
 			envVars.NewRelicLicense = stringValue
+		case helpers.SessionKeyEnvVar:
+			envVars.SessionKey = stringValue
 		}
 	}
 }
@@ -74,6 +82,11 @@ func loadUPSVars(envVars *helpers.EnvVars) {
 			fmt.Println("Replacing " + helpers.NewRelicLicenseEnvVar)
 			replaceEnvVar(envVars, helpers.NewRelicLicenseEnvVar, newRelic)
 		}
+		if sessionKey, found := cfUPS.Credentials[helpers.SessionKeyEnvVar]; found {
+			fmt.Println("Replacing " + helpers.SessionKeyEnvVar)
+			replaceEnvVar(envVars, helpers.SessionKeyEnvVar, sessionKey)
+		}
+
 	} else {
 		fmt.Println("CF Env error: " + err.Error())
 	}


### PR DESCRIPTION
[FedRamp requires us](https://github.com/18F/cg-produc/issues/470) to set cookies with the [secure](https://github.com/18F/cg-product/issues/443) and [HttpOnly](https://github.com/18F/cg-product/issues/442) flags where appropriate.

This PR, sets the `HttpOnly` flag to true for all session cookies, and sets the `secure` flag to true based on the value of the `SECURE_COOKIES` environment variable.

While I was looking at the session handling code I noticed the key for securing sessions is not stored in an environment variable, so this PR also includes a change to move that secret into the `SESSION_KEY` envvar / user-provided-service.


cc: https://github.com/18F/cg-product/issues/470