### PR TITLE
Bug jsx build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ machine:
     CF_ORGANIZATION: "cf"
     CF_API_GC: "https://api.fr.cloud.gov"
     CF_ORGANIZATION_GC: "cloud-gov"
-    NODE_ENV: "prod"
   post:
     - cd cg-dashboard && nvm install && nvm use && nvm alias default $(nvm current)
     - mkdir -p download
@@ -39,7 +38,7 @@ test:
     - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
   override:
     - cd $WS && ./codecheck.sh -u
-    - cd $WS && npm test
+    - NODE_ENV="test" cd $WS && npm test
 
 deployment:
   deploy:
@@ -52,7 +51,10 @@ deployment:
   production:
     tag: /[0-9]+(\.[0-9]+)*/
     owner: 18F
+    environment:
+      NODE_ENV: "prod"
     commands:
+      - cd $WS && npm run build
       - cd $WS && pip install --user ruamel.yaml
       - cd $WS && export BUILD_INFO=build::$CIRCLE_BRANCH::$(date -u "+%Y-%m-%d-%H-%M-%S")::$CIRCLE_BUILD_NUM::$(deploy/npm-version.sh) && python deploy/vars-to-manifest.py
       - cd $WS && chmod a+x deploy/circle_deploy.sh && deploy/circle_deploy.sh

--- a/circle.yml
+++ b/circle.yml
@@ -32,15 +32,15 @@ dependencies:
     - cd $WS && go build
     - cd $WS && npm run build
 test:
-  environment:
-    NODE_ENV: "test"
   pre:
     - go get github.com/axw/gocov/gocov
     - go get github.com/mattn/goveralls
     - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
   override:
     - cd $WS && ./codecheck.sh -u
-    - cd $WS && npm test
+    - cd $WS && npm test:
+      environment:
+        NODE_ENV: "test"
 
 deployment:
   deploy:
@@ -53,10 +53,10 @@ deployment:
   production:
     tag: /[0-9]+(\.[0-9]+)*/
     owner: 18F
-    environment:
-      NODE_ENV: "prod"
     commands:
-      - cd $WS && npm run build
+      - cd $WS && npm run build:
+        environment:
+          NODE_ENV: "test"
       - cd $WS && pip install --user ruamel.yaml
       - cd $WS && export BUILD_INFO=build::$CIRCLE_BRANCH::$(date -u "+%Y-%m-%d-%H-%M-%S")::$CIRCLE_BUILD_NUM::$(deploy/npm-version.sh) && python deploy/vars-to-manifest.py
       - cd $WS && chmod a+x deploy/circle_deploy.sh && deploy/circle_deploy.sh

--- a/circle.yml
+++ b/circle.yml
@@ -38,9 +38,7 @@ test:
     - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
   override:
     - cd $WS && ./codecheck.sh -u
-    - cd $WS && npm test:
-        environment:
-          NODE_ENV: "test"
+    - cd $WS && NODE_ENV="test" npm test
 
 deployment:
   deploy:
@@ -54,9 +52,7 @@ deployment:
     tag: /[0-9]+(\.[0-9]+)*/
     owner: 18F
     commands:
-      - cd $WS && npm run build:
-          environment:
-            NODE_ENV: "test"
+      - cd $WS && NODE_ENV="prod" npm run build
       - cd $WS && pip install --user ruamel.yaml
       - cd $WS && export BUILD_INFO=build::$CIRCLE_BRANCH::$(date -u "+%Y-%m-%d-%H-%M-%S")::$CIRCLE_BUILD_NUM::$(deploy/npm-version.sh) && python deploy/vars-to-manifest.py
       - cd $WS && chmod a+x deploy/circle_deploy.sh && deploy/circle_deploy.sh

--- a/circle.yml
+++ b/circle.yml
@@ -32,13 +32,15 @@ dependencies:
     - cd $WS && go build
     - cd $WS && npm run build
 test:
+  environment:
+    NODE_ENV: "test"
   pre:
     - go get github.com/axw/gocov/gocov
     - go get github.com/mattn/goveralls
     - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
   override:
     - cd $WS && ./codecheck.sh -u
-    - NODE_ENV="test" cd $WS && npm test
+    - cd $WS && npm test
 
 deployment:
   deploy:

--- a/circle.yml
+++ b/circle.yml
@@ -39,8 +39,8 @@ test:
   override:
     - cd $WS && ./codecheck.sh -u
     - cd $WS && npm test:
-      environment:
-        NODE_ENV: "test"
+        environment:
+          NODE_ENV: "test"
 
 deployment:
   deploy:
@@ -55,8 +55,8 @@ deployment:
     owner: 18F
     commands:
       - cd $WS && npm run build:
-        environment:
-          NODE_ENV: "test"
+          environment:
+            NODE_ENV: "test"
       - cd $WS && pip install --user ruamel.yaml
       - cd $WS && export BUILD_INFO=build::$CIRCLE_BRANCH::$(date -u "+%Y-%m-%d-%H-%M-%S")::$CIRCLE_BUILD_NUM::$(deploy/npm-version.sh) && python deploy/vars-to-manifest.py
       - cd $WS && chmod a+x deploy/circle_deploy.sh && deploy/circle_deploy.sh

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,8 +77,7 @@ const config = {
   },
 
   plugins: [
-    new ExtractTextPlugin('style.css', { allChunks: true }),
-    new WebpackKarmaWarningsPlugin()
+    new ExtractTextPlugin('style.css', { allChunks: true })
   ],
 
   publicPath: './static'
@@ -87,6 +86,7 @@ const config = {
 if (PRODUCTION) {
   config.plugins.push(new webpack.optimize.DedupePlugin());
   config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+  config.plugins.push(new WebpackKarmaWarningsPlugin());
 }
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const WebpackKarmaWarningsPlugin = require(
   './static_src/test/webpack-karma-warnings-plugin.js');
 
 const PRODUCTION = (process.env.NODE_ENV === 'prod');
+const TEST = (process.env.NODE_ENV === 'test');
 const CG_STYLE_PATH = process.env.CG_STYLE_PATH;
 
 const srcDir = './static_src';
@@ -82,6 +83,10 @@ const config = {
 
   publicPath: './static'
 };
+
+if (TEST) {
+  config.plugins.push(new WebpackKarmaWarningsPlugin());
+}
 
 if (PRODUCTION) {
   config.plugins.push(new webpack.optimize.DedupePlugin());


### PR DESCRIPTION
The karma warnings plugin is great at ensuring syntax errors in tests
don't stop the test file from being tested at all, but creates really
bad error messages during the build. This fix would make that plugin
only run on CI, when we really need to know if tests aren't being run
due to syntax errors.

Ref #743