### PR TITLE
Change action to use type property

### DIFF
--- a/static_src/components/action.jsx
+++ b/static_src/components/action.jsx
@@ -90,7 +90,7 @@ export default class Action extends React.Component {
           aria-label={ this.props.label }
           onClick={ (ev) => this.props.clickHandler(ev) }
           disabled={this.props.disabled}
-          type="button"
+          type={ this.props.type }
         >
           { this.props.children }
         </button>


### PR DESCRIPTION
Which fixes form submits because they are not of type "submit" rather
then type "button".