### PR TITLE
Minify assets in production.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ machine:
     CF_ORGANIZATION: "cf"
     CF_API_GC: "https://api.fr.cloud.gov"
     CF_ORGANIZATION_GC: "cloud-gov"
+    NODE_ENV: "prod"
   post:
     - cd cg-dashboard && nvm install && nvm use && nvm alias default $(nvm current)
     - mkdir -p download

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-
 const path = require('path');
 const webpack = require('webpack');
 


### PR DESCRIPTION
Assets currently aren't minified on dashboard.fr.cloud.gov. Minification shrinks the javascript bundle from over 6mb to about 1mb. This patch tells circle to minify assets on deploy.