### PR TITLE
Use cached buildpack.

### DIFF
--- a/manifests/manifest-base.yml
+++ b/manifests/manifest-base.yml
@@ -1,5 +1,5 @@
 ---
-buildpack: https://github.com/cloudfoundry/go-buildpack.git#v1.7.8
+buildpack: go_buildpack
 memory: 256M
 services:
   - deck-ups


### PR DESCRIPTION
So that we don't have to download the go buildpack on each deploy, and so that we get updates from the platform for free.