### PR TITLE
Set random oauth state and verify on callback.

### DIFF
--- a/controllers/secure_test.go
+++ b/controllers/secure_test.go
@@ -48,6 +48,9 @@ func TestOAuth(t *testing.T) {
 			TokenURL: "http://tokenURL.com/oauth/token",
 		},
 	}
+	mockSettings.StateGenerator = func() (string, error) {
+		return "state", nil
+	}
 
 	for _, test := range oauthTests {
 		// Initialize a new session store.

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,11 +1,13 @@
 package helpers
 
 import (
-	"golang.org/x/oauth2"
-
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 // TimeoutConstant is a constant which holds how long any incoming request should wait until we timeout.
@@ -52,4 +54,25 @@ func GetValidToken(req *http.Request, settings *Settings) *oauth2.Token {
 
 	// If couldn't find token or if it's expired, return nil
 	return nil
+}
+
+// GenerateRandomBytes returns securely generated random bytes.
+// Borrowed from https://elithrar.github.io/article/generating-secure-random-numbers-crypto-rand/
+func GenerateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// GenerateRandomString returns a URL-safe, base64 encoded
+// securely generated random string.
+// Borrowed from https://elithrar.github.io/article/generating-secure-random-numbers-crypto-rand/
+func GenerateRandomString(s int) (string, error) {
+	b, err := GenerateRandomBytes(s)
+	return base64.URLEncoding.EncodeToString(b), err
 }

--- a/helpers/settings.go
+++ b/helpers/settings.go
@@ -22,6 +22,8 @@ type Settings struct {
 	Sessions sessions.Store
 	// context.Context var from golang.org/x/net/context to make token Client work
 	TokenContext context.Context
+	// Generate secure random state
+	StateGenerator func() (string, error)
 	// UAA API
 	UaaURL string
 	// Log API
@@ -78,6 +80,10 @@ func (s *Settings) InitSettings(envVars EnvVars) error {
 			AuthURL:  envVars.LoginURL + "/oauth/authorize",
 			TokenURL: envVars.UAAURL + "/oauth/token",
 		},
+	}
+
+	s.StateGenerator = func() (string, error) {
+		return GenerateRandomString(32)
 	}
 
 	// Initialize Sessions.


### PR DESCRIPTION
So that oauth state isn't hard-coded to "state" and is verified on callback. See https://www.cloudfoundry.org/how-to-integrate-an-application-with-cloud-foundry-using-oauth2-2/, "Responsibilities of a Client Application".