### PR TITLE
Space quicklook UI on the overview page

### DIFF
--- a/static_src/actions/org_actions.js
+++ b/static_src/actions/org_actions.js
@@ -59,6 +59,12 @@ export default {
       type: orgActionTypes.ORG_TOGGLE_SPACE_MENU,
       orgGuid
     });
-  }
+  },
 
+  toggleQuicklook(orgGuid) {
+    AppDispatcher.handleUIAction({
+      type: orgActionTypes.ORG_TOGGLE_QUICKLOOK,
+      orgGuid
+    });
+  }
 };

--- a/static_src/actions/space_actions.js
+++ b/static_src/actions/space_actions.js
@@ -21,6 +21,13 @@ export default {
     });
   },
 
+  fetchAllForOrg(orgGuid) {
+    AppDispatcher.handleViewAction({
+      type: spaceActionTypes.SPACES_FOR_ORG_FETCH,
+      orgGuid
+    });
+  },
+
   receivedSpace(space) {
     AppDispatcher.handleServerAction({
       type: spaceActionTypes.SPACE_RECEIVED,

--- a/static_src/components/app_count_status.jsx
+++ b/static_src/components/app_count_status.jsx
@@ -54,7 +54,11 @@ export default class AppCountStatus extends React.Component {
       status = this.worstStatus(props.apps);
     }
 
-    return <CountStatus count={ props.appCount } name="apps" status={ status } />;
+    return (
+      <CountStatus count={ props.appCount } name="apps"
+        status={ status } iconType="app"
+      />
+    );
   }
 }
 

--- a/static_src/components/count_status.jsx
+++ b/static_src/components/count_status.jsx
@@ -5,6 +5,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import createStyler from '../util/create_styler';
 import { appStates } from '../constants.js';
+import EntityIcon from './entity_icon.jsx';
 
 const ICON_TYPES = [
   'space',
@@ -37,7 +38,12 @@ export default class CountStatus extends React.Component {
 
     return (
       <span className={ this.styler('count_status', statusClass) }>
-        <strong>{ props.count }</strong> { props.name }
+        <span className={ this.styler('count_status-icon') }>
+          <EntityIcon entity={ props.iconType } state={ props.status } />
+        </span>
+        <span className={ this.styler('count_status-text') }>
+          <strong>{ props.count }</strong> { props.name }
+        </span>
       </span>
     );
   }

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -1,0 +1,42 @@
+
+import React from 'react';
+
+import Icon from './icon.jsx';
+import { appStates } from '../constants.js';
+import createStyler from '../util/create_styler';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+
+const ENTITIES = ['app', 'space', 'org'];
+
+const STATE_MAP = {
+  [appStates.running]: 'ok',
+  [appStates.started]: 'ok',
+  [appStates.stopped]: 'inactive',
+  [appStates.crashed]: 'error'
+};
+
+const propTypes = {
+  entity: React.PropTypes.oneOf(ENTITIES).isRequired,
+  state: React.PropTypes.oneOf(Object.values(appStates))
+};
+
+const defaultProps = {
+  state: appStates.default
+};
+
+export default class EntityIcon extends React.Component {
+  constructor(props) {
+    super(props);
+    this.props = props;
+    this.styler = createStyler(style);
+  }
+
+  render() {
+    const stateClass = STATE_MAP[this.props.state];
+
+    return <Icon name={ this.props.entity } styleType={ stateClass } iconType="fill" />;
+  }
+}
+
+EntityIcon.propTypes = propTypes;
+EntityIcon.defaultProps = defaultProps;

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -1,39 +1,58 @@
 
-import classNames from 'classnames';
-import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
+
+import createStyler from '../util/create_styler';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+
+const ICON_TYPES = [
+  'fill',
+  'stroke'
+];
+
+const STYLE_TYPES = [
+  'alt',
+  'ok',
+  'inactive',
+  'error'
+];
+
+const propTypes = {
+  name: React.PropTypes.string.isRequired,
+  styleType: React.PropTypes.oneOf(STYLE_TYPES),
+  iconType: React.PropTypes.oneOf(ICON_TYPES)
+};
+
+const defaultProps = {
+  styleType: 'alt',
+  iconType: 'stroke'
+};
 
 export default class Icon extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
+    this.styler = createStyler(style);
   }
 
   getImagePath(iconName) {
-    var img = require('cloudgov-style/img/cloudgov-sprite.svg');
+    const img = require('cloudgov-style/img/cloudgov-sprite.svg');
     return `assets/${img}#i-${iconName}`;
   }
 
   render() {
-    var iconClasses = classNames(style.icon,
-        style[`icon-${ this.props.styleType }`]);
+    const mainClass = this.props.iconType === 'fill' ? 'icon-fill' : 'icon';
+    const styleClass = `${mainClass}-${this.props.styleType}`;
+    const iconClasses = this.styler(mainClass, styleClass);
 
     return (
-      <div className={ style['icon-container'] }>
-        <svg className={ iconClasses }>
-          <use
-            xlinkHref={ this.getImagePath(this.props.name) }>
-          </use>
-        </svg>
-      </div>
+      <svg className={ iconClasses }>
+        <use
+          xlinkHref={ this.getImagePath(this.props.name) }>
+        </use>
+      </svg>
     );
   }
 }
 
-Icon.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  styleType: React.PropTypes.string
-}
-Icon.defaultProps = {
-  styleType: 'alt'
-}
+Icon.propTypes = propTypes;
+Icon.defaultProps = defaultProps;

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -6,6 +6,7 @@ import createStyler from '../util/create_styler';
 
 import AppCountStatus from './app_count_status.jsx';
 import SpaceCountStatus from './space_count_status.jsx';
+import orgActions from '../actions/org_actions.js';
 
 const propTypes = {
   org: React.PropTypes.object.isRequired,
@@ -21,6 +22,12 @@ export default class OrgQuickLook extends React.Component {
     super(props);
     this.state = {};
     this.styler = createStyler(style);
+
+    this.toggleOrg = this.toggleOrg.bind(this);
+  }
+
+  toggleOrg() {
+    orgActions.toggleQuicklook(this.props.org.guid);
   }
 
   totalAppCount(spaces) {
@@ -43,7 +50,7 @@ export default class OrgQuickLook extends React.Component {
     <div>
       <div className={ this.styler('panel-column') }>
         <h2>
-          <a href={ `/#/org/${props.org.guid}` }>{ props.org.name }</a>
+          <a onClick={ this.toggleOrg } href="#">{ props.org.name }</a>
         </h2>
       </div>
       <div className={ this.styler('panel-column') }>

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -5,6 +5,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 import AppCountStatus from './app_count_status.jsx';
+import EntityIcon from './entity_icon.jsx';
 import SpaceCountStatus from './space_count_status.jsx';
 import orgActions from '../actions/org_actions.js';
 import spaceActions from '../actions/space_actions.js';
@@ -57,6 +58,7 @@ export default class OrgQuickLook extends React.Component {
     <div style={ panelStyle }>
       <div className={ this.styler('panel-column') }>
         <h2 className={ this.styler('sans-s6') }>
+          <EntityIcon entity="org" />
           <a onClick={ this.toggleOrg } href="#">{ props.org.name }</a>
         </h2>
       </div>

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -30,7 +30,9 @@ export default class OrgQuickLook extends React.Component {
 
   toggleOrg(ev) {
     ev.preventDefault();
-    spaceActions.fetchAllForOrg(this.props.org.guid);
+    if (!this.props.org.quicklook_open) {
+      spaceActions.fetchAllForOrg(this.props.org.guid);
+    }
     orgActions.toggleQuicklook(this.props.org.guid);
   }
 

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -17,6 +17,7 @@ const defaultProps = {
   spaces: []
 };
 
+// TODO rename org_quicklook and org_quick_look to remain consistent with store.
 export default class OrgQuickLook extends React.Component {
   constructor(props) {
     super(props);
@@ -26,7 +27,8 @@ export default class OrgQuickLook extends React.Component {
     this.toggleOrg = this.toggleOrg.bind(this);
   }
 
-  toggleOrg() {
+  toggleOrg(ev) {
+    ev.preventDefault();
     orgActions.toggleQuicklook(this.props.org.guid);
   }
 
@@ -45,9 +47,10 @@ export default class OrgQuickLook extends React.Component {
 
   render() {
     const props = this.props;
+    const panelStyle = props.org.quicklook_open ? { marginBottom: '3rem' } : null;
 
     return (
-    <div>
+    <div style={ panelStyle }>
       <div className={ this.styler('panel-column') }>
         <h2>
           <a onClick={ this.toggleOrg } href="#">{ props.org.name }</a>

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -56,7 +56,7 @@ export default class OrgQuickLook extends React.Component {
     return (
     <div style={ panelStyle }>
       <div className={ this.styler('panel-column') }>
-        <h2>
+        <h2 className={ this.styler('sans-s6') }>
           <a onClick={ this.toggleOrg } href="#">{ props.org.name }</a>
         </h2>
       </div>

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -7,6 +7,7 @@ import createStyler from '../util/create_styler';
 import AppCountStatus from './app_count_status.jsx';
 import SpaceCountStatus from './space_count_status.jsx';
 import orgActions from '../actions/org_actions.js';
+import spaceActions from '../actions/space_actions.js';
 
 const propTypes = {
   org: React.PropTypes.object.isRequired,
@@ -29,6 +30,7 @@ export default class OrgQuickLook extends React.Component {
 
   toggleOrg(ev) {
     ev.preventDefault();
+    spaceActions.fetchAllForOrg(this.props.org.guid);
     orgActions.toggleQuicklook(this.props.org.guid);
   }
 

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -47,7 +47,13 @@ export default class OverviewContainer extends React.Component {
   }
 
   orgSpaces(orgGuid) {
-    return this.state.spaces.filter((space) => space.organization_guid === orgGuid);
+    return this.state.spaces.filter((space) => space.organization_guid ===
+      orgGuid);
+  }
+
+  anyOrgsOpen() {
+    return this.state.orgs.reduce((prev, org) => prev || !!org.quicklook_open,
+      false);
   }
 
   render() {
@@ -57,7 +63,7 @@ export default class OverviewContainer extends React.Component {
 
     if (state.empty) {
       content = <h4 className="test-none_message">No organizations</h4>;
-    } else if (!this.state.loading && this.state.orgs.length > 0) {
+    } else if (!state.loading && this.state.orgs.length > 0 || this.anyOrgsOpen()) {
       content = (
       <div className={ this.styler('grid') }>
         <h1>Overview</h1>
@@ -70,7 +76,7 @@ export default class OverviewContainer extends React.Component {
               />
               { org.quicklook_open && this.orgSpaces(org.guid).map((space) =>
                 <SpaceQuicklook space={ space } orgGuid={ org.guid }
-                  key={ space.guid }
+                  key={ space.guid } loading={ state.loading }
                 />
               )}
             </PanelRow>

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -10,6 +10,7 @@ import OrgStore from '../stores/org_store.js';
 import Panel from './panel.jsx';
 import PanelRow from './panel_row.jsx';
 import SpaceStore from '../stores/space_store.js';
+import SpaceQuicklook from './space_quicklook.jsx';
 
 function stateSetter() {
   const orgs = OrgStore.getAll() || [];
@@ -67,6 +68,9 @@ export default class OverviewContainer extends React.Component {
                 org={ org }
                 spaces={ this.orgSpaces(org.guid) }
               />
+              { org.quicklook_open && this.orgSpaces(org.guid).map((space) => {
+                return <SpaceQuicklook space={ space } key={ space.guid } />
+              })}
             </PanelRow>
           )}
         </Panel>

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -69,7 +69,9 @@ export default class OverviewContainer extends React.Component {
                 spaces={ this.orgSpaces(org.guid) }
               />
               { org.quicklook_open && this.orgSpaces(org.guid).map((space) => {
-                return <SpaceQuicklook space={ space } key={ space.guid } />
+                return <SpaceQuicklook space={ space } orgGuid={ org.guid }
+                  key={ space.guid }
+                  />
               })}
             </PanelRow>
           )}

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -68,11 +68,11 @@ export default class OverviewContainer extends React.Component {
                 org={ org }
                 spaces={ this.orgSpaces(org.guid) }
               />
-              { org.quicklook_open && this.orgSpaces(org.guid).map((space) => {
-                return <SpaceQuicklook space={ space } orgGuid={ org.guid }
+              { org.quicklook_open && this.orgSpaces(org.guid).map((space) =>
+                <SpaceQuicklook space={ space } orgGuid={ org.guid }
                   key={ space.guid }
-                  />
-              })}
+                />
+              )}
             </PanelRow>
           )}
         </Panel>

--- a/static_src/components/panel_row.jsx
+++ b/static_src/components/panel_row.jsx
@@ -7,7 +7,8 @@ import createStyler from '../util/create_styler';
 
 const STYLES = [
   'bordered',
-  'boxed'
+  'boxed',
+  ''
 ];
 
 const propTypes = {

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
+import EntityIcon from './entity_icon.jsx';
 import Loading from './loading.jsx';
 import PanelRow from './panel_row.jsx';
 import { appStates } from '../constants.js';
@@ -61,12 +62,16 @@ export default class SpaceQuicklook extends React.Component {
     if (!this.props.loading) {
       content = (
         <PanelRow>
-          <h3><a href={ this.spaceHref() }>{ space.name }</a></h3>
+          <h3>
+            <EntityIcon entity="space" />
+            <a href={ this.spaceHref() }>{ space.name }</a>
+          </h3>
           { space.apps && space.apps.map((app) =>
             <PanelRow key={ app.guid }>
               <span className={ this.styler('panel-column') }>
                 <h3 className={ this.styler('sans-s5') }>
-                  { space.name } / { this.appName(app) }
+                  <EntityIcon entity="app" state={ app.state } />
+                  <span>{ space.name } / { this.appName(app) }</span>
                 </h3>
               </span>
               <span className={ this.styler('panel-column', 'panel-column-less') }>

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -4,11 +4,8 @@ import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
-import AppCountStatus from './app_count_status.jsx';
 import PanelRow from './panel_row.jsx';
-import SpaceCountStatus from './space_count_status.jsx';
 import { appStates } from '../constants.js';
-import orgActions from '../actions/org_actions.js';
 
 const propTypes = {
   space: React.PropTypes.object.isRequired,
@@ -59,8 +56,7 @@ export default class SpaceQuicklook extends React.Component {
     return (
       <PanelRow>
         <h3><a href={ this.spaceHref() }>{ space.name }</a></h3>
-        { space.apps && space.apps.map((app) => {
-          return (
+        { space.apps && space.apps.map((app) =>
           <PanelRow key={ app.guid }>
             <span className={ this.styler('panel-column') }>
               <h3>
@@ -71,8 +67,7 @@ export default class SpaceQuicklook extends React.Component {
               { this.appState(app.state) }
             </span>
           </PanelRow>
-          );
-        })}
+        )}
       </PanelRow>
     );
   }

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -10,7 +10,8 @@ import SpaceCountStatus from './space_count_status.jsx';
 import orgActions from '../actions/org_actions.js';
 
 const propTypes = {
-  space: React.PropTypes.object.isRequired
+  space: React.PropTypes.object.isRequired,
+  orgGuid: React.PropTypes.string.isRequired
 };
 
 const defaultProps = {
@@ -23,19 +24,29 @@ export default class SpaceQuicklook extends React.Component {
     this.styler = createStyler(style);
   }
 
+  spaceHref() {
+    const props = this.props;
+    return `/#/org/${props.orgGuid}/spaces/${props.space.guid}`;
+  }
+
+  appHref(appGuid) {
+    const props = this.props;
+    return `/#/org/${props.orgGuid}/spaces/${props.space.guid}/apps/${appGuid}`;
+  }
 
   render() {
     const space = this.props.space;
 
-    console.log(space);
     return (
       <PanelRow>
-        <h3>{ space.name }</h3>
+        <h3><a href={ this.spaceHref() }>{ space.name }</a></h3>
         { space.apps && space.apps.map((app) => {
           return (
           <PanelRow key={ app.guid }>
             <span className={ this.styler('panel-column') }>
-              <h3>{ space.name } / { app.name }</h3>
+              <h3>
+                { space.name } / <a href={ this.appHref(app.guid) }>{ app.name }</a>
+              </h3>
             </span>
             <span className={ this.styler('panel-column', 'panel-column-less') }>
               <span>{ app.state }</span>

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -65,7 +65,7 @@ export default class SpaceQuicklook extends React.Component {
           { space.apps && space.apps.map((app) =>
             <PanelRow key={ app.guid }>
               <span className={ this.styler('panel-column') }>
-                <h3>
+                <h3 className={ this.styler('sans-s5') }>
                   { space.name } / { this.appName(app) }
                 </h3>
               </span>

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -1,0 +1,52 @@
+
+import React from 'react';
+
+import style from 'cloudgov-style/css/cloudgov-style.css';
+import createStyler from '../util/create_styler';
+
+import AppCountStatus from './app_count_status.jsx';
+import PanelRow from './panel_row.jsx';
+import SpaceCountStatus from './space_count_status.jsx';
+import orgActions from '../actions/org_actions.js';
+
+const propTypes = {
+  space: React.PropTypes.object.isRequired
+};
+
+const defaultProps = {
+};
+
+export default class SpaceQuicklook extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.styler = createStyler(style);
+  }
+
+
+  render() {
+    const space = this.props.space;
+
+    console.log(space);
+    return (
+      <PanelRow>
+        <h3>{ space.name }</h3>
+        { space.apps && space.apps.map((app) => {
+          return (
+          <PanelRow key={ app.guid }>
+            <span className={ this.styler('panel-column') }>
+              <h3>{ space.name } / { app.name }</h3>
+            </span>
+            <span className={ this.styler('panel-column', 'panel-column-less') }>
+              <span>{ app.state }</span>
+            </span>
+          </PanelRow>
+          );
+        })}
+      </PanelRow>
+    );
+  }
+}
+
+SpaceQuicklook.propTypes = propTypes;
+SpaceQuicklook.defaultProps = defaultProps;

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -4,15 +4,18 @@ import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
+import Loading from './loading.jsx';
 import PanelRow from './panel_row.jsx';
 import { appStates } from '../constants.js';
 
 const propTypes = {
   space: React.PropTypes.object.isRequired,
-  orgGuid: React.PropTypes.string.isRequired
+  orgGuid: React.PropTypes.string.isRequired,
+  loading: React.PropTypes.bool
 };
 
 const defaultProps = {
+  loading: false
 };
 
 export default class SpaceQuicklook extends React.Component {
@@ -52,24 +55,30 @@ export default class SpaceQuicklook extends React.Component {
 
   render() {
     const space = this.props.space;
+    let loading = <Loading text="Loading spaces" loadingDelayMS={ 1 } />;
+    let content = <div>{ loading }</div>;
 
-    return (
-      <PanelRow>
-        <h3><a href={ this.spaceHref() }>{ space.name }</a></h3>
-        { space.apps && space.apps.map((app) =>
-          <PanelRow key={ app.guid }>
-            <span className={ this.styler('panel-column') }>
-              <h3>
-                { space.name } / { this.appName(app) }
-              </h3>
-            </span>
-            <span className={ this.styler('panel-column', 'panel-column-less') }>
-              { this.appState(app.state) }
-            </span>
-          </PanelRow>
-        )}
-      </PanelRow>
-    );
+    if (!this.props.loading) {
+      content = (
+        <PanelRow>
+          <h3><a href={ this.spaceHref() }>{ space.name }</a></h3>
+          { space.apps && space.apps.map((app) =>
+            <PanelRow key={ app.guid }>
+              <span className={ this.styler('panel-column') }>
+                <h3>
+                  { space.name } / { this.appName(app) }
+                </h3>
+              </span>
+              <span className={ this.styler('panel-column', 'panel-column-less') }>
+                { this.appState(app.state) }
+              </span>
+            </PanelRow>
+          )}
+        </PanelRow>
+      );
+    }
+
+    return content;
   }
 }
 

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -7,6 +7,7 @@ import createStyler from '../util/create_styler';
 import AppCountStatus from './app_count_status.jsx';
 import PanelRow from './panel_row.jsx';
 import SpaceCountStatus from './space_count_status.jsx';
+import { appStates } from '../constants.js';
 import orgActions from '../actions/org_actions.js';
 
 const propTypes = {
@@ -34,6 +35,24 @@ export default class SpaceQuicklook extends React.Component {
     return `/#/org/${props.orgGuid}/spaces/${props.space.guid}/apps/${appGuid}`;
   }
 
+  appState(appState) {
+    const statusClass = `status-${appState.toLowerCase()}`;
+    return (
+      <span className={ this.styler('status', statusClass) }>
+        { appState.toLowerCase() }
+      </span>
+    );
+  }
+
+  appName(app) {
+    const statusClass = (app.state === appStates.crashed) && 'status-crashed';
+    return (
+      <a className={ this.styler(statusClass) } href={ this.appHref(app.guid) }>
+        { app.name }
+      </a>
+    );
+  }
+
   render() {
     const space = this.props.space;
 
@@ -45,11 +64,11 @@ export default class SpaceQuicklook extends React.Component {
           <PanelRow key={ app.guid }>
             <span className={ this.styler('panel-column') }>
               <h3>
-                { space.name } / <a href={ this.appHref(app.guid) }>{ app.name }</a>
+                { space.name } / { this.appName(app) }
               </h3>
             </span>
             <span className={ this.styler('panel-column', 'panel-column-less') }>
-              <span>{ app.state }</span>
+              { this.appState(app.state) }
             </span>
           </PanelRow>
           );

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -59,6 +59,8 @@ const spaceActionTypes = keymirror({
   // Action to fetch all spaces (gets different information from single fetch,
   // such as quotas)
   SPACES_FETCH: null,
+  // Action to fetch all spaces for an org
+  SPACES_FOR_ORG_FETCH: null,
   // Action when a single space is received from the server.
   SPACE_RECEIVED: null,
   // Action when all spaces are received from the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -48,7 +48,9 @@ const orgActionTypes = keymirror({
   // Action when all organization summaries are received from the server.
   ORGS_SUMMARIES_RECEIVED: null,
   // Action when user toggles a space submenu in the sidenav
-  ORG_TOGGLE_SPACE_MENU: null
+  ORG_TOGGLE_SPACE_MENU: null,
+  // Action when a user opens up an org quick look
+  ORG_TOGGLE_QUICKLOOK: null
 });
 
 const spaceActionTypes = keymirror({

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -35,7 +35,7 @@ if (meta) {
   axios.defaults.headers.common['X-CSRF-Token'] = meta.content;
 }
 
-const MAX_OVERVIEW_SPACES = 20;
+const MAX_OVERVIEW_SPACES = 10;
 
 function login() {
   ReactDOM.render(<MainContainer><Login /></MainContainer>, mainEl);

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -84,9 +84,9 @@ class OrgStore extends BaseStore {
       case orgActionTypes.ORG_TOGGLE_QUICKLOOK: {
         const org = this.get(action.orgGuid);
         if (org) {
-          const ttoggledOrg = Object.assign({}, org,
+          const toggledOrg = Object.assign({}, org,
             { quicklook_open: !org.quicklook_open });
-          this.merge('guid', ttoggledOrg, () => this.emitChange());
+          this.merge('guid', toggledOrg, () => this.emitChange());
         }
         break;
       }

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -81,6 +81,16 @@ class OrgStore extends BaseStore {
         break;
       }
 
+      case orgActionTypes.ORG_TOGGLE_QUICKLOOK: {
+        const org = this.get(action.orgGuid);
+        if (org) {
+          const ttoggledOrg = Object.assign({}, org,
+            { quicklook_open: !org.quicklook_open });
+          this.merge('guid', ttoggledOrg, () => this.emitChange());
+        }
+        break;
+      }
+
       default:
         break;
     }

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -45,6 +45,17 @@ class SpaceStore extends BaseStore {
         break;
       }
 
+      case spaceActionTypes.SPACES_FOR_ORG_FETCH: {
+        const orgSpaces = this.getAll().filter((space) =>
+          space.organization_guid === action.orgGuid);
+        if (orgSpaces.length) {
+          const spaceRequests = orgSpaces.map((orgSpace) =>
+            cfApi.fetchSpace(orgSpace.guid));
+          this.load(spaceRequests);
+        }
+        break;
+      }
+
       case spaceActionTypes.SPACE_RECEIVED: {
         this.merge('guid', action.space, () => { });
         this.emitChange();

--- a/static_src/test/unit/actions/org_actions.spec.js
+++ b/static_src/test/unit/actions/org_actions.spec.js
@@ -74,16 +74,28 @@ describe('orgActions', () => {
 
       assertAction(spy, orgActionTypes.ORG_CHANGE_CURRENT, expectedParams);
     });
-  });
 
-  describe('changeCurrentOrg()', function() {
     it('should send a space menu toggle UI action', function() {
       let expected = 'asdlfka';
       let spy = setupUISpy(sandbox)
 
       orgActions.toggleSpaceMenu(expected);
-      
+
       assertAction(spy, orgActionTypes.ORG_TOGGLE_SPACE_MENU);
+    });
+  });
+
+  describe('toggleQuicklook()', function() {
+    it('should dispatch a UI event of type toggle quicklook', function() {
+      const orgGuid = 'asdlfka';
+      const expectedParams = {
+        orgGuid
+      };
+      const spy = setupUISpy(sandbox);
+
+      orgActions.toggleQuicklook(orgGuid);
+
+      assertAction(spy, orgActionTypes.ORG_TOGGLE_QUICKLOOK);
     });
   });
 });

--- a/static_src/test/unit/actions/space_actions.spec.js
+++ b/static_src/test/unit/actions/space_actions.spec.js
@@ -51,6 +51,18 @@ describe('spaceActions', () => {
     });
   });
 
+  describe('fetchAllForOrg()', () => {
+    it('should dispatch a view event to fetch all spaces for org', () => {
+      let spy = setupViewSpy(sandbox);
+
+      spaceActions.fetchAllForOrg('sdf');
+
+      expect(spy).toHaveBeenCalledOnce();
+      let arg = spy.getCall(0).args[0];
+      expect(arg.type).toEqual(spaceActionTypes.SPACES_FOR_ORG_FETCH);
+    });
+  });
+
   describe('receivedSpace()', () => {
     it('should dispatch server event of type space received', () => {
       var expected = { guid: 'asdf' },

--- a/static_src/test/unit/stores/org_store.spec.js
+++ b/static_src/test/unit/stores/org_store.spec.js
@@ -6,6 +6,7 @@ import '../../global_setup.js';
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
 import OrgStore from '../../../stores/org_store.js';
+import orgActions from '../../../actions/org_actions.js';
 import { orgActionTypes } from '../../../constants';
 
 describe('OrgStore', () => {
@@ -201,6 +202,32 @@ describe('OrgStore', () => {
       const actual = OrgStore.currentOrgName;
 
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('on toggle quicklook', function() {
+    it('should set quicklook_open to true for the org', function() {
+      const guid = 'osdvnx23bvc2';
+      const org = { guid, name: 'org' };
+
+      OrgStore.push(org);
+
+      orgActions.toggleQuicklook(guid);
+
+      const actual = OrgStore.get(guid);
+      expect(actual.quicklook_open).toBeTruthy();
+    });
+
+    it('should emit a change', function() {
+      const guid = 'osdvnx23435';
+      const org = { guid, name: 'org' };
+
+      OrgStore.push(org);
+      const spy = sandbox.spy(OrgStore, 'emitChange');
+
+      orgActions.toggleQuicklook(guid);
+
+      expect(spy).toHaveBeenCalledOnce();
     });
   });
 });

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -82,14 +82,15 @@ describe('SpaceStore', function() {
       SpaceStore.push({ guid: 'abc2', organization_guid: orgGuid });
       SpaceStore.push({ guid: 'abc3', organization_guid: '23fdg' });
 
-      const spy = sandbox.stub(cfApi, 'fetchSpace').returns(Promise.resolve());
+      const stub = sandbox.stub(cfApi, 'fetchSpace').returns(Promise.resolve());
 
       spaceActions.fetchAllForOrg(orgGuid);
 
-      expect(spy).toHaveBeenCalledTwice();
+      expect(stub).toHaveBeenCalledTwice();
     });
 
-    it('should emit change if there are spaces to be fetched', () => {
+    it('should emit a change from load call if there are spaces to be fetched',
+      () => {
       const orgGuid = '240jejxcb';
       SpaceStore.push({ guid: 'abc0', organization_guid: orgGuid });
 

--- a/static_src/test/unit/stores/space_store.spec.js
+++ b/static_src/test/unit/stores/space_store.spec.js
@@ -4,9 +4,11 @@ import '../../global_setup.js';
 import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
+import SpaceStore from '../../../stores/space_store.js';
+
+import cfApi from '../../../util/cf_api.js';
 import orgActions from '../../../actions/org_actions.js';
 import spaceActions from '../../../actions/space_actions.js';
-import SpaceStore from '../../../stores/space_store.js';
 
 describe('SpaceStore', function() {
   var sandbox;
@@ -68,6 +70,33 @@ describe('SpaceStore', function() {
 
       orgActions.receivedOrg({ guid: testGuid, spaces: [{}]});
       orgActions.receivedOrg({ guid: testGuid });
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('on fetch all for orgs', function() {
+    it('should call space fetch for each space that belongs to the org', () => {
+      const orgGuid = '240jejbvrl';
+      SpaceStore.push({ guid: 'abc1', organization_guid: orgGuid });
+      SpaceStore.push({ guid: 'abc2', organization_guid: orgGuid });
+      SpaceStore.push({ guid: 'abc3', organization_guid: '23fdg' });
+
+      const spy = sandbox.stub(cfApi, 'fetchSpace').returns(Promise.resolve());
+
+      spaceActions.fetchAllForOrg(orgGuid);
+
+      expect(spy).toHaveBeenCalledTwice();
+    });
+
+    it('should emit change if there are spaces to be fetched', () => {
+      const orgGuid = '240jejxcb';
+      SpaceStore.push({ guid: 'abc0', organization_guid: orgGuid });
+
+      const spy = sandbox.spy(SpaceStore, 'emitChange');
+
+      spaceActions.fetchAllForOrg('sdf');
+      spaceActions.fetchAllForOrg(orgGuid);
 
       expect(spy).toHaveBeenCalledOnce();
     });


### PR DESCRIPTION
Finishes overview page by having a quicklook UI for each space in an org, that gets displayed when you click on the org name.

More info in commit messages.

Relies on https://github.com/18F/cg-style/pull/200
Refs https://github.com/18F/cg-dashboard/issues/768