### PR TITLE
Set webpack to production mode.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ const config = {
     sourceMapFilename: 'bundle.js.map'
   },
 
-  devtool: (PRODUCTION) ? '' : 'eval-source-map',
+  devtool: PRODUCTION ? 'cheap-source-map' : 'eval-source-map',
 
   module: {
     loaders: [
@@ -92,6 +92,11 @@ if (PRODUCTION) {
   config.plugins.push(new webpack.optimize.DedupePlugin());
   config.plugins.push(new webpack.optimize.UglifyJsPlugin());
   config.plugins.push(new WebpackKarmaWarningsPlugin());
+  config.plugins.push(new webpack.DefinePlugin({
+    'process.env': {
+      'NODE_ENV': JSON.stringify('production')
+    }
+  }));
 }
 
 module.exports = config;


### PR DESCRIPTION
Following the official guidance from
https://webpack.js.org/guides/production-build/, this patch enables
cheap source maps in production for easier debugging and instructs
webpack to build in production mode when it should. This shrinks the
asset bundle a bit and disables development warnings.

@adborden @msecret 