### PR TITLE
Org quick look icons

### DIFF
--- a/static_src/components/app_count_status.jsx
+++ b/static_src/components/app_count_status.jsx
@@ -54,7 +54,8 @@ export default class AppCountStatus extends React.Component {
       status = this.worstStatus(props.apps);
     }
 
-    return <CountStatus count={ props.appCount } name="apps" status={ status } />;
+    return <CountStatus count={ props.appCount } name="apps"
+      status={ status } iconType="app" />;
   }
 }
 

--- a/static_src/components/app_count_status.jsx
+++ b/static_src/components/app_count_status.jsx
@@ -54,8 +54,11 @@ export default class AppCountStatus extends React.Component {
       status = this.worstStatus(props.apps);
     }
 
-    return <CountStatus count={ props.appCount } name="apps"
-      status={ status } iconType="app" />;
+    return (
+      <CountStatus count={ props.appCount } name="apps"
+        status={ status } iconType="app"
+      />
+    );
   }
 }
 

--- a/static_src/components/count_status.jsx
+++ b/static_src/components/count_status.jsx
@@ -5,6 +5,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import createStyler from '../util/create_styler';
 import { appStates } from '../constants.js';
+import EntityIcon from './entity_icon.jsx';
 
 const ICON_TYPES = [
   'space',
@@ -37,7 +38,12 @@ export default class CountStatus extends React.Component {
 
     return (
       <span className={ this.styler('count_status', statusClass) }>
-        <strong>{ props.count }</strong> { props.name }
+        <span style={{ float: 'left' }}>
+          <EntityIcon entity={ props.iconType } state={ props.status } />
+        </span>
+        <span style={{ float: 'right' }}>
+          <strong>{ props.count }</strong> { props.name }
+        </span>
       </span>
     );
   }

--- a/static_src/components/count_status.jsx
+++ b/static_src/components/count_status.jsx
@@ -38,10 +38,10 @@ export default class CountStatus extends React.Component {
 
     return (
       <span className={ this.styler('count_status', statusClass) }>
-        <span style={{ float: 'left' }}>
+        <span className={ this.styler('count_status-icon') }>
           <EntityIcon entity={ props.iconType } state={ props.status } />
         </span>
-        <span style={{ float: 'right' }}>
+        <span className={ this.styler('count_status-text') }>
           <strong>{ props.count }</strong> { props.name }
         </span>
       </span>

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -1,0 +1,42 @@
+
+import React from 'react';
+
+import Icon from './icon.jsx';
+import { appStates } from '../constants.js';
+import createStyler from '../util/create_styler';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+
+const ENTITIES = [ 'app', 'space', 'org'];
+
+const STATE_MAP = {};
+STATE_MAP[appStates.running] = 'ok';
+STATE_MAP[appStates.started] = 'ok';
+STATE_MAP[appStates.stopped] = 'inactive';
+STATE_MAP[appStates.crashed] = 'error';
+
+const propTypes = {
+  entity: React.PropTypes.oneOf(ENTITIES).isRequired,
+  state: React.PropTypes.oneOf(Object.values(appStates))
+};
+
+const defaultProps = {
+  state: appStates.default
+};
+
+export default class EntityIcon extends React.Component {
+  constructor(props) {
+    super(props);
+    this.props = props;
+    this.styler = createStyler(style);
+  }
+
+  render() {
+    const stateClass = STATE_MAP[this.props.state];
+
+    return <Icon name={ this.props.entity } styleType={ stateClass }
+      iconType="fill" />;
+  }
+}
+
+EntityIcon.propTypes = propTypes;
+EntityIcon.defaultProps = defaultProps;

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -8,11 +8,12 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const ENTITIES = ['app', 'space', 'org'];
 
-const STATE_MAP = {};
-STATE_MAP[appStates.running] = 'ok';
-STATE_MAP[appStates.started] = 'ok';
-STATE_MAP[appStates.stopped] = 'inactive';
-STATE_MAP[appStates.crashed] = 'error';
+const STATE_MAP = {
+  [appStates.running]: 'ok',
+  [appStates.started]: 'ok',
+  [appStates.stopped]: 'inactive',
+  [appStates.crashed]: 'error'
+};
 
 const propTypes = {
   entity: React.PropTypes.oneOf(ENTITIES).isRequired,

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -6,7 +6,7 @@ import { appStates } from '../constants.js';
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
-const ENTITIES = [ 'app', 'space', 'org'];
+const ENTITIES = ['app', 'space', 'org'];
 
 const STATE_MAP = {};
 STATE_MAP[appStates.running] = 'ok';
@@ -33,8 +33,7 @@ export default class EntityIcon extends React.Component {
   render() {
     const stateClass = STATE_MAP[this.props.state];
 
-    return <Icon name={ this.props.entity } styleType={ stateClass }
-      iconType="fill" />;
+    return <Icon name={ this.props.entity } styleType={ stateClass } iconType="fill" />;
   }
 }
 

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -1,39 +1,58 @@
 
-import classNames from 'classnames';
-import style from 'cloudgov-style/css/cloudgov-style.css';
 import React from 'react';
+
+import createStyler from '../util/create_styler';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+
+const ICON_TYPES = [
+  'fill',
+  'stroke'
+];
+
+const STYLE_TYPES = [
+  'alt',
+  'ok',
+  'inactive',
+  'error'
+];
+
+const propTypes = {
+  name: React.PropTypes.string.isRequired,
+  styleType: React.PropTypes.oneOf(STYLE_TYPES),
+  iconType: React.PropTypes.oneOf(ICON_TYPES)
+};
+
+const defaultProps = {
+  styleType: 'alt',
+  iconType: 'stroke'
+};
 
 export default class Icon extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
+    this.styler = createStyler(style);
   }
 
   getImagePath(iconName) {
-    var img = require('cloudgov-style/img/cloudgov-sprite.svg');
+    const img = require('cloudgov-style/img/cloudgov-sprite.svg');
     return `assets/${img}#i-${iconName}`;
   }
 
   render() {
-    var iconClasses = classNames(style.icon,
-        style[`icon-${ this.props.styleType }`]);
+    const mainClass = this.props.iconType === 'fill' ? 'icon-fill' : 'icon';
+    const styleClass = `${mainClass}-${this.props.styleType}`;
+    const iconClasses = this.styler(mainClass, styleClass);
 
     return (
-      <div className={ style['icon-container'] }>
-        <svg className={ iconClasses }>
-          <use
-            xlinkHref={ this.getImagePath(this.props.name) }>
-          </use>
-        </svg>
-      </div>
+      <svg className={ iconClasses }>
+        <use
+          xlinkHref={ this.getImagePath(this.props.name) }>
+        </use>
+      </svg>
     );
   }
 }
 
-Icon.propTypes = {
-  name: React.PropTypes.string.isRequired,
-  styleType: React.PropTypes.string
-}
-Icon.defaultProps = {
-  styleType: 'alt'
-}
+Icon.propTypes = propTypes;
+Icon.defaultProps = defaultProps;

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -5,6 +5,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 import AppCountStatus from './app_count_status.jsx';
+import EntityIcon from './entity_icon.jsx';
 import SpaceCountStatus from './space_count_status.jsx';
 import orgActions from '../actions/org_actions.js';
 import spaceActions from '../actions/space_actions.js';
@@ -57,6 +58,7 @@ export default class OrgQuickLook extends React.Component {
     <div style={ panelStyle }>
       <div className={ this.styler('panel-column') }>
         <h2 className={ this.styler('sans-s6') }>
+          <EntityIcon entity="org" />
           <a onClick={ this.toggleOrg } href="#">{ props.org.name }</a>
         </h2>
       </div>

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
+import EntityIcon from './entity_icon.jsx';
 import Loading from './loading.jsx';
 import PanelRow from './panel_row.jsx';
 import { appStates } from '../constants.js';
@@ -61,12 +62,16 @@ export default class SpaceQuicklook extends React.Component {
     if (!this.props.loading) {
       content = (
         <PanelRow>
-          <h3><a href={ this.spaceHref() }>{ space.name }</a></h3>
+          <h3>
+            <EntityIcon entity="space" />
+            <a href={ this.spaceHref() }>{ space.name }</a>
+          </h3>
           { space.apps && space.apps.map((app) =>
             <PanelRow key={ app.guid }>
               <span className={ this.styler('panel-column') }>
                 <h3 className={ this.styler('sans-s5') }>
-                  { space.name } / { this.appName(app) }
+                  <EntityIcon entity="app" state={ app.state } />
+                  <span>{ space.name } / { this.appName(app) }</span>
                 </h3>
               </span>
               <span className={ this.styler('panel-column', 'panel-column-less') }>


### PR DESCRIPTION
Adds icons to the org name, and space and count status components.
A new component for the entity icons was created to reduce certain
code like setting the right status class, ensuring a dev doesn't
pass the wrong icon type (can only be space, app, org), and setting
defaults for icon color. Refactored the Icon component so it uses
styler interface to keep consistent with newer code.

There was also functionality added to differentiate between stroke
and fill icons. This is a limitation in the SVGs, some of our icons
really have to be stroke and some really have to be fills. The current
set of icons are fills while the previous ones are strokes. I'm opting
to keep the generic `icon` class as stroke icons and adding a new class,
`icon-fill` for these new fill icons so that this isn't a breaking
change for cg-site. I think this is a sane default to set anyway.
Unfortunetely, a dashboard developer will have to know whether their
icon is a stroke or fill when using the Icon class, which is not a great
interface. Lucikly for entity icons, EntityIcon takes care of it.

Requires 18F/cg-style#ms-entity_icon branch on cg-style.