### PR TITLE
Border both the app and space icons

### DIFF
--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -34,7 +34,14 @@ export default class EntityIcon extends React.Component {
   render() {
     const stateClass = STATE_MAP[this.props.state];
 
-    return <Icon name={ this.props.entity } styleType={ stateClass } iconType="fill" />;
+    return (
+      <Icon
+        name={ this.props.entity }
+        styleType={ stateClass }
+        iconType="fill"
+        bordered={ ['app', 'space'].includes(this.props.entity) }
+      />
+    );
   }
 }
 

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -20,18 +20,15 @@ const STYLE_TYPES = [
 const propTypes = {
   name: React.PropTypes.string.isRequired,
   styleType: React.PropTypes.oneOf(STYLE_TYPES),
-  iconType: React.PropTypes.oneOf(ICON_TYPES)
+  iconType: React.PropTypes.oneOf(ICON_TYPES),
+  bordered: React.PropTypes.bool
 };
 
 const defaultProps = {
   styleType: 'default',
-  iconType: 'stroke'
+  iconType: 'stroke',
+  bordered: false
 };
-
-const BORDERED_ICONS = [
-  'app',
-  'space'
-];
 
 export default class Icon extends React.Component {
   constructor(props) {
@@ -49,7 +46,7 @@ export default class Icon extends React.Component {
   render() {
     const mainClass = this.props.iconType === 'fill' ? 'icon-fill' : 'icon';
     const styleClass = `icon-${this.props.styleType}`;
-    const borderedClass = (BORDERED_ICONS.includes(this.props.name)) &&
+    const borderedClass = (this.props.bordered) &&
       'icon-bordered';
     const iconClasses = this.styler(mainClass, styleClass, borderedClass);
 

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -13,7 +13,8 @@ const STYLE_TYPES = [
   'alt',
   'ok',
   'inactive',
-  'error'
+  'error',
+  'default'
 ];
 
 const propTypes = {
@@ -23,9 +24,14 @@ const propTypes = {
 };
 
 const defaultProps = {
-  styleType: 'alt',
+  styleType: 'default',
   iconType: 'stroke'
 };
+
+const BORDERED_ICONS = [
+  'app',
+  'space'
+];
 
 export default class Icon extends React.Component {
   constructor(props) {
@@ -36,13 +42,16 @@ export default class Icon extends React.Component {
 
   getImagePath(iconName) {
     const img = require('cloudgov-style/img/cloudgov-sprite.svg');
-    return `assets/${img}#i-${iconName}`;
+    const fill = this.props.iconType === 'fill' ? 'fill-' : '';
+    return `assets/${img}#i-${fill}${iconName}`;
   }
 
   render() {
     const mainClass = this.props.iconType === 'fill' ? 'icon-fill' : 'icon';
-    const styleClass = `${mainClass}-${this.props.styleType}`;
-    const iconClasses = this.styler(mainClass, styleClass);
+    const styleClass = `icon-${this.props.styleType}`;
+    const borderedClass = (BORDERED_ICONS.includes(this.props.name)) &&
+      'icon-bordered';
+    const iconClasses = this.styler(mainClass, styleClass, borderedClass);
 
     return (
       <svg className={ iconClasses }>


### PR DESCRIPTION
I decided to keep a list of bordered icons in Icon component, so the
user doesn't have to worry about what icons are supposed to be bordered.

When a new icon is added that has to be bordered, the dev will need
to add it to this list.