### PR TITLE
Fixes for app page

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -144,18 +144,18 @@ export default class AppContainer extends React.Component {
             <UsageLimits app={ this.state.app } quota={ this.state.quota } />
           </Panel>
 
-          <PanelGroup>
-            <PanelGroup columns={ 6 }>
+          <Panel>
+            <PanelGroup>
               <div className={ this.styler('panel-routes')}>
                 <RoutesPanel />
               </div>
             </PanelGroup>
-            <PanelGroup columns={ 6 }>
+            <PanelGroup>
               <div className={ this.styler('panel-services')}>
                 <ServiceInstancePanel />
               </div>
             </PanelGroup>
-          </PanelGroup>
+          </Panel>
 
           <Panel title="Recent activity">
             <ActivityLog initialAppGuid={ this.state.app.guid } />

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -144,7 +144,7 @@ export default class AppContainer extends React.Component {
             <UsageLimits app={ this.state.app } quota={ this.state.quota } />
           </Panel>
 
-          <Panel>
+          <PanelGroup>
             <PanelGroup>
               <div className={ this.styler('panel-routes')}>
                 <RoutesPanel />
@@ -155,7 +155,7 @@ export default class AppContainer extends React.Component {
                 <ServiceInstancePanel />
               </div>
             </PanelGroup>
-          </Panel>
+          </PanelGroup>
 
           <Panel title="Recent activity">
             <ActivityLog initialAppGuid={ this.state.app.guid } />

--- a/static_src/components/panel.jsx
+++ b/static_src/components/panel.jsx
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  title: 'Default title'
+  title: 'default'
 };
 
 export default class Panel extends React.Component {
@@ -21,9 +21,11 @@ export default class Panel extends React.Component {
   }
 
   render() {
+    const title = this.props.title !== 'default' &&
+      <h1 className={ this.styler('panel-title') }>{ this.props.title }</h1>;
     return (
       <div className={ this.styler('panel') }>
-        <h1 className={ this.styler('panel-title') }>{ this.props.title }</h1>
+       { title }
         <div className={ this.styler('panel-rows') }>
           { this.props.children }
         </div>

--- a/static_src/components/panel.jsx
+++ b/static_src/components/panel.jsx
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  title: 'default'
+  title: 'Default title'
 };
 
 export default class Panel extends React.Component {
@@ -21,11 +21,9 @@ export default class Panel extends React.Component {
   }
 
   render() {
-    const title = this.props.title !== 'default' &&
-      <h1 className={ this.styler('panel-title') }>{ this.props.title }</h1>;
     return (
       <div className={ this.styler('panel') }>
-       { title }
+        <h1 className={ this.styler('panel-title') }>{ this.props.title }</h1>
         <div className={ this.styler('panel-rows') }>
           { this.props.children }
         </div>


### PR DESCRIPTION
When looking at the app page, I realized the form for routes was pretty broken. This is because it's too large to fit in such a small width. The problem mainly has to do with that the design is using a much larger width grid then the current one due to us still having the sidenav. Once we rid the sidenav, we can do this, but for now, I dont' think it's feasible.