### PR TITLE
Small fixes 

### DIFF
--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -39,7 +39,7 @@ export default class EntityIcon extends React.Component {
         name={ this.props.entity }
         styleType={ stateClass }
         iconType="fill"
-        bordered={ ['app', 'space'].includes(this.props.entity) }
+        bordered={ ['app', 'space', 'service'].includes(this.props.entity) }
       />
     );
   }

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -62,7 +62,7 @@ export default class OrgQuickLook extends React.Component {
 
   render() {
     const props = this.props;
-    const panelStyle = props.org.quicklook_open ? { marginBottom: '3rem' } : null;
+    const panelStyle = props.org.quicklook_open ? { marginBottom: '2rem' } : null;
 
     return (
     <div style={ panelStyle } onClick={ this.onRowClick }

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -62,7 +62,7 @@ export default class OrgQuickLook extends React.Component {
 
   render() {
     const props = this.props;
-    const panelStyle = props.org.quicklook_open ? { marginBottom: '2rem' } : null;
+    const panelStyle = props.org.quicklook_open ? { marginBottom: '1rem' } : null;
 
     return (
     <div style={ panelStyle } onClick={ this.onRowClick }

--- a/static_src/components/routes_panel.jsx
+++ b/static_src/components/routes_panel.jsx
@@ -172,7 +172,6 @@ export default class RoutesPanel extends React.Component {
         <PanelGroup>
           <PanelHeader>
             <h3>Bound routes</h3>
-            <span>Manage routes in {this.spaceLink}</span>
           </PanelHeader>
           { this.renderRoutes(this.state.boundRoutes) }
         </PanelGroup>


### PR DESCRIPTION
- The manage routes at {space} link isn't valid right now and won't
be in the forseeable future as there is no route management on the
space page yet.
- Added border to service icon, requires, 18F/cg-style#ms-icon_improvements