### PR TITLE
Use go 1.6.3

### DIFF
--- a/manifests/manifest-base.yml
+++ b/manifests/manifest-base.yml
@@ -4,6 +4,6 @@ memory: 256M
 services:
   - deck-ups
 env:
-  GOVERSION: go1.6.4
+  GOVERSION: go1.6.3
   GOPACKAGENAME: github.com/18F/cg-dashboard
   GO15VENDOREXPERIMENT: 1


### PR DESCRIPTION
Avoids conflicting go version support in buildpacks 1.7.15 and 1.7.16