### PR TITLE
Partial fix for mis-placed click even on overview

### DIFF
--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -77,7 +77,8 @@ export default class AppList extends React.Component {
           <thead>
             <tr>
               <th>
-                Apps in <EntityIcon entity="space" />{ this.state.currentSpaceName }
+                <span>Apps in</span> <EntityIcon entity="space" />
+                <span> { this.state.currentSpaceName }</span>
               </th>
               <th>
                 Memory allocated

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -73,7 +73,7 @@ export default class AppList extends React.Component {
       content = <h4 className="test-none_message">No apps</h4>;
     } else if (!this.state.loading && this.state.apps.length > 0) {
       content = (
-        <table sortable>
+        <table>
           <thead>
             <tr>
               <th>

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -69,9 +69,9 @@ export default class OrgQuickLook extends React.Component {
       className={ this.styler('panel-row-is_clickable') }
     >
       <div className={ this.styler('panel-column') }>
-        <h2 className={ this.styler('sans-s6') } onClick={ this.onOrgClick }>
+        <h2 className={ this.styler('sans-s6') }>
           <EntityIcon entity="org" />
-          <a href={ this.orgHref() }>{ props.org.name }</a>
+          <a onClick={ this.onOrgClick }>{ props.org.name }</a>
         </h2>
       </div>
       <div className={ this.styler('panel-column') }>

--- a/static_src/components/space_list.jsx
+++ b/static_src/components/space_list.jsx
@@ -67,7 +67,7 @@ export default class SpaceList extends React.Component {
           <thead>
             <tr>
             { this.columns.map((column) =>
-              <th column={ column.label } className={ column.key }
+              <th className={ column.key }
                 key={ column.key }>
                 { column.label }
               </th>


### PR DESCRIPTION
Before, if you clicked to the side of the org text, it would register as an org click and go to the org page, which wasn't desired. Now you have to click on the actual org text.

The bug where you open the org menu before you click still exists.

Also fixed some new React errors