### PR TITLE
Fix styles of count_status

### DIFF
--- a/static_src/components/app_quicklook.jsx
+++ b/static_src/components/app_quicklook.jsx
@@ -96,7 +96,7 @@ export default class AppQuicklook extends React.Component {
         <div>
           <span className={ this.styler('panel-column') }>
             <h3 className={ this.styler('sans-s5') }>
-              <EntityIcon entity="app" state={ app.state } />
+              <EntityIcon entity="app" state={ app.state } iconSize="medium" />
               <span>{ this.props.spaceName } / { this.appName() }</span>
             </h3>
           </span>

--- a/static_src/components/count_status.jsx
+++ b/static_src/components/count_status.jsx
@@ -38,14 +38,14 @@ export default class CountStatus extends React.Component {
     const statusClass = `count_status-${props.status.toLowerCase()}`;
 
     return (
-      <span className={ this.styler('count_status', statusClass) }>
-        <span className={ this.styler('count_status-icon') }>
-          <EntityIcon entity={ props.iconType } state={ props.status } />
-        </span>
-        <span className={ this.styler('count_status-text') }>
+      <div className={ this.styler('count_status', statusClass) }>
+        <div className={ this.styler('count_status-icon') }>
+          <EntityIcon entity={ props.iconType } state={ props.status } iconSize="medium" />
+        </div>
+        <div className={ this.styler('count_status-text') }>
           <strong>{ props.count }</strong> { props.name }
-        </span>
-      </span>
+        </div>
+      </div>
     );
   }
 }

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -17,6 +17,7 @@ const STATE_MAP = {
 
 const propTypes = {
   entity: React.PropTypes.oneOf(ENTITIES).isRequired,
+  iconSize: React.PropTypes.string,
   state: React.PropTypes.oneOf(Object.values(appStates))
 };
 
@@ -38,6 +39,7 @@ export default class EntityIcon extends React.Component {
       <Icon
         name={ this.props.entity }
         styleType={ stateClass }
+        iconSize={ this.props.iconSize }
         iconType="fill"
         bordered={ ['app', 'space', 'service'].includes(this.props.entity) }
       />

--- a/static_src/components/org_quick_look.jsx
+++ b/static_src/components/org_quick_look.jsx
@@ -70,15 +70,17 @@ export default class OrgQuickLook extends React.Component {
     >
       <div className={ this.styler('panel-column') }>
         <h2 className={ this.styler('sans-s6') }>
-          <EntityIcon entity="org" />
+          <EntityIcon entity="org" iconSize="medium" />
           <a onClick={ this.onOrgClick }>{ props.org.name }</a>
         </h2>
       </div>
       <div className={ this.styler('panel-column') }>
-        <SpaceCountStatus spaces={ props.org.spaces } />
-        <AppCountStatus appCount={ this.totalAppCount(props.org.spaces) }
-          apps={ this.allApps() }
-        />
+        <div className={ this.styler('count_status_container') }>
+          <SpaceCountStatus spaces={ props.org.spaces } />
+          <AppCountStatus appCount={ this.totalAppCount(props.org.spaces) }
+            apps={ this.allApps() }
+          />
+        </div>
       </div>
     </div>
     );

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -42,7 +42,7 @@ export default class SpaceQuicklook extends React.Component {
       content = (
         <PanelRow>
           <h3>
-            <EntityIcon entity="space" />
+            <EntityIcon entity="space" iconSize="medium" />
             <a href={ this.spaceHref() }>{ space.name }</a>
           </h3>
           { space.apps && space.apps.map((app) =>


### PR DESCRIPTION
Paired with https://github.com/18F/cg-style/pull/248

- Use count_status-icon
- Use count_status_container
- Specify sizes for EntityIcon (quick fix)

Ideally, the EntityIcon would not need to specify a size, but it currently is causing the entire quick look panel to expand. This is the easier fix.