### PR TITLE
Removed unnecessary marketplace link

### DIFF
--- a/static_src/components/service_instance_panel.jsx
+++ b/static_src/components/service_instance_panel.jsx
@@ -127,7 +127,6 @@ export default class ServiceInstancePanel extends React.Component {
     if (!this.state.loading) {
       content = (
       <div>
-        <span>Manage services in { this.spaceLink } </span>
         <PanelGroup key="1">
           <PanelHeader>
             <h2>Bound service instances</h2>


### PR DESCRIPTION
There's already a link right below that goes to the same place, so this
is not needed.