### PR TITLE
Fix formatBytes for undefined

### DIFF
--- a/static_src/test/unit/util/format_bytes.spec.js
+++ b/static_src/test/unit/util/format_bytes.spec.js
@@ -3,12 +3,16 @@ import '../../global_setup.js';
 import formatBytes from '../../../util/format_bytes';
 
 describe('format_bytes util', function () {
+  it('formats undefined', function () {
+    expect(formatBytes(undefined)).toBe('0 B');
+  });
+
   it('formats zero', function () {
-    expect(formatBytes(0)).toBe('0 Bytes');
+    expect(formatBytes(0)).toBe('0 B');
   });
 
   it('formats bytes', function () {
-    expect(formatBytes(10)).toBe('10 Bytes');
+    expect(formatBytes(10)).toBe('10 B');
   });
 
   it('formats KB', function () {
@@ -21,11 +25,11 @@ describe('format_bytes util', function () {
 
   describe('with decimals', function () {
     it('formats zero', function () {
-      expect(formatBytes(0, 1)).toBe('0.0 Bytes');
+      expect(formatBytes(0, 1)).toBe('0.0 B');
     });
 
     it('formats bytes', function () {
-      expect(formatBytes(10, 1)).toBe('10.0 Bytes');
+      expect(formatBytes(10, 1)).toBe('10.0 B');
     });
 
     it('formats KB', function () {

--- a/static_src/util/format_bytes.js
+++ b/static_src/util/format_bytes.js
@@ -6,9 +6,9 @@
  * @returns {String} Formatted byte value with unit eg. 1.3 MB
  **/
 export default function formatBytes(bytes, decimals = 0) {
-  if (bytes === 0) return `${bytes.toFixed(decimals)} Bytes`;
+  if (!bytes) return `${Number(0).toFixed(decimals)} B`;
   const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return `${parseFloat((bytes / Math.pow(k, i))).toFixed(decimals)} ${sizes[i]}`;
 }


### PR DESCRIPTION
This fixes the formatter issue from https://github.com/18F/cg-dashboard/issues/890, but I'm not sure why we're getting undefined in some cases.