### PR TITLE
New panel logic and overview header

### DIFF
--- a/static_src/components/org_container.jsx
+++ b/static_src/components/org_container.jsx
@@ -85,22 +85,23 @@ export default class OrgContainer extends React.Component {
       // TODO repeated pattern space_container, overview
       content = (
       <div className={ this.styler('grid') }>
-        <div className={ this.styler('grid') }>
-          <div className={ this.styler('grid-width-6') }>
-            <h2>Organization overview</h2>
-          </div>
-          <div className={ this.styler('grid-width-6') }>
-            <div className={ this.styler('count_status_container') } >
-              <SpaceCountStatus spaces={ state.spaces } />
-              <AppCountStatus apps={ allApps } appCount={ allApps && allApps.length } />
-              <ServiceCountStatus services={ allServices }
-                serviceCount={ allServices && allServices.length }
-              />
-            </div>
-          </div>
-        </div>
 
         <Panel title="">
+          <div className={ this.styler('grid panel-overview-header') }>
+            <div className={ this.styler('grid-width-6') }>
+              <h1 className={ this.styler('panel-title') }>Organization overview</h1>
+            </div>
+            <div className={ this.styler('grid-width-6') }>
+              <div className={ this.styler('count_status_container') } >
+                <SpaceCountStatus spaces={ state.spaces } />
+                <AppCountStatus apps={ allApps } appCount={ allApps && allApps.length } />
+                <ServiceCountStatus services={ allServices }
+                  serviceCount={ allServices && allServices.length }
+                />
+              </div>
+            </div>
+          </div>
+
           { state.spaces.map((space) => (
             <SpaceQuicklook
               key={ space.guid }

--- a/static_src/components/panel.jsx
+++ b/static_src/components/panel.jsx
@@ -21,9 +21,15 @@ export default class Panel extends React.Component {
   }
 
   render() {
+
+    let panelHed = null;
+    if (this.props.title != '') {
+      panelHed = <h1 className={ this.styler('panel-title') }>{ this.props.title }</h1>;
+    }
+
     return (
       <div className={ this.styler('panel') }>
-        <h1 className={ this.styler('panel-title') }>{ this.props.title }</h1>
+        {panelHed}
         <div className={ this.styler('panel-rows') }>
           { this.props.children }
         </div>

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -74,20 +74,22 @@ export default class SpaceContainer extends React.Component {
       const space = this.state.space;
       main = (
       <div>
-        <div className={ this.styler('grid') }>
-          <div className={ this.styler('grid-width-8') }>
-            <h2>Space overview</h2>
-          </div>
-          <div className={ this.styler('grid-width-4') }>
-            <div className={ this.styler('count_status_container') }>
-              <AppCountStatus apps={ space.apps } appCount={ space.apps && space.apps.length } />
-              <ServiceCountStatus services={ space.services }
-                serviceCount={ space.services && space.services.length }
-              />
+        <Panel title="">
+
+          <div className={ this.styler('grid panel-overview-header') }>
+            <div className={ this.styler('grid-width-8') }>
+              <h1 className={ this.styler('panel-title') }>Space overview</h1>
+            </div>
+            <div className={ this.styler('grid-width-4') }>
+              <div className={ this.styler('count_status_container') }>
+                <AppCountStatus apps={ space.apps } appCount={ space.apps && space.apps.length } />
+                <ServiceCountStatus services={ space.services }
+                  serviceCount={ space.services && space.services.length }
+                />
+              </div>
             </div>
           </div>
-        </div>
-        <Panel title="">
+
           <AppList />
           <PanelActions>
             <span>Learn how to <a href={ config.docs.deploying_apps }>deploy a


### PR DESCRIPTION
This PR adds logic to the panel component to only include an `h1.panel-title` is the panel is explicitly given a title. If the title is left blank, the h1 will be omitted.

This allows flexibility in the space/org overview panel to include a special panel header that includes status and a bottom rule.

This is something of a pair with https://github.com/18F/cg-style/pull/250#pullrequestreview-14729427