### PR TITLE
Goodbye sidebar! (The templates to make this work)

### DIFF
--- a/static_src/components/disclaimer.jsx
+++ b/static_src/components/disclaimer.jsx
@@ -21,7 +21,7 @@ export default class Disclaimer extends React.Component {
       flagImg = <img alt={ flagAlt } src={ flag }></img>;
     }
     return (
-      <div className={ this.styler('usa-disclaimer') }>
+      <div className={ this.styler('usa-disclaimer', 'disclaimer-dashboard') }>
         <div className={ this.styler('grid') }>
           <span className={ this.styler('usa-disclaimer-official') }>
             { config.header.disclaimer }

--- a/static_src/components/disclaimer.jsx
+++ b/static_src/components/disclaimer.jsx
@@ -21,7 +21,7 @@ export default class Disclaimer extends React.Component {
       flagImg = <img alt={ flagAlt } src={ flag }></img>;
     }
     return (
-      <div className={ this.styler('usa-disclaimer', 'disclaimer-dashboard') }>
+      <div className={ this.styler('usa-disclaimer', 'disclaimer-no_sidebar') }>
         <div className={ this.styler('grid') }>
           <span className={ this.styler('usa-disclaimer-official') }>
             { config.header.disclaimer }

--- a/static_src/components/header.jsx
+++ b/static_src/components/header.jsx
@@ -35,7 +35,7 @@ export default class Header extends React.Component {
       </Action>
     </HeaderLink>;
     return (
-    <header className={ this.styler('header', 'header-dashboard') }>
+    <header className={ this.styler('header', 'header-no_sidebar') }>
       <div className={ this.styler('header-wrap') }>
         <div className={ this.styler('header-title') }>
           <a href="/" className={ this.styler('logo') } title="Home">

--- a/static_src/components/header.jsx
+++ b/static_src/components/header.jsx
@@ -35,7 +35,7 @@ export default class Header extends React.Component {
       </Action>
     </HeaderLink>;
     return (
-    <header className={ this.styler('header') }>
+    <header className={ this.styler('header', 'header-dashboard') }>
       <div className={ this.styler('header-wrap') }>
         <div className={ this.styler('header-title') }>
           <a href="/" className={ this.styler('logo') } title="Home">

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -55,7 +55,7 @@ export default class App extends React.Component {
       <div>
         <Disclaimer />
         <Header />
-        <div className={ this.styler('main_content', 'content-dashboard') }>
+        <div className={ this.styler('main_content', 'content-no_sidebar') }>
           <main className={ this.styler('usa-content') }>
             <div className={ this.styler('content', 'grid') }>
               { content }

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -43,11 +43,9 @@ export default class App extends React.Component {
 
   render() {
     let content;
-    let sidebar;
 
     if (this.state.isLoggedIn) {
       content = this.props.children;
-      sidebar = <Nav />;
     } else {
       content = <Login />;
     }
@@ -57,11 +55,8 @@ export default class App extends React.Component {
       <div>
         <Disclaimer />
         <Header />
-        <div className={ this.styler('sidenav-parent', 'main_content', 'content-dashboard') }>
-          <nav className={ this.styler('sidenav') }>
-            { sidebar }
-          </nav>
-          <main className={ this.styler('sidenav-main', 'usa-content') }>
+        <div className={ this.styler('main_content', 'content-dashboard') }>
+          <main className={ this.styler('usa-content') }>
             <div className={ this.styler('content', 'grid') }>
               { content }
             </div>


### PR DESCRIPTION
This updates the templates to remove the sidebar, and adds styling hooks for dashboard elements.

**Paired with https://github.com/18F/cg-style/pull/255**
**Based off Icon/Panel work in https://github.com/18F/cg-dashboard/pull/892 and https://github.com/18F/cg-style/pull/250 — Merge them first.**

- - -

![screen shot 2016-12-30 at 7 27 00 am](https://cloud.githubusercontent.com/assets/11464021/21567569/f936fd82-ce61-11e6-854c-50dd5aee0a31.png)

- - -

![screen shot 2016-12-30 at 7 27 18 am](https://cloud.githubusercontent.com/assets/11464021/21567573/ff196d02-ce61-11e6-9520-4a67d7b2edd3.png)
