### PR TITLE
Fixing the USA Disclaimer grid

### DIFF
--- a/static_src/components/disclaimer.jsx
+++ b/static_src/components/disclaimer.jsx
@@ -22,7 +22,7 @@ export default class Disclaimer extends React.Component {
     }
     return (
       <div className={ this.styler('usa-disclaimer') }>
-        <div className={ this.styler('grid') }>
+        <div className={ this.styler('usa-grid') }>
           <span className={ this.styler('usa-disclaimer-official') }>
             { config.header.disclaimer }
             { flagImg }


### PR DESCRIPTION
Small fix to put the disclaimer grid into alignment with the rest of the page.