### PR TITLE
Update Breadcrumbs to an OL for better semantics

### DIFF
--- a/static_src/components/breadcrumbs/breadcrumbs.jsx
+++ b/static_src/components/breadcrumbs/breadcrumbs.jsx
@@ -46,9 +46,9 @@ export default class Breadcrumbs extends React.Component {
     }
 
     return (
-      <div className={ this.styler('breadcrumbs') }>
+      <ol className={ this.styler('breadcrumbs') }>
         { breadcrumbs }
-      </div>
+      </ol>
     );
   }
 }

--- a/static_src/components/breadcrumbs/breadcrumbs_item.jsx
+++ b/static_src/components/breadcrumbs/breadcrumbs_item.jsx
@@ -22,9 +22,9 @@ export default class BreadcrumbsItem extends React.Component {
       : <span className={ this.styler('breadcrumbs-item-current') }>{ this.props.children }</span>;
 
     return (
-      <div className={ this.styler('breadcrumbs-item') }>
+      <li className={ this.styler('breadcrumbs-item') }>
         { content }
-      </div>
+      </li>
     );
   }
 }


### PR DESCRIPTION
Changing breadcrumbs to be an `<ol>` for better semantics.