### PR TITLE
Added style class to panel group headers

### DIFF
--- a/static_src/components/routes_panel.jsx
+++ b/static_src/components/routes_panel.jsx
@@ -175,13 +175,13 @@ export default class RoutesPanel extends React.Component {
         { this.createRouteForm }
         <PanelGroup>
           <PanelHeader>
-            <h2>Bound routes</h2>
+            <h2 className={ this.styler('panel-row-header') }>Bound routes</h2>
           </PanelHeader>
           { this.renderRoutes(this.state.boundRoutes) }
         </PanelGroup>
         <PanelGroup>
           <PanelHeader>
-            <h2>Routes available in {this.spaceLink}</h2>
+            <h2 className={ this.styler('panel-row-header') }>Routes available in {this.spaceLink}</h2>
           </PanelHeader>
           { this.renderRoutes(this.state.unboundRoutes) }
         </PanelGroup>

--- a/static_src/components/routes_panel.jsx
+++ b/static_src/components/routes_panel.jsx
@@ -181,7 +181,8 @@ export default class RoutesPanel extends React.Component {
         </PanelGroup>
         <PanelGroup>
           <PanelHeader>
-            <h2 className={ this.styler('panel-row-header') }>Routes available in {this.spaceLink}</h2>
+            <h2 className={ this.styler('panel-row-header') }>Routes available in
+              {this.spaceLink}</h2>
           </PanelHeader>
           { this.renderRoutes(this.state.unboundRoutes) }
         </PanelGroup>

--- a/static_src/components/service_instance_panel.jsx
+++ b/static_src/components/service_instance_panel.jsx
@@ -121,7 +121,7 @@ export default class ServiceInstancePanel extends React.Component {
       <div>
         <PanelGroup key="1">
           <PanelHeader>
-            <h2>Bound service instances</h2>
+            <h2 className={ this.styler('panel-row-header') }>Bound service instances</h2>
           </PanelHeader>
           <ServiceInstanceListPanel
             currentAppGuid={ this.state.currentAppGuid }
@@ -132,7 +132,7 @@ export default class ServiceInstancePanel extends React.Component {
         </PanelGroup>
         <PanelGroup key="2">
           <PanelHeader>
-            <h2>Service instances available in { this.spaceLink }</h2>
+            <h2 className={ this.styler('panel-row-header') }>Service instances available in { this.spaceLink }</h2>
           </PanelHeader>
           <ServiceInstanceListPanel
             currentAppGuid={ this.state.currentAppGuid }

--- a/static_src/components/service_instance_panel.jsx
+++ b/static_src/components/service_instance_panel.jsx
@@ -132,7 +132,8 @@ export default class ServiceInstancePanel extends React.Component {
         </PanelGroup>
         <PanelGroup key="2">
           <PanelHeader>
-            <h2 className={ this.styler('panel-row-header') }>Service instances available in { this.spaceLink }</h2>
+            <h2 className={ this.styler('panel-row-header') }>Service instances available in
+              { this.spaceLink }</h2>
           </PanelHeader>
           <ServiceInstanceListPanel
             currentAppGuid={ this.state.currentAppGuid }


### PR DESCRIPTION
Cos they were way too big as-is. Now they look like this:

![screen shot 2017-01-04 at 2 29 03 pm](https://cloud.githubusercontent.com/assets/11464021/21661684/59f29204-d28a-11e6-9f93-4aebf37f5818.png)
