### PR TITLE
Remove deprecated buttons

### DIFF
--- a/static_src/components/action.jsx
+++ b/static_src/components/action.jsx
@@ -5,12 +5,10 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 const BUTTON_STYLES = [
-  'cautious',
   'warning',
   'primary',
-  'primary-alt',
-  'secondary',
-  'finish'
+  'finish',
+  'base'
 ];
 
 const BUTTON_TYPES = [

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -43,7 +43,7 @@ export default class ConfirmationBox extends React.Component {
         { this.props.message }</span>
         <div>
           <Action label="Cancel"
-              style="cautious"
+              style="base"
               type="outline"
               clickHandler={ this._cancelHandler }>
             <span>Cancel</span>

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -132,7 +132,7 @@ export default class CreateServiceInstance extends React.Component {
           <p><em>
             After you create a service instance, you can look at your space to check whether your service instance was created. (<a href="https://github.com/18F/cg-dashboard/issues/457">We’ll make this better.</a>) Then you can bind the service instance to an app <a href="https://docs.cloud.gov/apps/managed-services/">using the command line</a>.
           </em></p>
-                                                                                                                                       <Action label="cancel" style="base"
+                                                                                                                                       <Action label="cancel" style="base" type="outline"
               clickHandler={ this._onCancelForm.bind(this) }>
             Cancel
           </Action>

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -132,7 +132,7 @@ export default class CreateServiceInstance extends React.Component {
           <p><em>
             After you create a service instance, you can look at your space to check whether your service instance was created. (<a href="https://github.com/18F/cg-dashboard/issues/457">We’ll make this better.</a>) Then you can bind the service instance to an app <a href="https://docs.cloud.gov/apps/managed-services/">using the command line</a>.
           </em></p>
-                                                                                                                                       <Action label="cancel" style="secondary"
+                                                                                                                                       <Action label="cancel" style="base"
               clickHandler={ this._onCancelForm.bind(this) }>
             Cancel
           </Action>

--- a/static_src/components/route.jsx
+++ b/static_src/components/route.jsx
@@ -104,7 +104,7 @@ export default class Route extends React.Component {
   bindAction(unbind) {
     return (
       <Action key="unbind" label={ (!!unbind) ? 'Unbind' : 'Bind' }
-        style={ (!!unbind) ? 'warning' : 'base' } type={ (!!unbind) ? 'link' : 'button' }
+        style={ (!!unbind) ? 'warning' : 'primary' } type={ (!!unbind) ? 'link' : 'button' }
         clickHandler={ (!!unbind) ? this._toggleRemove : this._bindHandler }
       >
         { (!!unbind) ? 'Unbind' : 'Bind' }

--- a/static_src/components/route.jsx
+++ b/static_src/components/route.jsx
@@ -104,7 +104,7 @@ export default class Route extends React.Component {
   bindAction(unbind) {
     return (
       <Action key="unbind" label={ (!!unbind) ? 'Unbind' : 'Bind' }
-        style={ (!!unbind) ? 'warning' : 'outline' } type={ (!!unbind) ? 'link' : 'button' }
+        style={ (!!unbind) ? 'warning' : 'base' } type={ (!!unbind) ? 'link' : 'button' }
         clickHandler={ (!!unbind) ? this._toggleRemove : this._bindHandler }
       >
         { (!!unbind) ? 'Unbind' : 'Bind' }

--- a/static_src/components/route_form.jsx
+++ b/static_src/components/route_form.jsx
@@ -174,7 +174,7 @@ export default class RouteForm extends React.Component {
         <div className={ this.styler('route-form-actions') }>
           <PanelActions>
             <Action clickHandler={ this.props.cancelHandler } label="Cancel"
-              style="cautious" type="outline"
+              style="base" type="outline"
             >
               Cancel
             </Action>

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -111,9 +111,9 @@ export default class ServiceInstanceList extends React.Component {
           <thead>
             <tr>
             { this.columns.map((column) =>
-              <th column={ column.label } className={ column.key }
-                key={ column.key }>
-                { column.label }</th>
+              <th className={ column.key } key={ column.key }>
+                { column.label }
+              </th>
             )}
             </tr>
           </thead>
@@ -123,16 +123,16 @@ export default class ServiceInstanceList extends React.Component {
             const lastOpTime = lastOp.updated_at || lastOp.created_at;
             return (
               <tr key={ instance.guid }>
-                <td column="Name"><span>{ instance.name }</span></td>
-                <td column="Last operation">{ instance.last_operation.type }</td>
-                <td column="Updated at">
+                <td><span>{ instance.name }</span></td>
+                <td>{ instance.last_operation.type }</td>
+                <td>
                   { formatDateTime(lastOpTime) }
                 </td>
-                <td column="Delete" style={specialtdStyles}>
+                <td style={specialtdStyles}>
                   <span>
                     <div>
                       <Action
-                        style="secondary"
+                        style="base"
                         classes={ ['test-delete_instance'] }
                         disabled={instance.confirmDelete}
                         clickHandler={ this._handleDeleteConfirmation.bind(

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -101,7 +101,7 @@ export default class UserList extends React.Component {
               if (this.state.currentUserAccess) {
                 button = (
                   <Action
-                    style="secondary"
+                    style="base"
                     clickHandler={ this._handleDelete.bind(this, user.guid) }
                     label="delete">
                     <span>Remove User From Org</span>


### PR DESCRIPTION
Some buttons have been deprecated. This PR removes them from being used in dashboard, fixing button colors where they are incorrect.

It also fixes other React warnings due to incorrect prop usage.

Ref https://github.com/18F/cg-dashboard/issues/914