### PR TITLE
Fixed route and other error handling

### DIFF
--- a/static_src/stores/route_store.js
+++ b/static_src/stores/route_store.js
@@ -218,7 +218,8 @@ class RouteStore extends BaseStore {
         const route = this.get(action.routeGuid);
         if (!route) break;
         const newRoute = Object.assign({}, route, {
-          error: action.error
+          error: action.error,
+          loading: null
         });
         this.merge('guid', newRoute, (changed) => {
           if (changed) this.emitChange();

--- a/static_src/test/unit/stores/route_store.spec.js
+++ b/static_src/test/unit/stores/route_store.spec.js
@@ -642,7 +642,8 @@ describe('RouteStore', function() {
 
       const actual = RouteStore.get(routeGuid);
       const expected = Object.assign({}, route, {
-        error: err
+        error: err,
+        loading: null
       });
 
       expect(actual).toEqual(expected);

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -213,7 +213,7 @@ export default {
       .then((res) => {
         serviceActions.createdInstance(this.formatSplitResponse(res.data));
       }).catch((err) => {
-        handleError(err, serviceActions.errorCreateInstance);
+        handleError(err.response, serviceActions.errorCreateInstance);
       });
   },
 
@@ -266,13 +266,15 @@ export default {
         const updatedApp = Object.assign({}, res.data.entity, { guid: appGuid });
         appActions.updatedApp(updatedApp);
       })
-      .catch((err) => handleError(err, appActions.error.bind(null, appGuid)));
+      .catch((err) => handleError(err.response,
+        appActions.error.bind(null, appGuid)));
   },
 
   postAppRestart(appGuid) {
     return http.post(`${APIV}/apps/${appGuid}/restage`).then(() => {
       appActions.restarted(appGuid);
-    }).catch((err) => handleError(err, appActions.error.bind(this, appGuid)));
+    }).catch((err) => handleError(err.response,
+      appActions.error.bind(this, appGuid)));
   },
 
   /**
@@ -308,10 +310,10 @@ export default {
       .then(() => {
         userActions.deletedUser(userGuid, orgGuid);
       }).catch((err) => {
-        if (err.data) {
+        if (err.response.data) {
           userActions.errorRemoveUser(userGuid, err.data);
         } else {
-          handleError(err);
+          handleError(err.response);
         }
       });
   },
@@ -393,7 +395,7 @@ export default {
     return http.post(`${APIV}/routes`, payload).then((res) => {
       routeActions.createdRoute(this.formatSplitResponse(res.data));
       return res.data;
-    }).catch((err) => handleError(err, routeActions.errorCreateRoute));
+    }).catch((err) => handleError(err.response, routeActions.errorCreateRoute));
   },
 
   // http://apidocs.cloudfoundry.org/241/routes/delete_a_particular_route.html
@@ -402,7 +404,7 @@ export default {
     return http.delete(url).then(() => {
       routeActions.deletedRoute(routeGuid);
     }).catch((err) => {
-      handleError(err, routeActions.error.bind(this, routeGuid));
+      handleError(err.response, routeActions.error.bind(this, routeGuid));
     });
   },
 
@@ -412,7 +414,7 @@ export default {
     return http.put(url).then(() => {
       routeActions.associatedApp(routeGuid, appGuid);
     }).catch((err) => {
-      handleError(err, routeActions.error.bind(this, routeGuid));
+      handleError(err.response, routeActions.error.bind(this, routeGuid));
     });
   },
 
@@ -421,7 +423,7 @@ export default {
     return http.delete(url).then(() => {
       routeActions.unassociatedApp(routeGuid, appGuid);
     }).catch((err) => {
-      handleError(err, routeActions.error.bind(this, routeGuid));
+      handleError(err.response, routeActions.error.bind(this, routeGuid));
     });
   },
 
@@ -437,7 +439,7 @@ export default {
     return http.put(url, payload).then(() => {
       routeActions.updatedRoute(routeGuid, route);
     }).catch((err) => {
-      handleError(err, routeActions.error.bind(this, routeGuid));
+      handleError(err.response, routeActions.error.bind(this, routeGuid));
     });
   },
 
@@ -468,7 +470,7 @@ export default {
     return http.post(`${APIV}/service_bindings`, payload).then((res) => {
       serviceActions.boundService(this.formatSplitResponse(res.data));
     }).catch((err) => {
-      handleError(err, serviceActions.instanceError.bind(
+      handleError(err.response, serviceActions.instanceError.bind(
         this, serviceInstanceGuid));
     });
   },
@@ -478,7 +480,7 @@ export default {
     () => {
       serviceActions.unboundService(serviceBinding);
     }).catch((err) => {
-      handleError(err, serviceActions.instanceError.bind(
+      handleError(err.response, serviceActions.instanceError.bind(
         this, serviceBinding.service_instance_guid));
     });
   }


### PR DESCRIPTION
A change, maybe in axios ajax module, maybe somewhere else changed
the error responses so the actual data resides in a `response` object
within the error object. This was breaking the error catching. The
fix is the pass the error `response` object to the `handleError`
function so the correct data is supplied to it so it can pass the
error correctly to the UI with the correct information.

Additionally, the route store wasn't resetting the route loading state after
and error, which was causing the editing loading text to appear after any
error.

Ref https://github.com/18F/cg-dashboard/issues/915