### PR TITLE
Better handling of app instance state

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import Action from './action.jsx';
 import ActivityLog from './activity_log.jsx';
-import { appHealth } from '../util/health';
+import { appHealth, worstAppInstanceState } from '../util/health';
 import AppStore from '../stores/app_store.js';
 import Breadcrumbs from './breadcrumbs.jsx';
 import EntityIcon from './entity_icon.jsx';
@@ -96,8 +96,11 @@ export default class AppContainer extends React.Component {
   }
 
   get statusUI() {
+    const worstState = worstAppInstanceState(
+      (this.state.app.app_instances || []).map(instance => instance.state)
+    );
     return (
-      <span className={ this.styler('usa-label') }>{ this.state.app.state }</span>
+      <span className={ this.styler('usa-label') }>{ worstState }</span>
     );
   }
 

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Action from './action.jsx';
 import ActivityLog from './activity_log.jsx';
 import { appHealth, worstAppInstanceState } from '../util/health';
+import { appStates } from '../constants';
 import AppStore from '../stores/app_store.js';
 import Breadcrumbs from './breadcrumbs.jsx';
 import EntityIcon from './entity_icon.jsx';
@@ -96,9 +97,14 @@ export default class AppContainer extends React.Component {
   }
 
   get statusUI() {
-    const worstState = worstAppInstanceState(
-      (this.state.app.app_instances || []).map(instance => instance.state)
-    );
+    let worstState = this.state.app.state;
+    if (this.state.app.state === appStates.started) {
+      // If the app is started, use the instance state
+      worstState = worstAppInstanceState(
+	(this.state.app.app_instances || []).map(instance => instance.state)
+      );
+    }
+
     return (
       <span className={ this.styler('usa-label') }>{ worstState }</span>
     );

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -5,7 +5,7 @@ const appStates = {
   crashed: 'CRASHED',
   down: 'DOWN',
   flapping: 'FLAPPING',
-  none: 'NONE',
+  unknown: 'UNKNOWN',
   restarting: 'RESTARTING',
   running: 'RUNNING',
   started: 'STARTED',

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -64,7 +64,7 @@ class AppStore extends BaseStore {
         }).catch((error) => {
           const erroredApp = Object.assign({}, action.app, {
             error,
-            state: appStates.none
+            state: appStates.unknown
           });
 
           this.merge('guid', erroredApp);

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -109,7 +109,7 @@ describe('AppStore', function() {
       var sharedGuid = 'cmadkljcsa';
 
       let existingApp = { guid: sharedGuid, name: 'adsfa' };
-      let newApp = { guid: sharedGuid, instances: [{ guid: 'dfs' }] }
+      let newApp = { guid: sharedGuid, instances: 2 }
 
       AppStore.push(existingApp);
 
@@ -122,7 +122,7 @@ describe('AppStore', function() {
 
       let actual = AppStore.get(sharedGuid);
       expect(actual).toEqual({ guid: sharedGuid, name: 'adsfa',
-          instances: [{ guid: 'dfs' }] });
+          instances: 2 });
     });
 
     it('should add app to data if it doesn\'t already exist', function() {
@@ -164,7 +164,7 @@ describe('AppStore', function() {
       AppDispatcher.handleViewAction({
         type: appActionTypes.APP_STATS_RECEIVED,
         appGuid: sharedGuid,
-        app: { stats: {} }
+        app: { app_instances: [{stats: {}}] }
       });
 
       expect(spy).toHaveBeenCalledOnce();
@@ -174,7 +174,7 @@ describe('AppStore', function() {
       var sharedGuid = 'cmadkljcsa';
 
       let existingApp = { guid: sharedGuid, name: 'adsfa' };
-      let newApp = { stats: { mem_quota: 123543 }};
+      let newApp = { app_instances: [{ stats: { mem_quota: 123543 } }] };
 
       AppStore.push(existingApp);
       expect(AppStore.get(sharedGuid)).toEqual(existingApp);
@@ -186,13 +186,18 @@ describe('AppStore', function() {
       });
 
       let actual = AppStore.get(sharedGuid);
-      expect(actual).toEqual({ guid: sharedGuid, name: 'adsfa',
-          stats: { mem_quota: 123543 }});
+      expect(actual).toEqual({
+        guid: sharedGuid,
+        name: 'adsfa',
+        app_instances: [{
+          stats: { mem_quota: 123543 }
+        }]
+      });
     });
 
     it('should create a new app if it doesn\'t already exist', function() {
       var expectedGuid = 'adcasdcccsss',
-          expected = {stats: { mem_quota: 12 }};
+          expected = { app_instances: [{stats: { mem_quota: 12 }}] };
 
       AppDispatcher.handleServerAction({
         type: appActionTypes.APP_STATS_RECEIVED,
@@ -203,7 +208,7 @@ describe('AppStore', function() {
       let actual = AppStore.get(expectedGuid);
       expect(actual).toEqual({
         guid: expectedGuid,
-        stats: { mem_quota: 12 }
+        app_instances: [{stats: { mem_quota: 12 }}]
       });
     });
   });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -246,7 +246,7 @@ export default {
 
   fetchAppStats(appGuid) {
     return http.get(`${APIV}/apps/${appGuid}/stats`).then((res) => {
-      appActions.receivedAppStats(appGuid, res.data[0]);
+      appActions.receivedAppStats(appGuid, { app_instances: Object.values(res.data) });
     }).catch((err) => {
       handleError(err);
     });

--- a/static_src/util/health.js
+++ b/static_src/util/health.js
@@ -13,6 +13,16 @@ const HEALTH_RANKED = [
   entityHealth.inactive
 ];
 
+const APP_INSTANCE_STATE_RANKED = [
+  appStates.down,
+  appStates.crashed,
+  appStates.flapping,
+  appStates.restarting,
+  appStates.running,
+  appStates.started,
+  appStates.stopped
+];
+
 
 export function appHealth(app) {
   if (!app) {
@@ -42,14 +52,18 @@ export function appHealth(app) {
   return entityHealth.unknown;
 }
 
+// Lowest score is worst
+function rank(ranked, value) {
+  return ranked.indexOf(value);
+}
+
 export function isHealthyApp(app) {
   return HEALTHY_STATES.includes(appHealth(app));
 }
 
-// Lowest score is worst
 // Unknown health is worst (-1)
 export function rankWorseHealth(health) {
-  return HEALTH_RANKED.indexOf(health);
+  return rank(HEALTH_RANKED, health);
 }
 
 export function worstHealth(healths) {
@@ -57,7 +71,27 @@ export function worstHealth(healths) {
     return entityHealth.unknown;
   }
 
-  return healths.reduce((worst, health) =>
-    (rankWorseHealth(worst) > rankWorseHealth(health) ? health : worst)
-  , entityHealth.inactive);
+  return healths.reduce((worst, health) => {
+    if (!worst) {
+      return health;
+    }
+
+    return rankWorseHealth(worst) > rankWorseHealth(health) ? health : worst;
+  });
+}
+
+export function worstAppInstanceState(states) {
+  if (!states || !states.length) {
+    return appStates.none;
+  }
+
+  const score = rank.bind(null, APP_INSTANCE_STATE_RANKED);
+
+  return states.reduce((worst, state) => {
+    if (!worst) {
+      return state;
+    }
+
+    return score(worst) > score(state) ? state : worst;
+  });
 }

--- a/static_src/util/health.js
+++ b/static_src/util/health.js
@@ -82,7 +82,7 @@ export function worstHealth(healths) {
 
 export function worstAppInstanceState(states) {
   if (!states || !states.length) {
-    return appStates.none;
+    return appStates.unknown;
   }
 
   const score = rank.bind(null, APP_INSTANCE_STATE_RANKED);


### PR DESCRIPTION
Fetching stats actually gives us instance data, so we can get richer data if we treat it that way. We merge the instance stats into `app.app_instances`. To calculate instance usage, we average across the instances. To get the total usage, we sum them. To get the app status, we find the worse state within the instances.

This fixes an issue on the app  page where we show the wrong status label and gives us more accurate numbers in the usage and allocation panel.