### PR TITLE
Better handling of usage and allocation data

### DIFF
--- a/static_src/components/resource_usage.jsx
+++ b/static_src/components/resource_usage.jsx
@@ -43,7 +43,7 @@ export default class ResourceUsage extends React.Component {
 
   render() {
     const props = this.props;
-    let title = <h2 className={ this.styler('stat-header')}>{ props.title } allocated</h2>;
+    let title = <h2 className={ this.styler('stat-header')}>{ props.title }</h2>;
     let stat = (
       <Stat
         editable={ props.editable }
@@ -55,8 +55,8 @@ export default class ResourceUsage extends React.Component {
       />
     );
 
-    if (props.amountUsed) {
-      title = <h2 className={ this.styler('stat-header')}>{ props.title } used</h2>;
+    if (props.amountUsed && props.amountTotal) {
+      title = <h2 className={ this.styler('stat-header')}>{ props.title }</h2>;
       stat = (
         <Stat
           primaryStat={ props.amountUsed }
@@ -65,6 +65,7 @@ export default class ResourceUsage extends React.Component {
         />
       );
     }
+
     return (
       <div style={{ width: '100%' }}>
         { title }

--- a/static_src/components/stat.jsx
+++ b/static_src/components/stat.jsx
@@ -85,6 +85,15 @@ export default class Stat extends React.Component {
       </span>
     );
 
+    // Avoid rendering 0 or non-numbers
+    if (!this.state.primaryStat) {
+      primaryStat = (
+        <span className={ this.styler('stat-primary')}>
+          N/A
+        </span>
+      );
+    }
+
     if (this.props.editable) {
       primaryStat = (
         <div>

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -105,13 +105,13 @@ export default class UsageAndLimits extends React.Component {
     return (
     <div className={ this.styler('panel-row-space') }>
       <div className={ this.styler('panel-column') }>
-        <ResourceUsage title="Instance disk"
+        <ResourceUsage title="Instance disk used"
           amountUsed={ this.getStat('disk', average.bind(null, this.props.app.running_instances)) }
           amountTotal={ this.getStat('disk_quota') }
         />
       </div>
       <div className={ this.styler('panel-column') } style={{ textAlign: 'left' }}>
-        <ResourceUsage title="Instance disk"
+        <ResourceUsage title="Instance disk allocation"
           editable={ this.state.editing }
           max={ 2 * 1024 }
           min={ 1 }
@@ -132,13 +132,13 @@ export default class UsageAndLimits extends React.Component {
     return (
     <div>
       <div className={ this.styler('panel-column') }>
-        <ResourceUsage title="Instance memory"
+        <ResourceUsage title="Instance memory used"
           amountUsed={ this.getStat('mem', average.bind(null, this.props.app.running_instances)) }
           amountTotal={ this.getStat('mem_quota') }
         />
       </div>
       <div className={ this.styler('panel-column') } style={{ textAlign: 'left' }}>
-        <ResourceUsage title="Instance memory"
+        <ResourceUsage title="Instance memory allocation"
           editable={ this.state.editing }
           min={ 1 }
           max={ Math.floor(this.props.quota.memory_limit / this.state.partialApp.instances) }
@@ -152,25 +152,28 @@ export default class UsageAndLimits extends React.Component {
   }
 
   get totalDisk() {
-    // TODO get space quota
+    // There is no org/space level disk quota, so only show single stat
     return (
-    <div className={ this.styler('panel-row-space') }>
-      <ResourceUsage title="Total disk"
-        amountUsed={ this.getStat('disk', sum) }
-        amountTotal={ this.getStat('disk_quota') * this.props.app.instances }
-      />
-    </div>
+      <div className={ this.styler('panel-row-space') }>
+        <ResourceUsage title="Total disk used"
+          amountTotal={ this.getStat('disk', sum) }
+        />
+      </div>
     );
   }
 
   get totalMemory() {
+    const amountTotal = this.props.quota.memory_limit * 1024 * 1024;
+    const amountUsed = this.getStat('mem', sum);
+    const title = amountUsed ? 'Total memory used' : 'Total memory available';
+
     return (
-    <div>
-      <ResourceUsage title="Total memory"
-        amountUsed={ this.getStat('mem', sum) }
-        amountTotal={ this.props.quota.memory_limit * 1024 * 1024 }
-      />
-    </div>
+      <div>
+        <ResourceUsage title={ title }
+          amountUsed={ amountUsed }
+          amountTotal={ amountTotal }
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
- Avoid showing 0 or non-numbers (display N/A)
- Don't show a total available for total disk since there is no org/space quota
- Keep the stat titles fixed so they don't display the wrong thing if data is
  unavailable.
- General "best effort" to display helpful details even if app is crashed or
  stopped.

I don't know why we don't have quota data for the crashed app, but we don't so N/A is displayed for total memory available.

**Running**
![screenshot from 2017-01-05 14-04-18](https://cloud.githubusercontent.com/assets/509703/21699601/58750fd4-d351-11e6-85bb-cefc041a4171.png)

**Stopped**
![screenshot from 2017-01-05 14-04-49](https://cloud.githubusercontent.com/assets/509703/21699614/6600288c-d351-11e6-985f-2e82823c2d94.png)

**Crashed**
![screenshot from 2017-01-05 14-04-37](https://cloud.githubusercontent.com/assets/509703/21699605/5e7a3800-d351-11e6-85a9-c11b48d73290.png)
