### PR TITLE
Refactor org quicklook loading

### DIFF
--- a/static_src/actions/org_actions.js
+++ b/static_src/actions/org_actions.js
@@ -69,18 +69,28 @@ export default {
     });
 
     let fetch = Promise.resolve();
-    if (!org.quicklook || !org.quicklook.open) {
-      // TODO only fetch if spaces haven't already been fetched
+    if (!org.quicklook || !org.quicklook.isLoaded) {
       fetch = spaceActions.fetchAllForOrg(org.guid);
     }
 
-    fetch.then(() => {
-      AppDispatcher.handleUIAction({
-        type: orgActionTypes.ORG_TOGGLE_QUICKLOOK_SUCCESS,
-        orgGuid: org.guid
-      });
-    });
+    return fetch.then(
+      () => this.toggleQuicklookSuccess(org.guid),
+      (err) => this.toggleQuicklookError(org.guid, err)
+    );
+  },
 
-    return fetch;
+  toggleQuicklookSuccess(orgGuid) {
+    AppDispatcher.handleUIAction({
+      type: orgActionTypes.ORG_TOGGLE_QUICKLOOK_SUCCESS,
+      orgGuid
+    });
+  },
+
+  toggleQuicklookError(orgGuid, err) {
+    AppDispatcher.handleUIAction({
+      type: orgActionTypes.ORG_TOGGLE_QUICKLOOK_ERROR,
+      orgGuid,
+      err
+    });
   }
 };

--- a/static_src/actions/org_actions.js
+++ b/static_src/actions/org_actions.js
@@ -6,6 +6,7 @@
 
 import AppDispatcher from '../dispatcher.js';
 import { orgActionTypes } from '../constants';
+import spaceActions from './space_actions';
 
 export default {
 
@@ -61,10 +62,25 @@ export default {
     });
   },
 
-  toggleQuicklook(orgGuid) {
+  toggleQuicklook(org) {
     AppDispatcher.handleUIAction({
       type: orgActionTypes.ORG_TOGGLE_QUICKLOOK,
-      orgGuid
+      orgGuid: org.guid
     });
+
+    let fetch = Promise.resolve();
+    if (!org.quicklook || !org.quicklook.open) {
+      // TODO only fetch if spaces haven't already been fetched
+      fetch = spaceActions.fetchAllForOrg(org.guid);
+    }
+
+    fetch.then(() => {
+      AppDispatcher.handleUIAction({
+        type: orgActionTypes.ORG_TOGGLE_QUICKLOOK_SUCCESS,
+        orgGuid: org.guid
+      });
+    });
+
+    return fetch;
   }
 };

--- a/static_src/actions/space_actions.js
+++ b/static_src/actions/space_actions.js
@@ -5,7 +5,9 @@
  */
 
 import AppDispatcher from '../dispatcher.js';
+import cfApi from '../util/cf_api';
 import { spaceActionTypes } from '../constants.js';
+import SpaceStore from '../stores/space_store';
 
 export default {
   fetch(spaceGuid) {
@@ -13,12 +15,18 @@ export default {
       type: spaceActionTypes.SPACE_FETCH,
       spaceGuid
     });
+
+    // TODO error action should also be specified here
+    return cfApi.fetchSpace(spaceGuid).then(this.receivedSpace);
   },
 
   fetchAll() {
     AppDispatcher.handleViewAction({
       type: spaceActionTypes.SPACES_FETCH
     });
+
+    // TODO error action should also be specified here
+    return cfApi.fetchSpaces().then(this.receivedSpaces);
   },
 
   fetchAllForOrg(orgGuid) {
@@ -26,6 +34,12 @@ export default {
       type: spaceActionTypes.SPACES_FOR_ORG_FETCH,
       orgGuid
     });
+
+    // TODO error action should also be specified here
+    return Promise.all(SpaceStore.getAll()
+      .filter(space => space.organization_guid === orgGuid)
+      .map(space => this.fetch(space.guid))
+    );
   },
 
   receivedSpace(space) {

--- a/static_src/components/org_quicklook.jsx
+++ b/static_src/components/org_quicklook.jsx
@@ -6,9 +6,10 @@ import createStyler from '../util/create_styler';
 
 import AppCountStatus from './app_count_status.jsx';
 import EntityIcon from './entity_icon.jsx';
+import Loading from './loading.jsx';
 import SpaceCountStatus from './space_count_status.jsx';
+import SpaceQuicklook from './space_quicklook.jsx';
 import orgActions from '../actions/org_actions.js';
-import spaceActions from '../actions/space_actions.js';
 import { orgHref } from '../util/url';
 
 const propTypes = {
@@ -32,10 +33,7 @@ export default class OrgQuicklook extends React.Component {
 
   onRowClick(ev) {
     ev.preventDefault();
-    if (!this.props.org.quicklook_open) {
-      spaceActions.fetchAllForOrg(this.props.org.guid);
-    }
-    orgActions.toggleQuicklook(this.props.org.guid);
+    orgActions.toggleQuicklook(this.props.org);
   }
 
   onOrgClick(ev) {
@@ -60,29 +58,48 @@ export default class OrgQuicklook extends React.Component {
     }, []);
   }
 
+  get spacesContent() {
+    if (!this.props.org.quicklook || !this.props.org.quicklook.open) {
+      return null;
+    }
+
+    if (!this.props.org.quicklook.isLoaded) {
+      return <Loading />;
+    }
+
+    return this.props.spaces.map(space =>
+      <SpaceQuicklook space={ space } orgGuid={ this.props.org.guid } key={ space.guid } />
+    );
+  }
+
   render() {
     const props = this.props;
-    const panelStyle = props.org.quicklook_open ? { marginBottom: '1rem' } : null;
+    const panelStyle = props.org.quicklook && props.org.quicklook.open ?
+      { marginBottom: '1rem' } :
+      null;
 
     return (
-    <div style={ panelStyle } onClick={ this.onRowClick }
-      className={ this.styler('panel-row-is_clickable', 'test-org-quicklook') }
-    >
-      <div className={ this.styler('panel-column') }>
-        <h2 className={ this.styler('card-title-primary') }>
-          <EntityIcon entity="org" iconSize="medium" />
-          <a onClick={ this.onOrgClick }>{ props.org.name }</a>
-        </h2>
-      </div>
-      <div className={ this.styler('panel-column') }>
-        <div className={ this.styler('count_status_container') }>
-          <SpaceCountStatus spaces={ props.org.spaces } />
-          <AppCountStatus appCount={ this.totalAppCount(props.org.spaces) }
-            apps={ this.allApps() }
-          />
+      <div>
+        <div style={ panelStyle } onClick={ this.onRowClick }
+          className={ this.styler('panel-row-is_clickable', 'test-org-quicklook') }
+        >
+          <div className={ this.styler('panel-column') }>
+            <h2 className={ this.styler('card-title-primary') }>
+              <EntityIcon entity="org" iconSize="medium" />
+              <a onClick={ this.onOrgClick }>{ props.org.name }</a>
+            </h2>
+          </div>
+          <div className={ this.styler('panel-column') }>
+            <div className={ this.styler('count_status_container') }>
+              <SpaceCountStatus spaces={ props.org.spaces } />
+              <AppCountStatus appCount={ this.totalAppCount(props.org.spaces) }
+                apps={ this.allApps() }
+              />
+            </div>
+          </div>
         </div>
+        { this.spacesContent }
       </div>
-    </div>
     );
   }
 }

--- a/static_src/components/org_quicklook.jsx
+++ b/static_src/components/org_quicklook.jsx
@@ -20,8 +20,7 @@ const defaultProps = {
   spaces: []
 };
 
-// TODO rename org_quicklook and org_quick_look to remain consistent with store.
-export default class OrgQuickLook extends React.Component {
+export default class OrgQuicklook extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
@@ -88,5 +87,5 @@ export default class OrgQuickLook extends React.Component {
   }
 }
 
-OrgQuickLook.propTypes = propTypes;
-OrgQuickLook.defaultProps = defaultProps;
+OrgQuicklook.propTypes = propTypes;
+OrgQuicklook.defaultProps = defaultProps;

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -7,7 +7,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import { config } from 'skin';
 import Icon from './icon.jsx';
 import Loading from './loading.jsx';
-import OrgQuickLook from './org_quick_look.jsx';
+import OrgQuicklook from './org_quicklook.jsx';
 import OrgStore from '../stores/org_store.js';
 import PageHeader from './page_header.jsx';
 import Panel from './panel.jsx';
@@ -79,7 +79,7 @@ export default class OverviewContainer extends React.Component {
         <Panel title="Your organizations">
           { state.orgs.map((org) =>
             <PanelRow key={ org.guid } className="test-panel-row-organizations" styleClass="boxed">
-              <OrgQuickLook
+              <OrgQuicklook
                 org={ org }
                 spaces={ this.orgSpaces(org.guid) }
               />

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -56,7 +56,7 @@ export default class OverviewContainer extends React.Component {
   }
 
   anyOrgsOpen() {
-    return this.state.orgs.reduce((prev, org) => prev || !!org.quicklook_open,
+    return this.state.orgs.reduce((prev, org) => prev || !!(org.quicklook && org.quicklook.open),
       false);
   }
 
@@ -83,7 +83,7 @@ export default class OverviewContainer extends React.Component {
                 org={ org }
                 spaces={ this.orgSpaces(org.guid) }
               />
-              { org.quicklook_open && this.orgSpaces(org.guid).map((space) =>
+              { org.quicklook && org.quicklook.open && this.orgSpaces(org.guid).map((space) =>
                 <SpaceQuicklook space={ space } orgGuid={ org.guid }
                   key={ space.guid }
                 />

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -85,7 +85,7 @@ export default class OverviewContainer extends React.Component {
               />
               { org.quicklook_open && this.orgSpaces(org.guid).map((space) =>
                 <SpaceQuicklook space={ space } orgGuid={ org.guid }
-                  key={ space.guid } loading={ state.loading }
+                  key={ space.guid }
                 />
               )}
             </PanelRow>

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -14,7 +14,7 @@ import Panel from './panel.jsx';
 import PanelGroup from './panel_group.jsx';
 import PanelRow from './panel_row.jsx';
 import SpaceStore from '../stores/space_store.js';
-import SpaceQuicklook from './space_quicklook.jsx';
+
 
 function stateSetter() {
   const orgs = OrgStore.getAll() || [];
@@ -83,11 +83,6 @@ export default class OverviewContainer extends React.Component {
                 org={ org }
                 spaces={ this.orgSpaces(org.guid) }
               />
-              { org.quicklook && org.quicklook.open && this.orgSpaces(org.guid).map((space) =>
-                <SpaceQuicklook space={ space } orgGuid={ org.guid }
-                  key={ space.guid }
-                />
-              )}
             </PanelRow>
           )}
         </Panel>

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -5,6 +5,7 @@ import AppCountStatus from './app_count_status.jsx';
 import AppList from '../components/app_list.jsx';
 import Breadcrumbs from './breadcrumbs.jsx';
 import EntityIcon from './entity_icon.jsx';
+import Loading from './loading.jsx';
 import Marketplace from './marketplace.jsx';
 import OrgStore from '../stores/org_store.js';
 import PageHeader from './page_header.jsx';
@@ -23,7 +24,8 @@ function stateSetter() {
     space: SpaceStore.currentSpace() || {},
     currentOrg: OrgStore.currentOrg(),
     currentOrgGuid: OrgStore.currentOrgGuid,
-    currentSpaceGuid: SpaceStore.currentSpaceGuid
+    currentSpaceGuid: SpaceStore.currentSpaceGuid,
+    loading: SpaceStore.loading || OrgStore.loading
   };
 }
 
@@ -37,10 +39,12 @@ export default class SpaceContainer extends React.Component {
   }
 
   componentDidMount() {
+    OrgStore.addChangeListener(this._onChange);
     SpaceStore.addChangeListener(this._onChange);
   }
 
   componentWillUnmount() {
+    OrgStore.removeChangeListener(this._onChange);
     SpaceStore.removeChangeListener(this._onChange);
   }
 
@@ -57,6 +61,10 @@ export default class SpaceContainer extends React.Component {
   }
 
   render() {
+    if (this.state.loading) {
+      return <Loading />;
+    }
+
     let main = <div></div>;
     const title = (
       <span>

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -6,19 +6,16 @@ import createStyler from '../util/create_styler';
 
 import AppQuicklook from './app_quicklook.jsx';
 import EntityIcon from './entity_icon.jsx';
-import Loading from './loading.jsx';
 import PanelRow from './panel_row.jsx';
 import { spaceHref } from '../util/url';
 
 const propTypes = {
   space: React.PropTypes.object.isRequired,
   orgGuid: React.PropTypes.string.isRequired,
-  loading: React.PropTypes.bool,
   showAppDetail: React.PropTypes.bool
 };
 
 const defaultProps = {
-  loading: false,
   showAppDetail: false
 };
 
@@ -36,32 +33,25 @@ export default class SpaceQuicklook extends React.Component {
 
   render() {
     const space = this.props.space;
-    let loading = <Loading text="Loading spaces" loadingDelayMS={ 1 } />;
-    let content = <div>{ loading }</div>;
-
-    if (!this.props.loading) {
-      content = (
-        <PanelRow id={ `space-quicklook-${space.guid}` } className="test-space-quicklook">
-          <h3 className={ this.styler('contents-primary') }>
-            <EntityIcon entity="space" iconSize="medium" />
-            <a href={ this.spaceHref() }>{ space.name }</a>
-          </h3>
-          { space.apps && space.apps.map((app) =>
-             <AppQuicklook
-               key={ app.guid }
-               app={ app }
-               orgGuid={ this.props.orgGuid }
-               spaceGuid={ space.guid }
-               spaceName={ space.name }
-               extraInfo={ this.props.showAppDetail ?
-                 ['state', 'memory', 'diskQuota'] : ['state'] }
-             />
-          )}
-        </PanelRow>
-      );
-    }
-
-    return content;
+    return (
+      <PanelRow id={ `space-quicklook-${space.guid}` } className="test-space-quicklook">
+        <h3 className={ this.styler('contents-primary') }>
+          <EntityIcon entity="space" iconSize="medium" />
+          <a href={ this.spaceHref() }>{ space.name }</a>
+        </h3>
+        { space.apps && space.apps.map((app) =>
+           <AppQuicklook
+             key={ app.guid }
+             app={ app }
+             orgGuid={ this.props.orgGuid }
+             spaceGuid={ space.guid }
+             spaceName={ space.name }
+             extraInfo={ this.props.showAppDetail ?
+               ['state', 'memory', 'diskQuota'] : ['state'] }
+           />
+        )}
+      </PanelRow>
+    );
   }
 }
 

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -67,7 +67,11 @@ const orgActionTypes = keymirror({
   // Action when user toggles a space submenu in the sidenav
   ORG_TOGGLE_SPACE_MENU: null,
   // Action when a user opens up an org quick look
-  ORG_TOGGLE_QUICKLOOK: null
+  ORG_TOGGLE_QUICKLOOK: null,
+  // Action when the toggle completes successfully
+  ORG_TOGGLE_QUICKLOOK_SUCCESS: null,
+  // Action when the toggle fails to complete
+  ORG_TOGGLE_QUICKLOOK_ERROR: null
 });
 
 const spaceActionTypes = keymirror({

--- a/static_src/models/quicklook.js
+++ b/static_src/models/quicklook.js
@@ -1,0 +1,12 @@
+import Immutable from 'immutable';
+
+
+const defaults = {
+  isLoaded: false,
+  open: false
+};
+
+/* eslint-disable new-cap */
+export default class Quicklook extends Immutable.Record(defaults, 'Quicklook') {
+/* eslint-enable new-cap */
+}

--- a/static_src/models/quicklook.js
+++ b/static_src/models/quicklook.js
@@ -2,6 +2,7 @@ import Immutable from 'immutable';
 
 
 const defaults = {
+  error: null,
   isLoaded: false,
   open: false
 };

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -11,6 +11,7 @@ import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
 import LoginStore from './login_store.js';
 import { orgActionTypes } from '../constants.js';
+import Quicklook from '../models/quicklook';
 
 class OrgStore extends BaseStore {
   constructor() {
@@ -83,11 +84,11 @@ class OrgStore extends BaseStore {
 
       case orgActionTypes.ORG_TOGGLE_QUICKLOOK: {
         const org = this.get(action.orgGuid);
-        if (org) {
-          const toggledOrg = Object.assign({}, org,
-            { quicklook_open: !org.quicklook_open });
-          this.merge('guid', toggledOrg, () => this.emitChange());
-        }
+        const orgQuicklook = org.quicklook || new Quicklook();
+        const toggledOrg = { ...org,
+          quicklook: orgQuicklook.merge({ open: !orgQuicklook.open })
+        };
+        this.merge('guid', toggledOrg, () => this.emitChange());
         break;
       }
 

--- a/static_src/stores/org_store.js
+++ b/static_src/stores/org_store.js
@@ -84,11 +84,31 @@ class OrgStore extends BaseStore {
 
       case orgActionTypes.ORG_TOGGLE_QUICKLOOK: {
         const org = this.get(action.orgGuid);
-        const orgQuicklook = org.quicklook || new Quicklook();
+        const orgQuicklook = new Quicklook(org.quicklook || {});
         const toggledOrg = { ...org,
           quicklook: orgQuicklook.merge({ open: !orgQuicklook.open })
         };
-        this.merge('guid', toggledOrg, () => this.emitChange());
+        this.merge('guid', toggledOrg);
+        break;
+      }
+
+      case orgActionTypes.ORG_TOGGLE_QUICKLOOK_SUCCESS: {
+        const org = this.get(action.orgGuid);
+        const orgQuicklook = new Quicklook(org.quicklook);
+        const toggledOrg = { ...org,
+          quicklook: orgQuicklook.merge({ isLoaded: true, error: null })
+        };
+        this.merge('guid', toggledOrg);
+        break;
+      }
+
+      case orgActionTypes.ORG_TOGGLE_QUICKLOOK_ERROR: {
+        const org = this.get(action.orgGuid);
+        const orgQuicklook = org.quicklook;
+        const toggledOrg = { ...org,
+          quicklook: orgQuicklook.merge({ isLoaded: true, error: action.error })
+        };
+        this.merge('guid', toggledOrg);
         break;
       }
 

--- a/static_src/test/unit/actions/space_actions.spec.js
+++ b/static_src/test/unit/actions/space_actions.spec.js
@@ -28,7 +28,7 @@ describe('spaceActions', () => {
 
     beforeEach(function(done) {
       dispatcherSpy = setupViewSpy(sandbox);
-      fetchSpaceStub = sandbox.stub(cfApi, 'fetchSpace').yieldsAsync(expectedSpace);
+      fetchSpaceStub = sandbox.stub(cfApi, 'fetchSpace').returns(Promise.resolve(expectedSpace));
       receivedSpaceStub = sandbox.stub(spaceActions, 'receivedSpace');
       expectedGuid = 'abc1';
       expectedSpace = { guid: expectedGuid };
@@ -36,15 +36,17 @@ describe('spaceActions', () => {
     });
 
     it('dispatches SPACE_FETCH action', function() {
-      expect(dispatcherSpy).toHaveBeenCalledWith(spaceActionTypes.SPACE_FETCH);
+      const [action] = dispatcherSpy.getCall(0).args;
+      expect(dispatcherSpy).toHaveBeenCalledOnce();
+      expect(action.type).toBe(spaceActionTypes.SPACE_FETCH);
     });
 
-    it('calls api method once', (done) => {
+    it('calls api method once', function() {
       expect(fetchSpaceStub).toHaveBeenCalledOnce();
     });
 
     it('calls api with the guid', function() {
-      expect(fetchSpaceStub).toHaveBeenCalledWith(expected);
+      expect(fetchSpaceStub).toHaveBeenCalledWith(expectedGuid);
     });
 
     it('calls the receivedSpace action creator', function() {
@@ -55,7 +57,6 @@ describe('spaceActions', () => {
   describe('fetchAll()', () => {
     it('should dispatch a view event to fetch all spaces', () => {
       let spy = setupViewSpy(sandbox);
-      const spy = sandbox.spy(cfApi, 'fetchSpace').yieldsAsync(sentinel);
       const receivedSpaceStub = sandbox.stub(spaceActions, 'receivedSpace');
 
       spaceActions.fetchAll();

--- a/static_src/test/unit/actions/space_actions.spec.js
+++ b/static_src/test/unit/actions/space_actions.spec.js
@@ -20,29 +20,43 @@ describe('spaceActions', () => {
   });
 
   describe('fetch()', () => {
-    it('should call apis fetch method', () => {
-      var spy = sandbox.spy(cfApi, 'fetchSpace'),
-          expected = 'abc1';
+    let expectedSpace,
+      dispatcherSpy,
+      fetchSpaceStub,
+      receivedSpaceStub,
+      expectedGuid;
 
-      spaceActions.fetch(expected);
-
-      expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(expected);
+    beforeEach(function(done) {
+      dispatcherSpy = setupViewSpy(sandbox);
+      fetchSpaceStub = sandbox.stub(cfApi, 'fetchSpace').yieldsAsync(expectedSpace);
+      receivedSpaceStub = sandbox.stub(spaceActions, 'receivedSpace');
+      expectedGuid = 'abc1';
+      expectedSpace = { guid: expectedGuid };
+      spaceActions.fetch(expectedGuid).then(done, done.fail);
     });
 
-    it('should dispatch a view event of type space fetch', () => {
-      let spy = setupViewSpy(sandbox);
+    it('dispatches SPACE_FETCH action', function() {
+      expect(dispatcherSpy).toHaveBeenCalledWith(spaceActionTypes.SPACE_FETCH);
+    });
 
-      spaceActions.fetch();
+    it('calls api method once', (done) => {
+      expect(fetchSpaceStub).toHaveBeenCalledOnce();
+    });
 
-      let arg = spy.getCall(0).args[0];
-      expect(arg.type).toEqual(spaceActionTypes.SPACE_FETCH);
+    it('calls api with the guid', function() {
+      expect(fetchSpaceStub).toHaveBeenCalledWith(expected);
+    });
+
+    it('calls the receivedSpace action creator', function() {
+      expect(receivedSpaceStub).toHaveBeenCalledWith(expectedSpace);
     });
   });
 
   describe('fetchAll()', () => {
     it('should dispatch a view event to fetch all spaces', () => {
       let spy = setupViewSpy(sandbox);
+      const spy = sandbox.spy(cfApi, 'fetchSpace').yieldsAsync(sentinel);
+      const receivedSpaceStub = sandbox.stub(spaceActions, 'receivedSpace');
 
       spaceActions.fetchAll();
 

--- a/static_src/test/unit/stores/org_store.spec.js
+++ b/static_src/test/unit/stores/org_store.spec.js
@@ -206,16 +206,16 @@ describe('OrgStore', () => {
   });
 
   describe('on toggle quicklook', function() {
-    it('should set quicklook_open to true for the org', function() {
+    it('should set quicklook.open to true for the org', function() {
       const guid = 'osdvnx23bvc2';
       const org = { guid, name: 'org' };
 
       OrgStore.push(org);
 
-      orgActions.toggleQuicklook(guid);
+      orgActions.toggleQuicklook(org);
 
       const actual = OrgStore.get(guid);
-      expect(actual.quicklook_open).toBeTruthy();
+      expect(actual.quicklook.open).toBeTruthy();
     });
 
     it('should emit a change', function() {
@@ -225,7 +225,7 @@ describe('OrgStore', () => {
       OrgStore.push(org);
       const spy = sandbox.spy(OrgStore, 'emitChange');
 
-      orgActions.toggleQuicklook(guid);
+      orgActions.toggleQuicklook(org);
 
       expect(spy).toHaveBeenCalledOnce();
     });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -536,8 +536,6 @@ describe('cfApi', function() {
       let actual = spy.getCall(0).args[0];
       expect(actual).toMatch(new RegExp(expected));
       expect(actual).toMatch(new RegExp('space'));
-      actual = spy.getCall(0).args[1];
-      expect(actual).toEqual(spaceActions.receivedSpace);
     });
   });
 
@@ -553,21 +551,6 @@ describe('cfApi', function() {
       expect(stub).toHaveBeenCalledOnce();
       let actual = stub.getCall(0).args[0];
       expect(actual).toMatch(new RegExp('spaces'));
-    });
-
-    it('calls spaceActions.receivedSpaces action', function (done) {
-      const stub = sandbox.stub(http, 'get');
-      const actionSpy = sandbox.spy(spaceActions, 'receivedSpaces');
-      const expected = wrapInRes([{ guid: 'fake-guid-one' }]);
-      let testPromise = createPromise({ data: { resources: expected } });
-      stub.returns(testPromise);
-
-      cfApi.fetchSpaces().then(() => {
-        const args = actionSpy.getCall(0).args[0];
-        expect(args).toEqual(unwrapOfRes(expected));
-        expect(actionSpy).toHaveBeenCalledOnce();
-        done();
-      });
     });
   });
 

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -9,7 +9,6 @@ import loginActions from '../actions/login_actions.js';
 import orgActions from '../actions/org_actions.js';
 import quotaActions from '../actions/quota_actions.js';
 import routeActions from '../actions/route_actions.js';
-import spaceActions from '../actions/space_actions.js';
 import serviceActions from '../actions/service_actions.js';
 import userActions from '../actions/user_actions.js';
 
@@ -47,7 +46,9 @@ export default {
     return resources.map((r) => this.formatSplitResponse(r));
   },
 
-  fetch(url, action, multiple, ...params) {
+  fetch(url, _action, multiple, ...params) {
+    // Set a default noop action handler
+    const action = typeof _action === 'function' ? _action : () => {};
     return http.get(APIV + url).then((res) => {
       let data;
       if (!multiple) {
@@ -179,18 +180,15 @@ export default {
   },
 
   fetchSpaces() {
-    return http.get(`${APIV}/spaces`).then((res) => {
-      const spaces = this.formatSplitResponses(res.data.resources);
-      spaceActions.receivedSpaces(spaces);
-      return spaces;
-    }).catch((err) => {
+    return http.get(`${APIV}/spaces`).then(res =>
+      this.formatSplitResponses(res.data.resources)
+    ).catch((err) => {
       handleError(err);
     });
   },
 
   fetchSpace(spaceGuid) {
-    return this.fetchOne(`/spaces/${spaceGuid}/summary`,
-                         spaceActions.receivedSpace);
+    return this.fetchOne(`/spaces/${spaceGuid}/summary`);
   },
 
   fetchSpaceEvents(spaceGuid) {


### PR DESCRIPTION
With this PR I'm introducing some new guidelines about handling async state between components, actions, and stores.
- Each action creator (each method in `*_actions.js`)  should dispatch only
  a single action.
- Any XHR calls should happen within the fetch action creators which
  should return a promise of the request.
- Any `fetch` action should call the appropriate `receive`/`success`/`error` action on the resolve of the fetch's promise.
- Each async action should have a fetch, success, and error sub-action (e.g.
  `TOGGLE`, `TOGGLE_SUCCESS`, and `TOGGLE_ERROR`).

I've refactored the SpaceActions and SpaceStore to follow these principles (minus the error action). The org toggle action follows the fetch/success/error principle.

I feel like with these rules, it's a little more clear on how to manage async state. Fetch actions attach the success/error to the request promise. Success/error actions only fire the actions.

I've also removed the extra loading state from the SpaceQuicklook. Since the toggle is what controls the loading, the Org quicklook needs to conditionally render the Loading or SpaceQuicklook.

**Remaining work**
- [x] account for loading state on the space page, which was formerly wrapped into the space quicklook
- [ ] display the error in the UI