### PR TITLE
Work-around Session Filestore fallback bug

### DIFF
--- a/helpers/settings.go
+++ b/helpers/settings.go
@@ -120,6 +120,9 @@ func (s *Settings) InitSettings(envVars EnvVars, env *cfenv.App) error {
 		store.MaxLength(4096 * 4)
 		store.Options = &sessions.Options{
 			HttpOnly: true,
+			// TODO remove this; work-around for
+			// https://github.com/gorilla/sessions/issues/96
+			MaxAge: 60 * 60 * 24 * 7,
 			Secure:   s.SecureCookies,
 		}
 		s.Sessions = store

--- a/helpers/settings.go
+++ b/helpers/settings.go
@@ -123,7 +123,7 @@ func (s *Settings) InitSettings(envVars EnvVars, env *cfenv.App) error {
 			// TODO remove this; work-around for
 			// https://github.com/gorilla/sessions/issues/96
 			MaxAge: 60 * 60 * 24 * 7,
-			Secure:   s.SecureCookies,
+			Secure: s.SecureCookies,
 		}
 		s.Sessions = store
 	}


### PR DESCRIPTION
gorilla Session creation isn't handled correctly when MaxAge is unset. Work
around upstream bug[1] by explicitly setting MaxAge.

[1] https://github.com/gorilla/sessions/issues/96