### PR TITLE
Add test specific eslintrc

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,5 @@
-static_src/test/**/*.js
 static_src/tests.bundle.js
 test/**/*.js
-*.spec.jsx
 
 # Current exceptions. As you touch these files, you should fix the lint errors
 # and remove them from this list.
@@ -32,3 +30,43 @@ test/**/*.js
 /static_src/components/user_list.jsx
 /static_src/components/user_role_control.jsx
 /static_src/components/user_role_list_control.jsx
+/static_src/test/global_setup.js
+/static_src/test/server/api.js
+/static_src/test/server/authstatus.js
+/static_src/test/server/fixtures.js
+/static_src/test/server/server.js
+/static_src/test/unit/actions/activity_actions.spec.js
+/static_src/test/unit/actions/app_actions.spec.js
+/static_src/test/unit/actions/domain_actions.spec.js
+/static_src/test/unit/actions/org_actions.spec.js
+/static_src/test/unit/actions/quota_actions.spec.js
+/static_src/test/unit/actions/route_actions.spec.js
+/static_src/test/unit/actions/service_actions.spec.js
+/static_src/test/unit/actions/space_actions.spec.js
+/static_src/test/unit/actions/user_actions.spec.js
+/static_src/test/unit/helpers.js
+/static_src/test/unit/stores/activity_store.spec.js
+/static_src/test/unit/stores/app_store.spec.js
+/static_src/test/unit/stores/base_store.spec.js
+/static_src/test/unit/stores/domain_store.spec.js
+/static_src/test/unit/stores/login_store.spec.js
+/static_src/test/unit/stores/org_store.spec.js
+/static_src/test/unit/stores/quota_store.spec.js
+/static_src/test/unit/stores/route_store.spec.js
+/static_src/test/unit/stores/service_binding_store.spec.js
+/static_src/test/unit/stores/service_instance_store.spec.js
+/static_src/test/unit/stores/service_plan_store.spec.js
+/static_src/test/unit/stores/service_store.spec.js
+/static_src/test/unit/stores/space_store.spec.js
+/static_src/test/unit/stores/user_store.spec.js
+/static_src/test/unit/util/analytics.spec.js
+/static_src/test/unit/util/cf_api.spec.js
+/static_src/test/unit/util/format_bytes.spec.js
+/static_src/test/unit/util/format_date.spec.js
+/static_src/test/unit/util/health.spec.js
+/static_src/test/unit/util/loading_status.spec.js
+/static_src/test/unit/util/poll.spec.js
+/static_src/test/unit/util/uaa_api.spec.js
+/static_src/test/unit/util/url.spec.js
+/static_src/test/unit/util/validators.spec.js
+/static_src/test/webpack-karma-warnings-plugin.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-style": "cd node_modules/cloudgov-style && npm install && npm run build",
     "check-style": "/bin/bash -c '[[ $(npm ls cloudgov-style) =~ \"git://github.com\" ]] && npm run build-style || exit 0'",
     "clean": "rm -rf ./static/assets/*",
-    "lint": "eslint --ext .js --ext .jsx -c .eslintrc ./static_src",
+    "lint": "eslint --ext .js --ext .jsx ./static_src",
     "test": "npm run lint && karma start --single-run",
     "testing-server": "node ./static_src/test/server/server.js",
     "watch-server": "npm run testing-server & npm run watch",
@@ -96,5 +96,8 @@
     "url-loader": "^0.5.7",
     "watch": "^0.16.0",
     "webpack": "^1.14.0"
+  },
+  "devDependencies": {
+    "eslint-plugin-jasmine": "^2.2.0"
   }
 }

--- a/static_src/test/unit/.eslintrc
+++ b/static_src/test/unit/.eslintrc
@@ -1,0 +1,26 @@
+{
+  "extends": "plugin:jasmine/recommended",
+  "env": {
+    "jasmine": true
+  },
+  "globals": {
+    "sinon": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    },
+    "sourceType": "module"
+  },
+  "plugins": [
+    "jasmine"
+  ],
+  "rules": {
+    "comma-dangle": [2, "never"],
+    "func-names": [0, "always"],
+    "one-var": 0,
+    "one-var-declaration-per-line": 0,
+    "prefer-arrow-callback": 0
+  }
+}


### PR DESCRIPTION
Why should tests be excluded from linting?

This doesn't actually fix any of the linting issues, but just sets up the configuration for being able to lint tests. The policy is that if you touch a file, you should remove it from the ignore file and fix the lint errors.

The configuration isn't perfect. I tried picking rules that jived with the style that I see in the existing tests. We can tweak it as we go.