### PR TITLE
App start button

### DIFF
--- a/static_src/actions/app_actions.js
+++ b/static_src/actions/app_actions.js
@@ -75,6 +75,15 @@ export default {
     });
   },
 
+  start(appGuid) {
+    AppDispatcher.handleViewAction({
+      type: appActionTypes.APP_START,
+      appGuid
+    });
+
+    return cfApi.postAppRestart(appGuid).then(() => this.restarted(appGuid));
+  },
+
   restart(appGuid) {
     AppDispatcher.handleViewAction({
       type: appActionTypes.APP_RESTART,

--- a/static_src/actions/app_actions.js
+++ b/static_src/actions/app_actions.js
@@ -30,6 +30,8 @@ export default {
       appPartial,
       appGuid
     });
+
+    return cfApi.putApp(appGuid, appPartial).then((app) => this.updatedApp(app));
   },
 
   updatedApp(app) {
@@ -104,6 +106,7 @@ export default {
         (app) => app.data.running_instances > 0,
         cfApi.fetchAppStatus.bind(cfApi, appGuid)
       ).then((res) => {
+        this.fetchStats(appGuid);
         this.receivedApp(res.data);
       });
   },

--- a/static_src/actions/app_actions.js
+++ b/static_src/actions/app_actions.js
@@ -81,7 +81,8 @@ export default {
       appGuid
     });
 
-    return cfApi.postAppRestart(appGuid).then(() => this.restarted(appGuid));
+    return cfApi.putApp(appGuid, { state: 'STARTED' }).then(() =>
+      this.restarted(appGuid));
   },
 
   restart(appGuid) {

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -59,6 +59,7 @@ export default class AppContainer extends React.Component {
 
     this._onChange = this._onChange.bind(this);
     this._onRestart = this._onRestart.bind(this);
+    this._onStart = this._onStart.bind(this);
     this.styler = createStyler(style);
   }
 
@@ -80,6 +81,10 @@ export default class AppContainer extends React.Component {
 
   _onRestart() {
     appActions.restart(this.state.app.guid);
+  }
+
+  _onStart() {
+    appActions.start(this.state.app.guid);
   }
 
   get fullTitle() {
@@ -109,8 +114,20 @@ export default class AppContainer extends React.Component {
   }
 
   get restart() {
+    let action;
     let loading;
     let error;
+
+    let handler = this._onRestart;
+    let actionText = "Restart app";
+    if (!AppStore.isRunning(this.state.app)) {
+      handler = this._onStart;
+      actionText = "Start app";
+    }
+
+    if (AppStore.isStarting(this.state.app)) {
+      loading = <Loading text="Starting app" style="inline" />;
+    }
 
     if (AppStore.isRestarting(this.state.app)) {
       loading = <Loading text="Restarting app" style="inline" />;
@@ -126,17 +143,20 @@ export default class AppContainer extends React.Component {
       );
     }
 
+    action = loading ? loading : (
+      <Action
+        style="primary"
+        clickHandler={ handler }
+        label={ actionText }
+        type="outline"
+      >
+        <span>{ actionText }</span>
+      </Action>
+    );
+
     return (
       <div>
-        <Action
-          style="primary"
-          clickHandler={ this._onRestart }
-          label="restart app"
-          disabled={ !AppStore.isRunning(this.state.app) }
-          type="outline"
-        >
-          <span>Restart app</span>
-        </Action>
+        { action }
         { error }
         { loading }
       </div>

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -119,10 +119,10 @@ export default class AppContainer extends React.Component {
     let error;
 
     let handler = this._onRestart;
-    let actionText = "Restart app";
+    let actionText = 'Restart app';
     if (!AppStore.isRunning(this.state.app)) {
       handler = this._onStart;
-      actionText = "Start app";
+      actionText = 'Start app';
     }
 
     if (AppStore.isStarting(this.state.app)) {
@@ -143,7 +143,7 @@ export default class AppContainer extends React.Component {
       );
     }
 
-    action = loading ? loading : (
+    action = loading || (
       <Action
         style="primary"
         clickHandler={ handler }

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -158,7 +158,6 @@ export default class AppContainer extends React.Component {
       <div>
         { action }
         { error }
-        { loading }
       </div>
     );
   }

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -9,6 +9,7 @@ const appStates = {
   restarting: 'RESTARTING',
   running: 'RUNNING',
   started: 'STARTED',
+  starting: 'STARTING',
   stopped: 'STOPPED',
   default: 'STOPPED'
 };

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -162,6 +162,10 @@ const appActionTypes = keymirror({
   APP_ALL_RECEIVED: null,
   // Action when user views a different app
   APP_CHANGE_CURRENT: null,
+  // Action when starting an app.
+  APP_START: null,
+  // Action when request to start app completed on server.
+  APP_STARTED: null,
   // Action when restarting an app.
   APP_RESTART: null,
   // Action when app restarted on server.

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -107,6 +107,18 @@ class AppStore extends BaseStore {
         break;
       }
 
+      case appActionTypes.APP_START: {
+        const app = this.get(action.appGuid);
+        if (app) {
+          const startingApp = Object.assign({}, app,
+            { state: appStates.starting });
+          this.merge('guid', startingApp, (changed) => {
+            if (changed) this.emitChange();
+          });
+        }
+        break;
+      }
+
       case appActionTypes.APP_RESTART: {
         const app = this.get(action.appGuid);
         if (app) {

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -108,7 +108,6 @@ class AppStore extends BaseStore {
       }
 
       case appActionTypes.APP_RESTART: {
-        cfApi.postAppRestart(action.appGuid);
         const app = this.get(action.appGuid);
         if (app) {
           const restartingApp = Object.assign({}, app,
@@ -121,12 +120,6 @@ class AppStore extends BaseStore {
       }
 
       case appActionTypes.APP_RESTARTED: {
-        this.poll(
-          (app) => app.data.running_instances > 0,
-          cfApi.fetchAppStatus.bind(cfApi, action.appGuid)
-        ).then((res) => {
-          this.merge('guid', res.data);
-        });
         break;
       }
 

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -19,6 +19,10 @@ class AppStore extends BaseStore {
     this.subscribe(() => this._registerToActions.bind(this));
   }
 
+  isStarting(app) {
+    return app.state === appStates.starting;
+  }
+
   isRestarting(app) {
     return app.state === appStates.restarting;
   }

--- a/static_src/stores/app_store.js
+++ b/static_src/stores/app_store.js
@@ -46,7 +46,6 @@ class AppStore extends BaseStore {
         const existingApp = this.get(action.appGuid);
         const updatedApp = Object.assign({}, existingApp, { updating: true });
         this.merge('guid', updatedApp);
-        cfApi.putApp(action.appGuid, action.appPartial);
         break;
       }
 

--- a/static_src/test/unit/actions/app_actions.spec.js
+++ b/static_src/test/unit/actions/app_actions.spec.js
@@ -130,7 +130,7 @@ describe('appActions', function() {
   describe('start()', function() {
     it('should dispatch a view event of type app start with guid', function() {
       sandbox.stub(appActions, 'restarted').returns(Promise.resolve());
-      sandbox.stub(cfApi, 'postAppRestart').returns(Promise.resolve());
+      sandbox.stub(cfApi, 'putApp').returns(Promise.resolve());
       const appGuid = 'zzcvxkadsf';
       const expectedParams = {
         appGuid
@@ -142,13 +142,13 @@ describe('appActions', function() {
       assertAction(spy, appActionTypes.APP_START, expectedParams);
     });
 
-    it('should call cf api post to restart the app', function(done) {
-      const spy = sandbox.stub(cfApi, 'postAppRestart').returns(Promise.resolve());
+    it('should call cf api put app with state started to restart the app',
+        function(done) {
+      const spy = sandbox.stub(cfApi, 'putApp').returns(Promise.resolve());
       sandbox.stub(appActions, 'restarted').returns(Promise.resolve());
       const expectedGuid = 'asdfasd2vdamcdksa';
 
       appActions.start(expectedGuid).then(() => {
-        console.log('HEEEERRREEEE');
         expect(spy).toHaveBeenCalledOnce();
         let arg = spy.getCall(0).args[0];
         expect(arg).toEqual(expectedGuid);

--- a/static_src/test/unit/actions/app_actions.spec.js
+++ b/static_src/test/unit/actions/app_actions.spec.js
@@ -6,6 +6,8 @@ import { assertAction, setupUISpy, setupViewSpy, setupServerSpy } from '../helpe
 import cfApi from '../../../util/cf_api.js';
 import appActions from '../../../actions/app_actions.js';
 import { appActionTypes } from '../../../constants.js';
+import poll from '../../../util/poll.js';
+import * as pollUtil from '../../../util/poll.js';
 
 describe('appActions', function() {
   var sandbox;
@@ -137,6 +139,17 @@ describe('appActions', function() {
 
       assertAction(spy, appActionTypes.APP_RESTART, expectedParams);
     });
+
+    it('should call cf api post to restart the app', function() {
+      const spy = sandbox.spy(cfApi, 'postAppRestart');
+      const expectedGuid = 'asdfasd2vdamcdksa';
+
+      appActions.restart(expectedGuid);
+
+      expect(spy).toHaveBeenCalledOnce();
+      let arg = spy.getCall(0).args[0];
+      expect(arg).toEqual(expectedGuid);
+    });
   });
 
   describe('restarted()', function() {
@@ -150,6 +163,21 @@ describe('appActions', function() {
       appActions.restarted(appGuid);
 
       assertAction(spy, appActionTypes.APP_RESTARTED, expectedParams);
+    });
+
+    it('should poll until running instances is greater then 0', function() {
+      const spy = sandbox.stub(pollUtil, 'default').returns(Promise.resolve());
+      const expectedRes = {
+        data: { running_instances: 1 }
+      };
+
+      appActions.restarted('zxlcvkjklv');
+
+      expect(spy).toHaveBeenCalledOnce();
+      let args = spy.getCall(0).args;
+      expect(args[0]).toBeFunction();
+      expect(args[0](expectedRes)).toBeTruthy();
+      expect(args[1]).toBeFunction();
     });
   });
 

--- a/static_src/test/unit/actions/app_actions.spec.js
+++ b/static_src/test/unit/actions/app_actions.spec.js
@@ -127,6 +127,58 @@ describe('appActions', function() {
     });
   });
 
+  describe('updateApp()', function() {
+    it('should dispatch a view event of type app update with partial and guid',
+        function(done) {
+      sandbox.stub(appActions, 'updatedApp').returns(Promise.resolve());
+      sandbox.stub(cfApi, 'putApp').returns(Promise.resolve());
+      const appGuid = 'zxc,vnadsfj';
+      const appPartial = { mem: 123 };
+      const expectedParams = {
+        appGuid,
+        appPartial
+      };
+
+      let spy = setupViewSpy(sandbox);
+
+      appActions.updateApp(appGuid, appPartial).then(function() {
+        assertAction(spy, appActionTypes.APP_UPDATE,
+                     expectedParams)
+        done();
+      }).catch(done.fail);
+    });
+
+    it('should call cf api put app endpoint with guid and app partial',
+        function(done) {
+      const appGuid = 'zxc,vnadsfj';
+      const appPartial = { mem: 123 };
+      const spy = sandbox.stub(cfApi, 'putApp').returns(Promise.resolve());
+      sandbox.stub(appActions, 'updatedApp').returns(Promise.resolve());
+
+      appActions.updateApp(appGuid, appPartial).then(function() {
+        expect(spy).toHaveBeenCalledOnce();
+        let args = spy.getCall(0).args;
+        expect(args[0]).toEqual(appGuid);
+        expect(args[1]).toEqual(appPartial);
+        done();
+      }).catch(done.fail);
+    });
+
+    it('should call updated app action with app on success', function(done) {
+      const spy = sandbox.stub(appActions, 'updatedApp').returns(Promise.resolve());
+      const guid = '134ds3i4yzxvc';
+      const expectedApp = { guid, mem: 1034 };
+      sandbox.stub(cfApi, 'putApp').returns(Promise.resolve(expectedApp));
+
+      appActions.updateApp(guid).then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let arg = spy.getCall(0).args[0];
+        expect(arg).toEqual(expectedApp);
+        done();
+      }).catch(done.fail);
+    });
+  });
+
   describe('start()', function() {
     it('should dispatch a view event of type app start with guid', function() {
       sandbox.stub(appActions, 'restarted').returns(Promise.resolve());

--- a/static_src/test/unit/actions/app_actions.spec.js
+++ b/static_src/test/unit/actions/app_actions.spec.js
@@ -127,6 +127,48 @@ describe('appActions', function() {
     });
   });
 
+  describe('start()', function() {
+    it('should dispatch a view event of type app start with guid', function() {
+      sandbox.stub(appActions, 'restarted').returns(Promise.resolve());
+      sandbox.stub(cfApi, 'postAppRestart').returns(Promise.resolve());
+      const appGuid = 'zzcvxkadsf';
+      const expectedParams = {
+        appGuid
+      };
+      let spy = setupViewSpy(sandbox)
+
+      appActions.start(appGuid);
+
+      assertAction(spy, appActionTypes.APP_START, expectedParams);
+    });
+
+    it('should call cf api post to restart the app', function(done) {
+      const spy = sandbox.stub(cfApi, 'postAppRestart').returns(Promise.resolve());
+      sandbox.stub(appActions, 'restarted').returns(Promise.resolve());
+      const expectedGuid = 'asdfasd2vdamcdksa';
+
+      appActions.start(expectedGuid).then(() => {
+        console.log('HEEEERRREEEE');
+        expect(spy).toHaveBeenCalledOnce();
+        let arg = spy.getCall(0).args[0];
+        expect(arg).toEqual(expectedGuid);
+        done();
+      }).catch(done.fail);
+    });
+
+    it('should call restarted with guid on success of request', function(done) {
+      const spy = sandbox.stub(appActions, 'restarted').returns(Promise.resolve());
+      const expectedGuid = 'znxmcv23i4yzxvc';
+
+      appActions.start(expectedGuid).then(() => {
+        expect(spy).toHaveBeenCalledOnce();
+        let arg = spy.getCall(0).args[0];
+        expect(arg).toEqual(expectedGuid);
+        done();
+      }).catch(done.fail);
+    });
+  });
+
   describe('restart()', function() {
     it('should dispatch a view event of type app restart with guid', function() {
       const appGuid = 'zvmn3hkl';

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -232,17 +232,6 @@ describe('AppStore', function() {
   });
 
   describe('on app restart', function() {
-    it('should call cf api to restart the app with guid', function() {
-      const spy = sandbox.spy(cfApi, 'postAppRestart');
-      const expectedGuid = 'asdfasd2vdamcdksa';
-
-      appActions.restart(expectedGuid);
-
-      expect(spy).toHaveBeenCalledOnce();
-      let arg = spy.getCall(0).args[0];
-      expect(arg).toEqual(expectedGuid);
-    });
-
     it('should set app "state" to "restarting"', function() {
       const appGuid = 'zkvkljsf';
       const app = { guid: appGuid, state: 'RUNNING' };
@@ -267,20 +256,7 @@ describe('AppStore', function() {
   });
 
   describe('on app restarted', function() {
-    it('should poll until running instances is greater then 0', function() {
-      const spy = sandbox.stub(AppStore, 'poll').returns(Promise.resolve());
-      const expectedRes = {
-        data: { running_instances: 1 }
-      };
-
-      appActions.restarted('zxlcvkjklv');
-
-      expect(spy).toHaveBeenCalledOnce();
-      let args = spy.getCall(0).args;
-      expect(args[0]).toBeFunction();
-      expect(args[0](expectedRes)).toBeTruthy();
-      expect(args[1]).toBeFunction();
-    });
+    // TODO still needed?
   });
 
   describe('on app update', function () {

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -231,6 +231,30 @@ describe('AppStore', function() {
     });
   });
 
+  describe('on app start', function() {
+    it('should set app "state" to "starting"', function() {
+      const appGuid = 'zkvkljsf';
+      const app = { guid: appGuid, state: 'STOPPED' };
+      AppStore.push(app);
+
+      appActions.start(appGuid);
+
+      const actual = AppStore.get(appGuid);
+      expect(actual.state).toEqual('STARTING');
+    });
+
+    it('should emit a change', function() {
+      const appGuid = 'zkvkljsf';
+      const app = { guid: appGuid, state: 'STOPPED' };
+      AppStore.push(app);
+      const spy = sandbox.spy(AppStore, 'emitChange');
+
+      appActions.start(appGuid);
+
+      expect(spy).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('on app restart', function() {
     it('should set app "state" to "restarting"', function() {
       const appGuid = 'zkvkljsf';

--- a/static_src/test/unit/stores/app_store.spec.js
+++ b/static_src/test/unit/stores/app_store.spec.js
@@ -285,24 +285,11 @@ describe('AppStore', function() {
 
   describe('on app update', function () {
     let putApp;
+
     beforeEach(function () {
       putApp = sandbox.stub(cfApi, 'putApp');
       AppStore.push({ guid: '1234', instances: 2, memory: 128 });
       appActions.updateApp('1234', { instances: 3 });
-    });
-
-    it('calls api with guid', function () {
-      expect(putApp).toHaveBeenCalledOnce();
-
-      const [guid, app] = putApp.args[0];
-      expect(guid).toBe('1234');
-    });
-
-    it('calls api with partial app', function () {
-      const [guid, app] = putApp.args[0];
-
-      expect(app.memory).toBeFalsy();
-      expect(app.instances).toBe(3);
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -838,21 +838,6 @@ describe('cfApi', function() {
       }).catch(done.fail);
     });
 
-    it('should call app restarted with app guid on success', function(done) {
-      const appGuid = '2398dhgf028ulfd';
-      const stub = sandbox.stub(http, 'post');
-      const spy = sandbox.stub(appActions, 'restarted');
-      spy.returns();
-      stub.returns(createPromise({response: 'success'}));
-
-      cfApi.postAppRestart(appGuid).then(() => {
-        expect(spy).toHaveBeenCalledOnce();
-        const arg = spy.getCall(0).args[0];
-        expect(arg).toEqual(appGuid);
-        done();
-      }).catch(done.fail);
-    });
-
     it('should call app error with app guid on failure', function(done) {
       const appGuid = '2398dhgf028ulfd';
       const spy = sandbox.stub(appActions, 'error');

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -855,20 +855,17 @@ describe('cfApi', function() {
   });
 
   describe('putApp()', function() {
-    it('calls apps endpoint with guid', function (done) {
+    it('returns mapped app from the response', function (done) {
       const put = sandbox.stub(http, 'put', (url, app) => {
         return createPromise({data: {entity: app}});
       });
-      const updatedSpy = sandbox.spy(appActions, 'updatedApp');
       const expectedApp = {guid: '123'};
 
       cfApi.putApp(expectedApp.guid, expectedApp)
         .then(function () {
-          console.log(put.args);
           let [url, app] = put.args[0];
           expect(url).toMatch(new RegExp('/v2/apps/123$'));
           expect(app).toEqual(expectedApp);
-          expect(updatedSpy).toHaveBeenCalledOnce();
           done();
         }).catch(done.fail);
     });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -278,7 +278,7 @@ export default {
 
   postAppRestart(appGuid) {
     return http.post(`${APIV}/apps/${appGuid}/restage`).then(() => {
-      appActions.restarted(appGuid);
+      return appGuid;
     }).catch((err) => handleError(err,
       appActions.error.bind(this, appGuid)));
   },

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -269,8 +269,7 @@ export default {
   putApp(appGuid, app) {
     return http.put(`${APIV}/apps/${appGuid}`, app)
       .then((res) => {
-        const updatedApp = Object.assign({}, res.data.entity, { guid: appGuid });
-        appActions.updatedApp(updatedApp);
+        return Object.assign({}, res.data.entity, { guid: appGuid });
       })
       .catch((err) => handleError(err,
         appActions.error.bind(null, appGuid)));

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -268,17 +268,14 @@ export default {
 
   putApp(appGuid, app) {
     return http.put(`${APIV}/apps/${appGuid}`, app)
-      .then((res) => {
-        return Object.assign({}, res.data.entity, { guid: appGuid });
-      })
+      .then((res) => Object.assign({}, res.data.entity, { guid: appGuid }))
       .catch((err) => handleError(err,
         appActions.error.bind(null, appGuid)));
   },
 
   postAppRestart(appGuid) {
-    return http.post(`${APIV}/apps/${appGuid}/restage`).then(() => {
-      return appGuid;
-    }).catch((err) => handleError(err,
+    return http.post(`${APIV}/apps/${appGuid}/restage`).then(() => appGuid
+    ).catch((err) => handleError(err,
       appActions.error.bind(this, appGuid)));
   },
 


### PR DESCRIPTION
This adds a start button to the app page when the app isn't started yet, rather then just the restart button.

Uses the new method of moving cf api calls to the actions code. In this PR, it makes it easier to coordinate various actions calling each other but not dispatching an event until everything makes sense.

This code fixes a small UI issue which existed before, and is not required for code to be merged: https://github.com/18F/cg-style/pull/290.