### PR TITLE
Add PageStore to handle initial data loading

### DIFF
--- a/static_src/actions/page_actions.js
+++ b/static_src/actions/page_actions.js
@@ -1,0 +1,29 @@
+
+import AppDispatcher from '../dispatcher.js';
+import { pageActionTypes } from '../constants.js';
+
+export default {
+  load() {
+    AppDispatcher.handleViewAction({
+      type: pageActionTypes.PAGE_LOAD_STARTED
+    });
+
+    return Promise.resolve();
+  },
+
+  loadSuccess() {
+    AppDispatcher.handleViewAction({
+      type: pageActionTypes.PAGE_LOAD_SUCCESS
+    });
+
+    return Promise.resolve();
+  },
+
+  loadError() {
+    AppDispatcher.handleViewAction({
+      type: pageActionTypes.PAGE_LOAD_ERROR
+    });
+
+    return Promise.resolve();
+  }
+};

--- a/static_src/actions/space_actions.js
+++ b/static_src/actions/space_actions.js
@@ -47,6 +47,8 @@ export default {
       type: spaceActionTypes.SPACE_RECEIVED,
       space
     });
+
+    return Promise.resolve(space);
   },
 
   receivedSpaces(spaces) {
@@ -54,6 +56,8 @@ export default {
       type: spaceActionTypes.SPACES_RECEIVED,
       spaces
     });
+
+    return Promise.resolve(spaces);
   },
 
   changeCurrentSpace(spaceGuid) {
@@ -61,5 +65,7 @@ export default {
       type: spaceActionTypes.SPACE_CHANGE_CURRENT,
       spaceGuid
     });
+
+    return Promise.resolve(spaceGuid || null);
   }
 };

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -10,6 +10,7 @@ import Loading from './loading.jsx';
 import OrgQuicklook from './org_quicklook.jsx';
 import OrgStore from '../stores/org_store.js';
 import PageHeader from './page_header.jsx';
+import PageStore from '../stores/page_store.js';
 import Panel from './panel.jsx';
 import PanelGroup from './panel_group.jsx';
 import PanelRow from './panel_row.jsx';
@@ -21,8 +22,8 @@ function stateSetter() {
   const spaces = SpaceStore.getAll() || [];
 
   return {
-    empty: !OrgStore.loading && !SpaceStore.loading && !orgs.length,
-    loading: OrgStore.loading || SpaceStore.loading,
+    empty: !PageStore.loading && !orgs.length,
+    loading: PageStore.loading,
     orgs: orgs.sort((a, b) => a.name.localeCompare(b.name)),
     spaces
   };
@@ -38,11 +39,13 @@ export default class OverviewContainer extends React.Component {
 
   componentDidMount() {
     OrgStore.addChangeListener(this._onChange);
+    PageStore.addChangeListener(this._onChange);
     SpaceStore.addChangeListener(this._onChange);
   }
 
   componentWillUnmount() {
     OrgStore.removeChangeListener(this._onChange);
+    PageStore.removeChangeListener(this._onChange);
     SpaceStore.removeChangeListener(this._onChange);
   }
 

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -41,6 +41,15 @@ const loginActionTypes = keymirror({
   RECEIVED_STATUS: null
 });
 
+const pageActionTypes = keymirror({
+  // When a browser page starts loading e.g. during navigation
+  PAGE_LOAD_STARTED: null,
+  // All data for rendering the page has loaded successfully
+  PAGE_LOAD_SUCCESS: null,
+  // An error occurred when loading the page
+  PAGE_LOAD_ERROR: null
+});
+
 const quotaActionTypes = keymirror({
   // Action of fetching quotas for all organizations
   ORGS_QUOTAS_FETCH: null,
@@ -273,6 +282,7 @@ export {
   errorActionTypes,
   loginActionTypes,
   orgActionTypes,
+  pageActionTypes,
   quotaActionTypes,
   routeActionTypes,
   spaceActionTypes,

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -18,6 +18,7 @@ import MainContainer from './components/main_container.jsx';
 import orgActions from './actions/org_actions.js';
 import Overview from './components/overview_container.jsx';
 import OrgContainer from './components/org_container.jsx';
+import pageActions from './actions/page_actions.js';
 import quotaActions from './actions/quota_actions.js';
 import routeActions from './actions/route_actions.js';
 import spaceActions from './actions/space_actions.js';
@@ -41,18 +42,26 @@ function login() {
 }
 
 function overview() {
+  pageActions.load();
+
   // Reset the state
   orgActions.changeCurrentOrg();
   spaceActions.changeCurrentSpace();
   appActions.changeCurrentApp();
 
-  cfApi.fetchSpaces().then((spaces) => {
-    let i = 0;
-    const max = Math.min(MAX_OVERVIEW_SPACES, spaces.length);
-    for (; i < max; i++) {
-      spaceActions.fetch(spaces[i].guid);
-    }
-  });
+  spaceActions.fetchAll()
+    .then(spaces => {
+      let i = 0;
+      const max = Math.min(MAX_OVERVIEW_SPACES, spaces.length);
+      const fetches = [];
+      for (; i < max; i++) {
+        fetches.push(spaceActions.fetch(spaces[i].guid));
+      }
+
+      return Promise.all(fetches);
+    })
+    .then(pageActions.loadSuccess, pageActions.loadError);
+
   ReactDOM.render(<MainContainer>
     <Overview />
   </MainContainer>, mainEl);

--- a/static_src/stores/page_store.js
+++ b/static_src/stores/page_store.js
@@ -1,0 +1,37 @@
+
+import BaseStore from './base_store.js';
+import { pageActionTypes } from '../constants.js';
+
+class PageStore extends BaseStore {
+  constructor() {
+    super();
+    this._loading = false;
+    this.subscribe(() => this._registerToActions.bind(this));
+  }
+
+  get loading() {
+    return this._loading;
+  }
+
+  _registerToActions(action) {
+    switch (action.type) {
+      case pageActionTypes.PAGE_LOAD_STARTED: {
+        this._loading = true;
+        this.emitChange();
+        break;
+      }
+
+      case pageActionTypes.PAGE_LOAD_ERROR:
+      case pageActionTypes.PAGE_LOAD_SUCCESS: {
+        this._loading = false;
+        this.emitChange();
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+}
+
+export default new PageStore();


### PR DESCRIPTION
Fixes https://github.com/18F/cg-dashboard/issues/869

The problem is that when we cascade fetches (fetch all spaces, then fetch individual space details), there is a small gap between these where the state of the stores is not loading, so the loading indicator disappears, then a moment later re-appears. By explicitly controlling the state from the route via a new `PageStore` and `pageActions`, we can be sure the loading state doesn't change until we really want  it to.

I didn't add this to all the routes yet, wanted to get this bug fixed first.