### PR TITLE
Copy updates for dashboard components

### DIFF
--- a/static_src/components/activity_log.jsx
+++ b/static_src/components/activity_log.jsx
@@ -85,7 +85,7 @@ export default class ActivityLog extends React.Component {
         );
       content = (
         <div>
-          <p>View advanced logs at <a href="https://logs.cloud.gov">logs.cloud.gov</a></p>
+          <p>View more logs at <a href="https://logs.cloud.gov">logs.cloud.gov</a> (for East/West environment) or <a href="https://logs.fr.cloud.gov">logs.fr.cloud.gov</a> (for GovCloud environment).</p>
           <ul className={ this.styler('activity_log') }>
             { this.state.activity
                 .slice(0, this.state.maxItems)

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -186,7 +186,7 @@ export default class AppContainer extends React.Component {
             </div>
           </div>
           <Panel title="Usage and allocation">
-              <span>View more usage data at <a href="https://logs.cloud.gov">logs.cloud.gov</a></span>
+              <span>View more usage data at <a href="https://logs.cloud.gov">logs.cloud.gov</a> (for East/West environment) or <a href="https://logs.fr.cloud.gov">logs.fr.cloud.gov</a> (for GovCloud environment).</span>
             <UsageLimits app={ this.state.app } quota={ this.state.quota } />
           </Panel>
 

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -105,7 +105,7 @@ export default class CreateServiceInstance extends React.Component {
     } else if (this.state.createdTempNotification) {
       createAction = (
         <span className={ this.styler('status', 'status-ok') }>
-          Created! Find your instance in the service instances panel
+          Created! To bind the service instance to an app, go to an application page and use the services panel.
         </span>
       );
     }
@@ -145,9 +145,6 @@ export default class CreateServiceInstance extends React.Component {
             validator={ this.validateString }
           />
           { createAction }
-          <p><em>
-            After you create a service instance, you can look at your space to check whether your service instance was created. (<a href="https://github.com/18F/cg-dashboard/issues/457">We’ll make this better.</a>) Then you can bind the service instance to an app <a href="https://docs.cloud.gov/apps/managed-services/">using the command line</a>.
-          </em></p>
                                                                                                                                        <Action label="cancel" style="base" type="outline"
               clickHandler={ this._onCancelForm.bind(this) }>
             Cancel

--- a/static_src/components/info_activities.jsx
+++ b/static_src/components/info_activities.jsx
@@ -15,11 +15,12 @@ export default class InfoActivities extends React.Component {
       <section className={ this.props.className }>
         <h4>A few things you can do here</h4>
         <ul>
-          <li>See recent activity (log events) for your apps.</li>
-          <li>Manage permissions for users of your orgs and spaces.</li>
-          <li>Create and bind service instances for your spaces.</li>
+          <li>See recent log events for your apps.</li>
+          <li>Create and bind service instances for your apps.</li>
           <li>Create and bind routes for your apps.</li>
-
+          <li>Change memory allocation and number of instances for your apps.</li>
+          <li>Restart your apps.</li>
+          <li>Manage permissions for users of your orgs and spaces.</li>
         </ul>
       </section>
     );

--- a/static_src/components/info_environments.jsx
+++ b/static_src/components/info_environments.jsx
@@ -14,7 +14,7 @@ export default class InfoEnvironment extends React.Component {
     return (
       <section className={ this.props.className }>
         <h4>Environments</h4>
-        <p>If your org <a href="https://docs.cloud.gov/apps/govcloud/">is in GovCloud</a>, use <a href="https://dashboard.fr.cloud.gov/">https://dashboard.fr.cloud.gov/</a> to see it.</p>
+        <p>If your org <a href="https://cloud.gov/docs/apps/govcloud/">is in GovCloud</a>, use <a href="https://dashboard.fr.cloud.gov/">https://dashboard.fr.cloud.gov/</a> to see it.</p>
       </section>
     );
   }

--- a/static_src/components/info_sandbox.jsx
+++ b/static_src/components/info_sandbox.jsx
@@ -14,7 +14,7 @@ export default class InfoSandbox extends React.Component {
     return (
       <section className={ this.props.className }>
         <h4>Looking at an empty sandbox?</h4>
-        <p><a href="https://docs.cloud.gov/getting-started/your-first-deploy/">Try making a “hello world” app</a>.</p>
+        <p><a href="https://cloud.gov/docs/getting-started/your-first-deploy/">Try making a “hello world” app</a>.</p>
       </section>
     );
   }

--- a/static_src/components/info_structure.jsx
+++ b/static_src/components/info_structure.jsx
@@ -15,11 +15,11 @@ export default class InfoStructure extends React.Component {
       <section className={ this.props.className }>
         <h4>Basic cloud.gov structure</h4>
         <ul>
-          <li><strong>Organization:</strong> Each org is a <a href="https://docs.cloud.gov/intro/terminology/pricing-terminology/">system</a> (<a href="https://docs.cloud.gov/getting-started/concepts/">shared perimeter</a>) that contains <a href="https://docs.cloud.gov/intro/pricing/system-stuffing/">related spaces holding related applications</a>.
+          <li><strong>Organization:</strong> Each org is a <a href="https://cloud.gov/overview/terminology/pricing-terminology/#system">system</a> (<a href="https://cloud.gov/docs/getting-started/concepts/#organizations">shared perimeter</a>) that contains <a href="https://cloud.gov/overview/pricing/system-stuffing/">related spaces holding related applications</a>.
           </li>
-          <li><strong>Spaces:</strong> Within an org, your <a href="https://docs.cloud.gov/getting-started/concepts/">spaces</a> provide environments for applications (<a href="https://docs.cloud.gov/intro/overview/using-cloudgov-paas/">example use</a>).
+          <li><strong>Spaces:</strong> Within an org, your <a href="https://cloud.gov/docs/getting-started/concepts/#spaces">spaces</a> provide environments for applications (<a href="https://cloud.gov/overview/overview/using-cloudgov-paas/">example use</a>).
           </li>
-          <li><strong>Marketplace:</strong> Use your org’s <a href="https://docs.cloud.gov/apps/managed-services/">marketplace</a> to create <a href="https://docs.cloud.gov/intro/pricing/rates/">service instances</a> for spaces in that org.
+          <li><strong>Marketplace:</strong> Use your org’s <a href="https://cloud.gov/docs/apps/managed-services/">marketplace</a> to create <a href="https://cloud.gov/docs/services/">service</a> instances for spaces in that org.
           </li>
         </ul>
       </section>

--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -80,7 +80,7 @@ export default class Marketplace extends React.Component {
       content = (
         <div>
           <div>
-            <p className={ this.styler('page-dek') }>Use this marketplace to create service instances for spaces in this org. Then bind service instances to apps using the command line. <a href="https://docs.cloud.gov/apps/managed-services/">Learn about using service instances and marketplaces</a>.</p>
+            <p className={ this.styler('page-dek') }>Use this marketplace to create service instances for spaces in this org. Then bind service instances to apps. <a href="https://cloud.gov/docs/apps/managed-services/">Learn about using service instances</a>.</p>
           </div>
           { list }
           { form }

--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -80,7 +80,7 @@ export default class Marketplace extends React.Component {
       content = (
         <div>
           <div>
-            <p className={ this.styler('page-dek') }>Use this marketplace to create service instances for spaces in this org. Then bind service instances to apps. <a href="https://cloud.gov/docs/apps/managed-services/">Learn about using service instances</a>.</p>
+            <p className={ this.styler('page-dek') }>Use this marketplace to create service instances for apps in this space. Then bind service instances to apps. <a href="https://cloud.gov/docs/apps/managed-services/">Learn about using service instances</a>.</p>
           </div>
           { list }
           { form }

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -68,21 +68,9 @@ export default class UserList extends React.Component {
       content = (
       <div>
         <p><em>
-        { this.userTypePretty } Managers can change these roles. For details about these roles, see <a href="https://docs.cloudfoundry.org/concepts/roles.html#roles">Cloud Foundry roles and permissions</a>. To invite a new user or change a role, see <a href="https://docs.cloud.gov/apps/managing-teammates/">Managing Teammates</a>.
+        { this.userTypePretty } Managers can change these roles. For details about these roles, see <a href="https://docs.cloudfoundry.org/concepts/roles.html#roles">Cloud Foundry roles and permissions</a>. To invite a user and give them roles, see <a href="https://cloud.gov/docs/apps/managing-teammates/">Managing Teammates</a>.
         </em></p>
 
-        <p><em><strong>To add or remove a role:</strong><br />
-          Only { this.userTypePretty } Managers have permission to change these roles. To change a role, click a checkbox and wait a moment for the request to process, then see what happens:
-        </em></p>
-        <ul>
-          <li><em>If you tried adding a role and this was successful, the checkbox will become checked (and you won’t get an error message).</em></li>
-          <li><em>If you tried adding a role but didn’t have permission, the checkbox won’t update.</em></li>
-          <li><em>If you tried removing a role and this was successful, the checkbox will become unchecked (and you won’t get an error message).</em></li>
-          <li><em>If you tried removing a role but didn’t have permission, the checkbox will become unchecked and you’ll get an error message (“You are not authorized to perform the requested action”).</em></li>
-        </ul>
-        <p><em>
-          <a href="https://github.com/18F/cg-deck/issues/409">We’ll improve this.</a>
-        </em></p>
         <table>
           <thead>
             <tr>

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -69,7 +69,7 @@ export const config = {
     links: [
       {
         text: 'Documentation',
-        url: 'https://cloud.gov/docs'
+        url: 'https://cloud.gov/docs/'
       },
       {
         text: 'Updates',
@@ -84,7 +84,7 @@ export const config = {
   docs: {
     cli: 'https://cloud.gov/docs/getting-started/setup/',
     concepts_spaces: 'https://cloud.gov/docs/getting-started/concepts/',
-    deploying_apps: 'https://cloud.gov/docs/apps/deployment/',
+    deploying_apps: 'https://cloud.gov/docs/getting-started/your-first-deploy/',
     use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/'
   },
   github: {

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -78,6 +78,10 @@ export const config = {
       {
         text: 'Status',
         url: 'https://cloudgov.statuspage.io/'
+      },
+      {
+        text: 'Contact',
+        url: 'https://cloud.gov/docs/help/'
       }
     ]
   },


### PR DESCRIPTION
A few updates for outdated bits of copy:

* Link to both E/W and GovCloud logs sites.
* Update "Create service instance" copy (https://github.com/18F/cg-dashboard/issues/969) - removing the pre-action feedback and improving the post-action feedback (which should probably stick around longer so that people can read it - noted this at https://github.com/18F/cg-dashboard/issues/457).
* Update list of features in "A few things you can do here" in overview (https://github.com/18F/cg-dashboard/issues/966).
* Update docs links to their newer locations.
* Update marketplace copy, based on @adborden's version (https://github.com/18F/cg-dashboard/issues/968).
* Remove outdated copy about user role checkboxes (https://github.com/18F/cg-dashboard/issues/967).

Also:

* Add a contact link to the header (followup on https://github.com/18F/cg-dashboard/pull/674#issuecomment-275813433).