### PR TITLE
Move activity-related API calls from store to actions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -36,7 +36,6 @@ static_src/test/server/fixtures/
 /static_src/test/server/authstatus.js
 /static_src/test/server/fixtures.js
 /static_src/test/server/server.js
-/static_src/test/unit/actions/activity_actions.spec.js
 /static_src/test/unit/actions/app_actions.spec.js
 /static_src/test/unit/actions/domain_actions.spec.js
 /static_src/test/unit/actions/org_actions.spec.js
@@ -46,7 +45,6 @@ static_src/test/server/fixtures/
 /static_src/test/unit/actions/space_actions.spec.js
 /static_src/test/unit/actions/user_actions.spec.js
 /static_src/test/unit/helpers.js
-/static_src/test/unit/stores/activity_store.spec.js
 /static_src/test/unit/stores/app_store.spec.js
 /static_src/test/unit/stores/base_store.spec.js
 /static_src/test/unit/stores/domain_store.spec.js
@@ -69,5 +67,4 @@ static_src/test/server/fixtures/
 /static_src/test/unit/util/poll.spec.js
 /static_src/test/unit/util/uaa_api.spec.js
 /static_src/test/unit/util/url.spec.js
-/static_src/test/unit/util/validators.spec.js
 /static_src/test/webpack-karma-warnings-plugin.js

--- a/static_src/actions/activity_actions.js
+++ b/static_src/actions/activity_actions.js
@@ -2,6 +2,7 @@
 
 import AppDispatcher from '../dispatcher.js';
 import { activityActionTypes } from '../constants';
+import cfApi from '../util/cf_api.js';
 
 export default {
   fetchSpaceEvents(spaceGuid) {
@@ -9,6 +10,8 @@ export default {
       type: activityActionTypes.EVENTS_FETCH,
       spaceGuid
     });
+
+    return cfApi.fetchSpaceEvents(spaceGuid);
   },
 
   receivedSpaceEvents(events) {
@@ -16,6 +19,8 @@ export default {
       type: activityActionTypes.EVENTS_RECEIVED,
       events
     });
+
+    return Promise.resolve(events);
   },
 
   fetchAppLogs(appGuid) {
@@ -23,6 +28,8 @@ export default {
       type: activityActionTypes.LOGS_FETCH,
       appGuid
     });
+
+    return cfApi.fetchAppLogs(appGuid);
   },
 
   receivedAppLogs(appGuid, logs) {
@@ -31,5 +38,7 @@ export default {
       appGuid,
       logs
     });
+
+    return Promise.resolve(logs);
   }
 };

--- a/static_src/actions/activity_actions.js
+++ b/static_src/actions/activity_actions.js
@@ -4,14 +4,14 @@ import AppDispatcher from '../dispatcher.js';
 import { activityActionTypes } from '../constants';
 import cfApi from '../util/cf_api.js';
 
-export default {
+const activityActions = {
   fetchSpaceEvents(spaceGuid) {
     AppDispatcher.handleViewAction({
       type: activityActionTypes.EVENTS_FETCH,
       spaceGuid
     });
 
-    return cfApi.fetchSpaceEvents(spaceGuid);
+    return cfApi.fetchSpaceEvents(spaceGuid).then(activityActions.receivedSpaceEvents);
   },
 
   receivedSpaceEvents(events) {
@@ -29,7 +29,8 @@ export default {
       appGuid
     });
 
-    return cfApi.fetchAppLogs(appGuid);
+    return cfApi.fetchAppLogs(appGuid)
+      .then(logs => activityActions.receivedAppLogs(appGuid, logs));
   },
 
   receivedAppLogs(appGuid, logs) {
@@ -42,3 +43,5 @@ export default {
     return Promise.resolve(logs);
   }
 };
+
+export default activityActions;

--- a/static_src/stores/activity_store.js
+++ b/static_src/stores/activity_store.js
@@ -2,7 +2,6 @@
 import Immutable from 'immutable';
 
 import BaseStore from './base_store.js';
-import cfApi from '../util/cf_api.js';
 import { activityActionTypes } from '../constants.js';
 
 function parseLogTimestamp(timestamp) {
@@ -80,7 +79,6 @@ class ActivityStore extends BaseStore {
       case activityActionTypes.EVENTS_FETCH:
         this._eventsFetching = true;
         this._eventsFetched = false;
-        cfApi.fetchSpaceEvents(action.spaceGuid);
         this.emitChange();
         break;
 
@@ -100,7 +98,6 @@ class ActivityStore extends BaseStore {
       case activityActionTypes.LOGS_FETCH:
         this._logsFetching = true;
         this._logsFetched = false;
-        cfApi.fetchAppLogs(action.appGuid);
         this.emitChange();
         break;
 

--- a/static_src/test/unit/actions/activity_actions.spec.js
+++ b/static_src/test/unit/actions/activity_actions.spec.js
@@ -18,17 +18,28 @@ describe('activityActions', () => {
   });
 
   describe('space events', () => {
-    it('should dispatch a EVENTS_FETCH view action', () => {
-      var spaceGuid = 'adsfa',
-          expectedParams = {
-            spaceGuid
-          };
+    describe('.fetchSpaceEvents()', () => {
+      let viewSpy, fetchSpaceEventsStub, expectedParams;
 
-      let spy = setupViewSpy(sandbox)
+      beforeEach(function () {
+        let spaceGuid = 'adsfa';
+        expectedParams = {
+          spaceGuid
+        };
 
-      activityActions.fetchSpaceEvents(spaceGuid);
+        viewSpy = setupViewSpy(sandbox)
+        fetchSpaceEventsStub = sandbox.stub(cfApi, 'fetchSpaceEvents').returns(Promise.resolve());
 
-      assertAction(spy, activityActionTypes.EVENTS_FETCH, expectedParams);
+        return activityActions.fetchSpaceEvents(spaceGuid);
+      });
+
+      it('should dispatch a EVENTS_FETCH view action', () => {
+        assertAction(viewSpy, activityActionTypes.EVENTS_FETCH, expectedParams);
+      });
+
+      it('should call cfApi.fetchSpaceEvents', function () {
+        expect(fetchSpaceEventsStub).toHaveBeenCalledOnce();
+      });
     });
 
     it('should dispatch a EVENTS_RECEIVED server action', () => {
@@ -45,17 +56,28 @@ describe('activityActions', () => {
   });
 
   describe('app logs', () => {
-    it('should dispatch a LOGS_FETCH view action', () => {
-      var appGuid = 'adsfa',
-          expectedParams = {
-            appGuid
-          };
+    describe('.fetchAppLogs()', () => {
+      let viewSpy, fetchAppLogsStub, expectedParams;
 
-      let spy = setupViewSpy(sandbox)
+      beforeEach(() => {
+        const appGuid = 'adsfa';
+        expectedParams = {
+          appGuid
+        };
 
-      activityActions.fetchAppLogs(appGuid);
+        viewSpy = setupViewSpy(sandbox)
+        fetchAppLogsStub = sandbox.stub(cfApi, 'fetchAppLogs').returns(Promise.resolve());
 
-      assertAction(spy, activityActionTypes.LOGS_FETCH, expectedParams);
+        return activityActions.fetchAppLogs(appGuid);
+      });
+
+      it('should dispatch a LOGS_FETCH view action', () => {
+        assertAction(viewSpy, activityActionTypes.LOGS_FETCH, expectedParams);
+      });
+
+      it('should call cfApi.fetchAppLogs', function () {
+        expect(fetchAppLogsStub).toHaveBeenCalledOnce();
+      });
     });
 
     it('should dispatch a LOGS_RECEIVED server action', () => {

--- a/static_src/test/unit/actions/activity_actions.spec.js
+++ b/static_src/test/unit/actions/activity_actions.spec.js
@@ -19,18 +19,22 @@ describe('activityActions', () => {
 
   describe('space events', () => {
     describe('.fetchSpaceEvents()', () => {
-      let viewSpy, fetchSpaceEventsStub, expectedParams;
+      let viewSpy, fetchSpaceEventsStub, expectedParams, expectedEvents, receivedSpaceEventsStub;
 
-      beforeEach(function () {
+      beforeEach(function (done) {
         let spaceGuid = 'adsfa';
         expectedParams = {
           spaceGuid
         };
 
-        viewSpy = setupViewSpy(sandbox)
-        fetchSpaceEventsStub = sandbox.stub(cfApi, 'fetchSpaceEvents').returns(Promise.resolve());
+        expectedEvents = [];
 
-        return activityActions.fetchSpaceEvents(spaceGuid);
+        viewSpy = setupViewSpy(sandbox)
+        fetchSpaceEventsStub = sandbox.stub(cfApi, 'fetchSpaceEvents').returns(Promise.resolve(expectedEvents));
+        receivedSpaceEventsStub = sandbox.stub(activityActions, 'receivedSpaceEvents').returns(Promise.resolve());
+
+        activityActions.fetchSpaceEvents(spaceGuid)
+          .then(done, done.fail);
       });
 
       it('should dispatch a EVENTS_FETCH view action', () => {
@@ -39,6 +43,10 @@ describe('activityActions', () => {
 
       it('should call cfApi.fetchSpaceEvents', function () {
         expect(fetchSpaceEventsStub).toHaveBeenCalledOnce();
+      });
+
+      it('should call receivedSpaceEvents', function () {
+        expect(receivedSpaceEventsStub).toHaveBeenCalledWith(expectedEvents);
       });
     });
 
@@ -57,18 +65,21 @@ describe('activityActions', () => {
 
   describe('app logs', () => {
     describe('.fetchAppLogs()', () => {
-      let viewSpy, fetchAppLogsStub, expectedParams;
+      let appGuid, viewSpy, fetchAppLogsStub, receivedAppLogsStub, expectedParams, expectedLogs;
 
-      beforeEach(() => {
-        const appGuid = 'adsfa';
+      beforeEach((done) => {
+        appGuid = 'adsfa';
         expectedParams = {
           appGuid
         };
+        expectedLogs = [];
 
         viewSpy = setupViewSpy(sandbox)
-        fetchAppLogsStub = sandbox.stub(cfApi, 'fetchAppLogs').returns(Promise.resolve());
+        fetchAppLogsStub = sandbox.stub(cfApi, 'fetchAppLogs').returns(Promise.resolve(expectedLogs));
+        receivedAppLogsStub = sandbox.stub(activityActions, 'receivedAppLogs').returns(Promise.resolve());
 
-        return activityActions.fetchAppLogs(appGuid);
+        activityActions.fetchAppLogs(appGuid)
+          .then(done, done.fail);
       });
 
       it('should dispatch a LOGS_FETCH view action', () => {
@@ -77,6 +88,10 @@ describe('activityActions', () => {
 
       it('should call cfApi.fetchAppLogs', function () {
         expect(fetchAppLogsStub).toHaveBeenCalledOnce();
+      });
+
+      it('should call receivedAppLogs', () => {
+        expect(receivedAppLogsStub).toHaveBeenCalledWith(appGuid, expectedLogs);
       });
     });
 

--- a/static_src/test/unit/actions/activity_actions.spec.js
+++ b/static_src/test/unit/actions/activity_actions.spec.js
@@ -1,13 +1,12 @@
 import '../../global_setup.js';
 
-import AppDispatcher from '../../../dispatcher.js';
-import { assertAction, setupUISpy, setupViewSpy, setupServerSpy } from '../helpers.js';
+import { assertAction, setupViewSpy, setupServerSpy } from '../helpers.js';
 import cfApi from '../../../util/cf_api.js';
 import activityActions from '../../../actions/activity_actions.js';
 import { activityActionTypes } from '../../../constants.js';
 
 describe('activityActions', () => {
-  var sandbox;
+  let sandbox;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -22,16 +21,18 @@ describe('activityActions', () => {
       let viewSpy, fetchSpaceEventsStub, expectedParams, expectedEvents, receivedSpaceEventsStub;
 
       beforeEach(function (done) {
-        let spaceGuid = 'adsfa';
+        const spaceGuid = 'adsfa';
         expectedParams = {
           spaceGuid
         };
 
         expectedEvents = [];
 
-        viewSpy = setupViewSpy(sandbox)
-        fetchSpaceEventsStub = sandbox.stub(cfApi, 'fetchSpaceEvents').returns(Promise.resolve(expectedEvents));
-        receivedSpaceEventsStub = sandbox.stub(activityActions, 'receivedSpaceEvents').returns(Promise.resolve());
+        viewSpy = setupViewSpy(sandbox);
+        fetchSpaceEventsStub = sandbox.stub(cfApi, 'fetchSpaceEvents')
+          .returns(Promise.resolve(expectedEvents));
+        receivedSpaceEventsStub = sandbox.stub(activityActions, 'receivedSpaceEvents')
+          .returns(Promise.resolve());
 
         activityActions.fetchSpaceEvents(spaceGuid)
           .then(done, done.fail);
@@ -51,12 +52,12 @@ describe('activityActions', () => {
     });
 
     it('should dispatch a EVENTS_RECEIVED server action', () => {
-      var events = ['event-one', 'event-two', 'event-three'],
-          expectedParams = {
-            events
-          };
+      const events = ['event-one', 'event-two', 'event-three'],
+        expectedParams = {
+          events
+        };
 
-      let spy = setupServerSpy(sandbox)
+      const spy = setupServerSpy(sandbox);
 
       activityActions.receivedSpaceEvents(events);
       assertAction(spy, activityActionTypes.EVENTS_RECEIVED, expectedParams);
@@ -74,9 +75,11 @@ describe('activityActions', () => {
         };
         expectedLogs = [];
 
-        viewSpy = setupViewSpy(sandbox)
-        fetchAppLogsStub = sandbox.stub(cfApi, 'fetchAppLogs').returns(Promise.resolve(expectedLogs));
-        receivedAppLogsStub = sandbox.stub(activityActions, 'receivedAppLogs').returns(Promise.resolve());
+        viewSpy = setupViewSpy(sandbox);
+        fetchAppLogsStub = sandbox.stub(cfApi, 'fetchAppLogs')
+          .returns(Promise.resolve(expectedLogs));
+        receivedAppLogsStub = sandbox.stub(activityActions, 'receivedAppLogs')
+          .returns(Promise.resolve());
 
         activityActions.fetchAppLogs(appGuid)
           .then(done, done.fail);
@@ -96,17 +99,16 @@ describe('activityActions', () => {
     });
 
     it('should dispatch a LOGS_RECEIVED server action', () => {
-      var appGuid = 'app-one',
-          logs = ['logs-one', 'logs-two', 'logs-three'],
-          expectedParams = {
-            appGuid,
-            logs
-          };
+      const appGuid = 'app-one',
+        logs = ['logs-one', 'logs-two', 'logs-three'],
+        expectedParams = {
+          appGuid,
+          logs
+        };
 
-      let spy = setupServerSpy(sandbox)
+      const spy = setupServerSpy(sandbox);
 
       activityActions.receivedAppLogs(appGuid, logs);
-      let actionInfo = spy.getCall(0).args[0];
       assertAction(spy, activityActionTypes.LOGS_RECEIVED, expectedParams);
     });
   });

--- a/static_src/test/unit/stores/activity_store.spec.js
+++ b/static_src/test/unit/stores/activity_store.spec.js
@@ -31,17 +31,6 @@ describe('ActivityStore', function() {
   });
 
   describe('on event fetch', function () {
-    it('should call cfApi.fetchSpaceEvents', function () {
-      var spy = sandbox.spy(cfApi, 'fetchSpaceEvents');
-
-      AppDispatcher.handleViewAction({
-        type: activityActionTypes.EVENTS_FETCH,
-        spaceGuid: 'fakeSpaceGuid'
-      });
-
-      expect(spy).toHaveBeenCalledOnce();
-    });
-
     it('should set events fetching to true fetched to false', function() {
       AppDispatcher.handleViewAction({
         type: activityActionTypes.EVENTS_FETCH,
@@ -109,17 +98,6 @@ describe('ActivityStore', function() {
   });
 
   describe('on logs fetch', function () {
-    it('should call cfApi.fetchAppLogs', function () {
-      var spy = sandbox.spy(cfApi, 'fetchAppLogs');
-
-      AppDispatcher.handleViewAction({
-        type: activityActionTypes.LOGS_FETCH,
-        appGuid: 'fakeAppGuid'
-      });
-
-      expect(spy).toHaveBeenCalledOnce();
-    });
-
     it('should set logs fetching to true fetched to false', function() {
       AppDispatcher.handleViewAction({
         type: activityActionTypes.LOGS_FETCH,

--- a/static_src/test/unit/stores/activity_store.spec.js
+++ b/static_src/test/unit/stores/activity_store.spec.js
@@ -4,15 +4,14 @@ import Immutable from 'immutable';
 import '../../global_setup.js';
 
 import AppDispatcher from '../../../dispatcher.js';
-import cfApi from '../../../util/cf_api.js';
 import ActivityStore from '../../../stores/activity_store.js';
 import { activityActionTypes } from '../../../constants';
 
-describe('ActivityStore', function() {
-  var sandbox;
+describe('ActivityStore', function () {
+  let sandbox;
 
   beforeEach(() => {
-    ActivityStore._data = Immutable.List();
+    ActivityStore._data = Immutable.List(); // eslint-disable-line new-cap
     ActivityStore._eventsFetched = false;
     ActivityStore._eventsFetching = false;
     ActivityStore._logsFetched = false;
@@ -24,14 +23,14 @@ describe('ActivityStore', function() {
     sandbox.restore();
   });
 
-  describe('constructor()', function() {
-    it('should start data as empty array', function() {
+  describe('constructor()', function () {
+    it('should start data as empty array', function () {
       expect(ActivityStore.getAll()).toBeEmptyArray();
     });
   });
 
   describe('on event fetch', function () {
-    it('should set events fetching to true fetched to false', function() {
+    it('should set events fetching to true fetched to false', function () {
       AppDispatcher.handleViewAction({
         type: activityActionTypes.EVENTS_FETCH,
         spaceGuid: 'fakeSpaceGuid'
@@ -41,7 +40,7 @@ describe('ActivityStore', function() {
       expect(ActivityStore._eventsFetching).toEqual(true);
     });
 
-    it('should emit a change event', function() {
+    it('should emit a change event', function () {
       const spy = sandbox.spy(ActivityStore, 'emitChange');
 
       AppDispatcher.handleViewAction({
@@ -59,12 +58,12 @@ describe('ActivityStore', function() {
         {
           guid: 'fakeActivityGuidOne',
           name: 'fakeActivityNameOne',
-          activity_type : 'event'
+          activity_type: 'event'
         },
         {
           guid: 'fakeActivityGuidTwo',
           name: 'fakeActivityNameTwo',
-          activity_type : 'event'
+          activity_type: 'event'
         }
       ];
       const spy = sandbox.spy(ActivityStore, 'emitChange');
@@ -79,11 +78,11 @@ describe('ActivityStore', function() {
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set events fetched to true, fetching to false', function() {
+    it('should set events fetched to true, fetching to false', function () {
       const activity = [
         {
           guid: 'fakeActivityGuidOne',
-          activity_type : 'event'
+          activity_type: 'event'
         }
       ];
 
@@ -98,7 +97,7 @@ describe('ActivityStore', function() {
   });
 
   describe('on logs fetch', function () {
-    it('should set logs fetching to true fetched to false', function() {
+    it('should set logs fetching to true fetched to false', function () {
       AppDispatcher.handleViewAction({
         type: activityActionTypes.LOGS_FETCH,
         appGuid: 'fakeAppGuid'
@@ -108,7 +107,7 @@ describe('ActivityStore', function() {
       expect(ActivityStore._logsFetching).toEqual(true);
     });
 
-    it('should emit a change event', function() {
+    it('should emit a change event', function () { // eslint-disable-line jasmine/no-spec-dupes
       const spy = sandbox.spy(ActivityStore, 'emitChange');
 
       AppDispatcher.handleViewAction({
@@ -121,10 +120,10 @@ describe('ActivityStore', function() {
   });
 
   describe('on logs received', function () {
-    it('should merge activity and emit change', function () {
+    it('should merge activity and emit change', function () { // eslint-disable-line
       const logs = [
         {
-          message: "federalist.18f.gov - [17/08/2016:00:09:56.467 +0000] \"GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 HTTP/1.1\" 200 0 90 \"https://federalist.18f.gov/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36\" 127.0.0.1:34350 x_forwarded_for:\"50.0.192.84\" x_forwarded_proto:\"https\" vcap_request_id:5e288c8d-d9d8-4589-7956-0427ab11e33f response_time:0.003466191 app_id:32f77e21-d504-4b4a-91c3-ea4c6bcc47e5\n"
+          message: "federalist.18f.gov - [17/08/2016:00:09:56.467 +0000] \"GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 HTTP/1.1\" 200 0 90 \"https://federalist.18f.gov/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36\" 127.0.0.1:34350 x_forwarded_for:\"50.0.192.84\" x_forwarded_proto:\"https\" vcap_request_id:5e288c8d-d9d8-4589-7956-0427ab11e33f response_time:0.003466191 app_id:32f77e21-d504-4b4a-91c3-ea4c6bcc47e5\n" // eslint-disable-line
         }
       ];
 
@@ -139,10 +138,10 @@ describe('ActivityStore', function() {
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set fetched to true, fetching to false', function() {
+    it('should set fetched to true, fetching to false', function () {
       const logs = [
         {
-          message: "federalist.18f.gov - [17/08/2016:00:09:56.467 +0000] \"GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 HTTP/1.1\" 200 0 90 \"https://federalist.18f.gov/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36\" 127.0.0.1:34350 x_forwarded_for:\"50.0.192.84\" x_forwarded_proto:\"https\" vcap_request_id:5e288c8d-d9d8-4589-7956-0427ab11e33f response_time:0.003466191 app_id:32f77e21-d504-4b4a-91c3-ea4c6bcc47e5\n"
+          message: "federalist.18f.gov - [17/08/2016:00:09:56.467 +0000] \"GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 HTTP/1.1\" 200 0 90 \"https://federalist.18f.gov/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36\" 127.0.0.1:34350 x_forwarded_for:\"50.0.192.84\" x_forwarded_proto:\"https\" vcap_request_id:5e288c8d-d9d8-4589-7956-0427ab11e33f response_time:0.003466191 app_id:32f77e21-d504-4b4a-91c3-ea4c6bcc47e5\n" // eslint-disable-line
         }
       ];
 
@@ -156,8 +155,8 @@ describe('ActivityStore', function() {
     });
   });
 
-  describe('fetching', function() {
-    it('should be true when either events or logs fetching', function() {
+  describe('fetching', function () {
+    it('should be true when either events or logs fetching', function () {
       expect(ActivityStore.fetching).toEqual(false);
 
       ActivityStore._logsFetching = true;
@@ -172,8 +171,8 @@ describe('ActivityStore', function() {
     });
   });
 
-  describe('fetched', function() {
-    it('should only be true when both events and logs fetched', function() {
+  describe('fetched', function () {
+    it('should only be true when both events and logs fetched', function () {
       expect(ActivityStore.fetched).toEqual(false);
 
       ActivityStore._logsFetched = true;
@@ -192,26 +191,26 @@ describe('ActivityStore', function() {
     it('should parse log items', function () {
       const logs = [
         {
-          message: "federalist.18f.gov - [17/08/2016:00:09:56.467 +0000] \"GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 HTTP/1.1\" 200 0 90 \"https://federalist.18f.gov/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36\" 127.0.0.1:34350 x_forwarded_for:\"50.0.192.84\" x_forwarded_proto:\"https\" vcap_request_id:5e288c8d-d9d8-4589-7956-0427ab11e33f response_time:0.003466191 app_id:32f77e21-d504-4b4a-91c3-ea4c6bcc47e5\n"
+          message: "federalist.18f.gov - [17/08/2016:00:09:56.467 +0000] \"GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 HTTP/1.1\" 200 0 90 \"https://federalist.18f.gov/\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36\" 127.0.0.1:34350 x_forwarded_for:\"50.0.192.84\" x_forwarded_proto:\"https\" vcap_request_id:5e288c8d-d9d8-4589-7956-0427ab11e33f response_time:0.003466191 app_id:32f77e21-d504-4b4a-91c3-ea4c6bcc47e5\n" // eslint-disable-line
         }
       ];
       const expected = [
         {
-          app_guid: "32f77e21-d504-4b4a-91c3-ea4c6bcc47e5",
+          app_guid: '32f77e21-d504-4b4a-91c3-ea4c6bcc47e5',
           raw: logs[0],
-          host: "federalist.18f.gov",
-          guid: "2016-08-17 00:09 +00005e288c8d-d9d8-4589-7956-0427ab11e33f",
-          activity_type: "log",
+          host: 'federalist.18f.gov',
+          guid: '2016-08-17 00:09 +00005e288c8d-d9d8-4589-7956-0427ab11e33f',
+          activity_type: 'log',
           metadata: {
-            x_forward_for: "50.0.192.84",
-            x_forward_proto: "https",
-            vcap_request_id: "5e288c8d-d9d8-4589-7956-0427ab11e33f",
-            response_time: "0.003466191"
+            x_forward_for: '50.0.192.84',
+            x_forward_proto: 'https',
+            vcap_request_id: '5e288c8d-d9d8-4589-7956-0427ab11e33f',
+            response_time: '0.003466191'
           },
-          timestamp: "2016-08-17 00:09 +0000",
-          protocol: "HTTP/1.1",
-          status_code:200,
-          requested_url: "GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 "
+          timestamp: '2016-08-17 00:09 +0000',
+          protocol: 'HTTP/1.1',
+          status_code: 200,
+          requested_url: 'GET /socket.io/?__sails_io_sdk_version=0.11.0&__sails_io_sdk_platform=browser&__sails_io_sdk_language=javascript&EIO=3&transport=polling&t=1471392596201-8120 ' // eslint-disable-line
         }
       ];
 
@@ -221,6 +220,6 @@ describe('ActivityStore', function() {
       });
 
       expect(ActivityStore.getAll()).toEqual(expected);
-    })
-  })
+    });
+  });
 });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -4,7 +4,6 @@ import '../../global_setup.js';
 import http from 'axios';
 import Immutable from 'immutable';
 
-import activityActions from '../../../actions/activity_actions.js';
 import appActions from '../../../actions/app_actions.js';
 import cfApi from '../../../util/cf_api.js';
 import domainActions from '../../../actions/domain_actions.js';
@@ -562,9 +561,6 @@ describe('cfApi', function() {
 
         cfApi.fetchSpaceEvents(spaceGuid);
         expect(spy).toHaveBeenCalledOnce();
-
-        action = spy.getCall(0).args[1];
-        expect(action).toEqual(activityActions.receivedSpaceEvents);
     });
   });
 
@@ -789,20 +785,6 @@ describe('cfApi', function() {
 
       let calledUrl = spy.getCall(0).args[0];
       expect(calledUrl).toEqual(expected);
-    });
-
-    it('calls the receivedAppLogs activity action', function (done) {
-      var expected = 'yyyybba1',
-          spy = sandbox.spy(activityActions, 'receivedAppLogs'),
-          stub = sandbox.stub(http, 'get'),
-          testPromise = createPromise({ status: true, data: [] });
-
-      stub.returns(testPromise);
-
-      cfApi.fetchAppLogs(expected).then(() => {
-        expect(spy).toHaveBeenCalledOnce();
-        done();
-      });
     });
   });
 

--- a/static_src/test/unit/util/validators.spec.js
+++ b/static_src/test/unit/util/validators.spec.js
@@ -15,12 +15,12 @@ describe('vaidateNumber', function () {
 
     it('fails for empty', function () {
       const result = validator();
-      expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID'});
+      expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID' });
     });
 
     it('fails for NaN', function () {
       const result = validator('Not a number');
-      expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID'});
+      expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID' });
     });
 
     it('passes for number string', function () {
@@ -52,7 +52,6 @@ describe('vaidateNumber', function () {
     });
 
     it('fails for above max', function () {
-      debugger;
       const result = validator('1025');
       expect(result).toEqual({ message: 'Total exceeds 1024', type: 'NUMBER_MAX' });
     });
@@ -118,12 +117,12 @@ describe('vaidateNumber', function () {
       expect(result).toBe(null);
     });
 
-    it('accepts min', function () {
+    it('accepts min', function () { // eslint-disable-line jasmine/no-spec-dupes
       const result = validator('1');
       expect(result).toBe(null);
     });
 
-    it('accepts max', function () {
+    it('accepts max', function () { // eslint-disable-line jasmine/no-spec-dupes
       const result = validator('1024');
       expect(result).toBe(null);
     });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -1,6 +1,5 @@
 import http from 'axios';
 
-import activityActions from '../actions/activity_actions.js';
 import { noticeError } from '../util/analytics.js';
 import appActions from '../actions/app_actions.js';
 import domainActions from '../actions/domain_actions.js';
@@ -192,8 +191,7 @@ export default {
   },
 
   fetchSpaceEvents(spaceGuid) {
-    return this.fetchAllPages(`/spaces/${spaceGuid}/events`,
-                               activityActions.receivedSpaceEvents);
+    return this.fetchAllPages(`/spaces/${spaceGuid}/events`, results => results);
   },
 
   fetchServiceInstance(instanceGuid) {
@@ -257,11 +255,11 @@ export default {
   },
 
   fetchAppLogs(appGuid) {
-    return http.get(`log/recent?app=${appGuid}`).then((res) => {
-      activityActions.receivedAppLogs(appGuid, res.data);
-    }).catch((err) => {
-      handleError(err);
-    });
+    return http.get(`log/recent?app=${appGuid}`)
+      .then(res => res.data)
+      .catch((err) => {
+        handleError(err);
+      });
   },
 
   putApp(appGuid, app) {


### PR DESCRIPTION
This is the first part of https://github.com/18F/cg-dashboard/issues/973 to move the API calls from the store to the actions.

I've also included linting cleanup but can move that to a separate PR if it makes things too confusing.