### PR TITLE
Add error action for activity logs fetch

### DIFF
--- a/static_src/actions/activity_actions.js
+++ b/static_src/actions/activity_actions.js
@@ -30,7 +30,8 @@ const activityActions = {
     });
 
     return cfApi.fetchAppLogs(appGuid)
-      .then(logs => activityActions.receivedAppLogs(appGuid, logs));
+      .then(logs => activityActions.receivedAppLogs(appGuid, logs))
+      .catch(err => activityActions.errorAppLogs(appGuid, err));
   },
 
   receivedAppLogs(appGuid, logs) {
@@ -41,6 +42,16 @@ const activityActions = {
     });
 
     return Promise.resolve(logs);
+  },
+
+  errorAppLogs(appGuid, err) {
+    AppDispatcher.handleServerAction({
+      type: activityActionTypes.LOGS_ERROR,
+      appGuid,
+      err
+    });
+
+    return Promise.resolve();
   }
 };
 

--- a/static_src/components/activity_log.jsx
+++ b/static_src/components/activity_log.jsx
@@ -28,7 +28,9 @@ function stateSetter(props) {
 
   return {
     activity,
-    empty: (ActivityStore.fetched && activity.length === 0)
+    empty: (ActivityStore.fetched && activity.length === 0),
+    hasErrors: ActivityStore.hasErrors,
+    errors: ActivityStore.errors
   };
 }
 
@@ -74,7 +76,9 @@ export default class ActivityLog extends React.Component {
   render() {
     let content = <div></div>;
 
-    if (this.state.empty) {
+    if (this.state.empty && this.state.hasErrors) {
+      content = <h5 className="test-none_message">An error occured fetching recent activity</h5>;
+    } else if (this.state.empty) {
       content = <h5 className="test-none_message">No recent activity</h5>;
     } else {
       let showMore = (this.state.activity.length >= this.props.maxItems) &&

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -269,6 +269,9 @@ const domainActionTypes = keymirror({
 const activityActionTypes = keymirror({
   EVENTS_FETCH: null,
   EVENTS_RECEIVED: null,
+
+  // An error occured while fetching logs
+  LOGS_ERROR: null,
   LOGS_FETCH: null,
   LOGS_RECEIVED: null
 });

--- a/static_src/stores/activity_store.js
+++ b/static_src/stores/activity_store.js
@@ -63,6 +63,7 @@ class ActivityStore extends BaseStore {
     this._eventsFetching = false;
     this._logsFetched = false;
     this._logsFetching = false;
+    this.errors = {};
   }
 
   get fetched() {
@@ -71,6 +72,10 @@ class ActivityStore extends BaseStore {
 
   get fetching() {
     return this._eventsFetching || this._logsFetching;
+  }
+
+  get hasErrors() {
+    return this.errors.log || this.errors.event;
   }
 
   _registerToActions(action) {
@@ -98,6 +103,7 @@ class ActivityStore extends BaseStore {
       case activityActionTypes.LOGS_FETCH:
         this._logsFetching = true;
         this._logsFetched = false;
+        this.errors.log = null;
         this.emitChange();
         break;
 
@@ -111,6 +117,13 @@ class ActivityStore extends BaseStore {
           return parsed;
         });
         this.mergeMany('guid', activity, () => {});
+        this.emitChange();
+        break;
+
+      case activityActionTypes.LOGS_ERROR:
+        this._logsFetching = false;
+        this._logsFetched = true;
+        this.errors.log = action.err;
         this.emitChange();
         break;
 

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -34,6 +34,15 @@ function handleError(err, errHandler = errorActions.errorFetch) {
   }
 }
 
+// Some general error handling for API calls
+// Logs the error, reports to NR, and rejects the error so error actions can
+// handle them appropriately.
+function promiseHandleError(err) {
+  console.warn('cf_api error', { err }); // eslint-disable-line no-console
+  noticeError(err);
+  return Promise.reject(err);
+}
+
 export default {
   version: APIV,
 
@@ -257,9 +266,7 @@ export default {
   fetchAppLogs(appGuid) {
     return http.get(`log/recent?app=${appGuid}`)
       .then(res => res.data)
-      .catch((err) => {
-        handleError(err);
-      });
+      .catch(promiseHandleError);
   },
 
   putApp(appGuid, app) {


### PR DESCRIPTION
Adds an action for log fetch failure, so that the app can display a better message than just "No recent activity".

I realized that the current `handleError` in `cf_api` doesn't work well for promises, so I created a new simpler one. I expect the existing `handleError` to disappear once all the actions are removed from `cf_api`.