### PR TITLE
Rename user-provided-service to match app name

### DIFF
--- a/manifests/manifest-base.yml
+++ b/manifests/manifest-base.yml
@@ -2,7 +2,7 @@
 buildpack: go_buildpack
 memory: 256M
 services:
-- deck-ups
+- dashboard-ups
 - dashboard-redis
 env:
   GOVERSION: go1.6.3

--- a/server.go
+++ b/server.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	defaultPort           = "9999"
-	cfUserProvidedService = "deck-ups"
+	cfUserProvidedService = "dashboard-ups"
 )
 
 func loadEnvVars() helpers.EnvVars {

--- a/static_src/test/server/fixtures/space_summaries.js
+++ b/static_src/test/server/fixtures/space_summaries.js
@@ -500,7 +500,7 @@ const spaceSummaries = [
         ],
         service_count: 1,
         service_names: [
-          "fake-deck-ups"
+          "fake-dashboard-ups"
         ],
         running_instances: 1,
         name: "fake-cg-dashboard",
@@ -611,7 +611,7 @@ const spaceSummaries = [
     services: [
       {
         guid: "7d637f49-3979-448e-bc24-b3f3caf10711",
-        name: "deck-ups",
+        name: "dashboard-ups",
         bound_app_count: 1
       }
     ]
@@ -639,7 +639,7 @@ const spaceSummaries = [
         ],
         service_count: 1,
         service_names: [
-          "deck-ups"
+          "dashboard-ups"
         ],
         running_instances: 1,
         name: "fake-cg-dashboard-staging",
@@ -704,7 +704,7 @@ const spaceSummaries = [
         ],
         service_count: 1,
         service_names: [
-          "deck-ups"
+          "dashboard-ups"
         ],
         running_instances: 1,
         name: "fake-cg-dashboard-demo",
@@ -754,7 +754,7 @@ const spaceSummaries = [
     services: [
       {
         guid: "08f2a9e8-d527-43b5-b223-e383c28d1c51",
-        name: "deck-ups",
+        name: "dashboard-ups",
         bound_app_count: 2
       }
     ]


### PR DESCRIPTION
"Deck" is no longer used, everything is named "dashboard" instead.

`dashboard-ups` has been created in all environments. This can be merged and deployed at any time.