### PR TITLE
Fix missing spaces

### DIFF
--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -347,7 +347,7 @@ describe('cfApi', function() {
         var callCount = stub.callCount;
         expect(callCount).toEqual(response.data.total_pages);
         done();
-      });
+      }).catch(done.fail);
     });
 
     it('should combine the responses from all the requests', function(done) {
@@ -356,32 +356,43 @@ describe('cfApi', function() {
       var dataOne = {
         data: {
           next_url: true,
-          total_pages: 2,
+          total_pages: 3,
           resources: [
             { metadata: { guid: 'higw' }}
           ]
         }
       };
-      var dataTwo = Object.assign({}, dataOne, {
+      var dataTwo =  {
+        data: {
+          next_url: true,
+          resources: [
+            { metadata: { guid: 'dmc' }},
+            { metadata: { guid: 'abc' }}
+          ]
+        }
+      };
+      const dataThree = {
         data: {
           next_url: false,
           resources: [
-            { metadata: { guid: 'xvms' }},
-            { metadata: { guid: 'zxc' }}
+            { metadata: { guid: '23fd' }},
+            { metadata: { guid: '234s' }}
           ]
         }
-      });
+      }
 
       stub.onFirstCall().returns(createPromise(dataOne));
       stub.onSecondCall().returns(createPromise(dataTwo));
+      stub.onThirdCall().returns(createPromise(dataThree));
 
       cfApi.fetchAllPages(expectedUrl, function(responses) {
-        var combined = dataOne.data.resources.concat(dataTwo.data.resources).map(
+        const combined = dataOne.data.resources.concat(dataTwo.data.resources)
+          .concat(dataThree.data.resources).map(
           (r) => Object.assign({}, r.metadata, r.entity));
-        expect(stub).toHaveBeenCalledTwice();
+        expect(stub).toHaveBeenCalledThrice();
         expect(responses).toEqual(combined);
         done();
-      });
+      }).catch(done.fail);
     });
   });
 

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -115,8 +115,8 @@ export default {
       const reqs = urls.map((u) => http.get(u).then((r) => r.data.resources));
 
       return Promise.all(reqs)
-        .then((all) => all.pop())
-        .then((all) => [].concat.call([], res.data.resources, all))
+        .then((all) => [].concat.apply([], all))
+        .then((all) => res.data.resources.concat(all))
         .then((all) => action(this.formatSplitResponses(all), ...params))
         .catch((err) => handleError(err));
     });
@@ -191,12 +191,7 @@ export default {
   },
 
   fetchSpaces() {
-    return http.get(`${APIV}/spaces`).then(res =>
-      this.formatSplitResponses(res.data.resources)
-    ).catch((err) => {
-      handleError(err);
-      return Promise.reject(err);
-    });
+    return this.fetchAllPages('/spaces', (results) => Promise.resolve(results));
   },
 
   fetchSpace(spaceGuid) {


### PR DESCRIPTION
Fixes bugs where users with admin permissions (users who can see all orgs) were not able to see certain spaces.

Bug was due to how data from the promise code was being put together. It was only adding
in the data from the last two requests rather then all of them. I also wrote a test case for this to ensure it doesn't happen again.

Refs https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-2876