### PR TITLE
Fix layout broken on prod build

### DIFF
--- a/static_src/components/complex_list.jsx
+++ b/static_src/components/complex_list.jsx
@@ -60,7 +60,7 @@ export default class ComplexList extends React.Component {
         { header }
         { emptyMessage }
         { this.props.children.length > 0 && this.props.children.map((child, i) => {
-          if (child.type.name === 'ComplexList') {
+          if (child.type === ComplexList) {
             return child;
           }
           return (


### PR DESCRIPTION
In order to build the nested complex lists, I was using the `name`
property of the React component's `type` field. I though this was
a React defined property, but it might actually be the function
name property from standard JS. This `name` property seems to change
in the production build when build with Uglify.

This change uses the standard way of checking type as I've read about
in various places.