### PR TITLE
Fix service panel loading on app page

### DIFF
--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -21,6 +21,7 @@ export default class BaseStore extends EventEmitter {
     this._loadingStatus.on('loading', () => this.emitChange());
     this._loadingStatus.on('loaded', () => this.emitChange());
     this._data = new Immutable.List();
+    this.setMaxListeners(20);
   }
 
   subscribe(actionSubscribe) {


### PR DESCRIPTION
Bump up the EventEmitter max listeners, we're up to about 11 on the app page. We can come up with a better fix where we just set listeners in fewer places, but this is a decent quick fix.