### PR TITLE
Reduce number of listeners on ServiceInstanceStore

### DIFF
--- a/static_src/components/activity_log.jsx
+++ b/static_src/components/activity_log.jsx
@@ -7,6 +7,7 @@ import ActivityStore from '../stores/activity_store';
 import PanelActions from './panel_actions.jsx';
 import createStyler from '../util/create_styler';
 import { config } from 'skin';
+import ServiceInstanceStore from '../stores/service_instance_store';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 function stateSetter(props) {
@@ -58,10 +59,12 @@ export default class ActivityLog extends React.Component {
 
   componentDidMount() {
     ActivityStore.addChangeListener(this._onChange);
+    ServiceInstanceStore.addChangeListener(this._onChange);
   }
 
   componentWillUnmount() {
     ActivityStore.removeChangeListener(this._onChange);
+    ServiceInstanceStore.removeChangeListener(this._onChange);
   }
 
   _onChange() {
@@ -109,7 +112,16 @@ export default class ActivityLog extends React.Component {
           <ul className={ this.styler('activity_log') }>
             { this.state.activity
                 .slice(0, this.state.maxItems)
-                .map(item => <ActivityLogItem key={ item.guid } item={ item } />)
+                .map(item => {
+                  let service;
+                  if (item.metadata.request && item.metadata.service_instance_guid) {
+                    service = ServiceInstanceStore.get(
+                      item.metadata.request.service_instance_guid
+                    );
+                  }
+
+                  return <ActivityLogItem key={ item.guid } item={ item } service={ service } />;
+                })
             }
             { showMore }
           </ul>

--- a/static_src/components/activity_log.jsx
+++ b/static_src/components/activity_log.jsx
@@ -4,7 +4,9 @@ import React from 'react';
 import Action from './action.jsx';
 import ActivityLogItem from './activity_log_item.jsx';
 import ActivityStore from '../stores/activity_store';
+import DomainStore from '../stores/domain_store';
 import PanelActions from './panel_actions.jsx';
+import RouteStore from '../stores/route_store';
 import createStyler from '../util/create_styler';
 import { config } from 'skin';
 import ServiceInstanceStore from '../stores/service_instance_store';
@@ -59,11 +61,15 @@ export default class ActivityLog extends React.Component {
 
   componentDidMount() {
     ActivityStore.addChangeListener(this._onChange);
+    DomainStore.addChangeListener(this._onChange);
+    RouteStore.addChangeListener(this._onChange);
     ServiceInstanceStore.addChangeListener(this._onChange);
   }
 
   componentWillUnmount() {
     ActivityStore.removeChangeListener(this._onChange);
+    DomainStore.removeChangeListener(this._onChange);
+    RouteStore.removeChangeListener(this._onChange);
     ServiceInstanceStore.removeChangeListener(this._onChange);
   }
 
@@ -120,7 +126,21 @@ export default class ActivityLog extends React.Component {
                     );
                   }
 
-                  return <ActivityLogItem key={ item.guid } item={ item } service={ service } />;
+                  let domain;
+                  const route = RouteStore.get(item.metadata.route_guid);
+                  if (route) {
+                    domain = DomainStore.get(route.domain_guid);
+                  }
+
+                  return (
+                    <ActivityLogItem
+                      key={ item.guid }
+                      item={ item }
+                      service={ service }
+                      route={ route }
+                      domain={ domain }
+                    />
+                  );
                 })
             }
             { showMore }

--- a/static_src/components/activity_log_item.jsx
+++ b/static_src/components/activity_log_item.jsx
@@ -7,54 +7,16 @@ import createStyler from '../util/create_styler';
 import ElasticLine from './elastic_line.jsx';
 import ElasticLineItem from './elastic_line_item.jsx';
 import formatRoute from '../util/format_route';
-import RouteStore from '../stores/route_store';
-import DomainStore from '../stores/domain_store';
-
-function stateSetter(props) {
-  const { item, service } = props;
-  const route = RouteStore.get(item.metadata.route_guid);
-
-  let domain;
-  if (route) {
-    domain = DomainStore.get(route.domain_guid);
-  }
-
-  return {
-    domain,
-    route,
-    service
-  };
-}
-
 
 export default class ActivityLogItem extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { ...stateSetter(props),
+    this.state = {
       showRawJson: false
     };
 
     this.styler = createStyler(style);
-    this._onChange = this._onChange.bind(this);
     this.toggleRawJson = this.toggleRawJson.bind(this);
-  }
-
-  componentDidMount() {
-    DomainStore.addChangeListener(this._onChange);
-    RouteStore.addChangeListener(this._onChange);
-  }
-
-  componentWillReceiveProps(props) {
-    this.setState(stateSetter(props));
-  }
-
-  componentWillUnmount() {
-    DomainStore.removeChangeListener(this._onChange);
-    RouteStore.removeChangeListener(this._onChange);
-  }
-
-  _onChange() {
-    this.setState(stateSetter(this.props));
   }
 
   formatTimestamp(timestamp) {
@@ -119,10 +81,8 @@ export default class ActivityLogItem extends React.Component {
   get eventContent() {
     let content = `${this.props.item.type} isn't handled`;
     let url = 'a url';
-    const item = this.props.item;
+    const { domain, item, route } = this.props;
     const metadata = item.metadata;
-    const route = this.state.route;
-    const domain = this.state.domain;
     if (route && domain) {
       url = formatRoute(domain.name, route.host, route.path);
     }
@@ -165,7 +125,7 @@ export default class ActivityLogItem extends React.Component {
         );
       }
     } else if (item.type === 'audit.service_binding.create') {
-      const service = this.state.service;
+      const service = this.props.service;
       const serviceText = (service) ? service.guid : 'a service';
       content = (
         <span>{ item.actor_name} bound { serviceText } to the app.</span>
@@ -234,5 +194,8 @@ export default class ActivityLogItem extends React.Component {
 }
 
 ActivityLogItem.propTypes = {
-  item: React.PropTypes.object.isRequired
+  domain: React.PropTypes.object,
+  item: React.PropTypes.object.isRequired,
+  route: React.PropTypes.object,
+  service: React.PropTypes.object
 };

--- a/static_src/components/activity_log_item.jsx
+++ b/static_src/components/activity_log_item.jsx
@@ -9,17 +9,10 @@ import ElasticLineItem from './elastic_line_item.jsx';
 import formatRoute from '../util/format_route';
 import RouteStore from '../stores/route_store';
 import DomainStore from '../stores/domain_store';
-import ServiceInstanceStore from '../stores/service_instance_store';
-
 
 function stateSetter(props) {
-  const item = props.item;
+  const { item, service } = props;
   const route = RouteStore.get(item.metadata.route_guid);
-
-  let service;
-  if (item.metadata.request && item.metadata.service_instance_guid) {
-    service = ServiceInstanceStore.get(item.metadata.request.service_instance_guid);
-  }
 
   let domain;
   if (route) {
@@ -49,13 +42,15 @@ export default class ActivityLogItem extends React.Component {
   componentDidMount() {
     DomainStore.addChangeListener(this._onChange);
     RouteStore.addChangeListener(this._onChange);
-    ServiceInstanceStore.addChangeListener(this._onChange);
+  }
+
+  componentWillReceiveProps(props) {
+    this.setState(stateSetter(props));
   }
 
   componentWillUnmount() {
     DomainStore.removeChangeListener(this._onChange);
     RouteStore.removeChangeListener(this._onChange);
-    ServiceInstanceStore.removeChangeListener(this._onChange);
   }
 
   _onChange() {

--- a/static_src/test/global_setup.js
+++ b/static_src/test/global_setup.js
@@ -221,3 +221,25 @@ beforeEach(function() {
 jasmine.jasmineSinon = {
   messageFactories: messageFactories
 };
+
+beforeEach(() => {
+  // Any call to console.warn or console.error should fail the test. If
+  // console.warn or console.error is expected, they should be stubbed
+  // appropriately.
+  sinon.stub(console, 'warn').throws(
+    new Error(
+      `Unexpected call to console.warn during a test. Please add an expectation or fix the test.`
+    )
+  );
+  // TODO enable the same for console.error
+  //sinon.stub(console, 'error').throws(
+  //  new Error(
+  //    `Unexpected call to console.error during a test. Please add an expectation or fix the test.`
+  //  )
+  //);
+});
+
+afterEach(function () {
+  console.warn.restore();
+  //console.error.restore();
+});

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -63,6 +63,15 @@ describe('BaseStore', () => {
 
       expect(spy).toHaveBeenCalledOnce();
     });
+
+    it('warns if called more than MAX_LISTENERS_THRESHOLD', function () {
+      console.warn.returns();
+      for (let i = 1; i <= 11; i++) {
+        store.addChangeListener(() => {});
+      }
+
+      expect(console.warn).toHaveBeenCalledOnce();
+    });
   });
 
   describe('removeChangeListener()', function() {


### PR DESCRIPTION
Adds a warning when we are getting close to maxing out the number of listeners on a store. Currently `DomainStore` and `RouteStore` also have listeners within `ActivityLogItem` and could be hoisted up in the same way.