### PR TITLE
Refactor Usage and Limits form

### DIFF
--- a/static_src/components/form/form_element.jsx
+++ b/static_src/components/form/form_element.jsx
@@ -34,6 +34,14 @@ export default class FormElement extends React.Component {
     this.validate();
   }
 
+  componentWillReceiveProps(props) {
+    // If our validator changed, we want to update the error state.
+    // TODO we probably also want to notify others about the validation result,
+    // but this is a poor place to do it.
+    const err = props.validator(this.state.value, props.label);
+    this.setState({ err });
+  }
+
   componentWillUnmount() {
     if (this.props.detatchFromForm) {
       this.props.detatchFromForm(this);

--- a/static_src/components/form/form_element.jsx
+++ b/static_src/components/form/form_element.jsx
@@ -10,12 +10,15 @@ function nextId() {
 export default class FormElement extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { err: null };
+    this.state = {
+      err: null,
+      value: this.props.value || ''
+    };
+
     if (!this.props.key) {
       this.state.id = nextId();
     }
 
-    Object.assign(this.state, this.checkValidationFromProps(props));
     this.componentWillMount = this.componentWillMount.bind(this);
     this.componentWillUnmount = this.componentWillUnmount.bind(this);
     this.onChange = this.onChange.bind(this);
@@ -27,8 +30,8 @@ export default class FormElement extends React.Component {
     }
   }
 
-  componentWillReceiveProps(props) {
-    this.setState(this.checkValidationFromProps(props));
+  componentDidMount() {
+    this.validate();
   }
 
   componentWillUnmount() {
@@ -45,17 +48,6 @@ export default class FormElement extends React.Component {
 
   get classes() {
     return this.props.classes.length ? classNames(...this.props.classes) : this.props.className;
-  }
-
-  checkValidationFromProps(props) {
-    if (props.value === undefined) {
-      return {};
-    }
-
-    // Only if an initial value is set, validate it
-    const value = props.value;
-    const err = props.validator && props.validator(value);
-    return { value, err };
   }
 
   validate() {

--- a/static_src/components/form/form_number.jsx
+++ b/static_src/components/form/form_number.jsx
@@ -1,21 +1,21 @@
 import React from 'react';
 
 import FormText from './form_text.jsx';
-import { validateNumber } from '../../util/validators';
+import { validateInteger } from '../../util/validators';
 
 
 export default class FormNumber extends React.Component {
   constructor(props) {
     super(props);
-    this.validateNumber = validateNumber({ max: props.max, min: props.min }).bind(this);
+    this.validateInteger = validateInteger({ max: props.max, min: props.min }).bind(this);
   }
 
   componentWillReceiveProps(props) {
-    this.validateNumber = validateNumber({ max: props.max, min: props.min }).bind(this);
+    this.validateInteger = validateInteger({ max: props.max, min: props.min }).bind(this);
   }
 
   render() {
-    const props = Object.assign({}, this.props, { validator: this.validateNumber });
+    const props = Object.assign({}, this.props, { validator: this.validateInteger });
     return <FormText { ...props } />;
   }
 }

--- a/static_src/components/form/form_text.jsx
+++ b/static_src/components/form/form_text.jsx
@@ -21,39 +21,38 @@ export default class FormText extends FormElement {
     return <FormError message={ this.state.err.message } />;
   }
 
-  get inline() {
-    const errorClass = !!this.error && 'error';
-    return (
-      <span className={ this.styler(errorClass) }>
-        <input type="text" id={ this.key } value={ this.state.value }
-          onChange={ this.onChange } className={ this.classes }
-        />
-        { this.error }
-      </span>
-    );
-  }
+  render() {
+    const classes = [];
 
-  get content() {
+    if (this.props.inline) {
+      classes.push('form_text-inline');
+    }
+
+    if (!!this.error) {
+      classes.push('error');
+    }
+
+    // Spaces in label give a healthy space for inline forms
+    const label = <label htmlFor={ this.key }> { this.props.label } </label>;
     return (
-      <div>
-        { this.error }
-        <label htmlFor={ this.key }>{ this.props.label }</label>
+      <div className={ this.styler(classes) }>
+        { !this.props.labelAfter && label }
         <input type="text" id={ this.key } value={ this.state.value }
           onChange={ this.onChange } className={ this.classes }
         />
+        { this.props.labelAfter && label }
+        { this.error }
       </div>
     );
-  }
-
-  render() {
-    return this.props.inline ? this.inline : this.content;
   }
 }
 
 FormText.propTypes = Object.assign({}, FormElement.propTypes, {
-  inline: React.PropTypes.bool
+  inline: React.PropTypes.bool,
+  labelAfter: React.PropTypes.bool
 });
 
 FormText.defaultProps = Object.assign({}, FormElement.defaultProps, {
-  inline: false
+  inline: false,
+  labelAfter: false
 });

--- a/static_src/components/form/form_text.jsx
+++ b/static_src/components/form/form_text.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
+import style from 'cloudgov-style/css/cloudgov-style.css';
 import FormElement from './form_element.jsx';
 import FormError from './form_error.jsx';
+import createStyler from '../../util/create_styler';
 
 
 export default class FormText extends FormElement {
   constructor(props) {
     super(props);
     this.state = this.state || {};
+    this.styler = createStyler(style);
   }
 
   get error() {
@@ -19,8 +22,9 @@ export default class FormText extends FormElement {
   }
 
   get inline() {
+    const errorClass = !!this.error && 'error';
     return (
-      <span>
+      <span className={ this.styler(errorClass) }>
         <input type="text" id={ this.key } value={ this.state.value }
           onChange={ this.onChange } className={ this.classes }
         />

--- a/static_src/components/resource_usage.jsx
+++ b/static_src/components/resource_usage.jsx
@@ -44,10 +44,9 @@ export default class ResourceUsage extends React.Component {
 
   render() {
     const props = this.props;
-    const title = <h2 className={ this.styler('stat-header')}>{ props.title }</h2>;
 
     let properties = {
-      title,
+      title: props.title,
       primaryStat: props.amountTotal,
       secondaryInfo: props.secondaryInfo,
       editable: props.editable,

--- a/static_src/components/stat.jsx
+++ b/static_src/components/stat.jsx
@@ -61,6 +61,11 @@ export default class Stat extends React.Component {
   }
 
   onValidate(err, value) {
+    if (err) {
+      // No need to update model on error
+      return;
+    }
+
     // TODO the max/min limits don't match this unit, the validators work on
     // raw input rather than the converted value.
     const unit = this.state.unit;

--- a/static_src/components/stat.jsx
+++ b/static_src/components/stat.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
-import { FormNumber, FormText } from './form';
+import { FormNumber } from './form';
 import createStyler from '../util/create_styler';
 import formatBytes from '../util/format_bytes';
 
@@ -103,12 +103,13 @@ export default class Stat extends React.Component {
     if (this.props.editable) {
       primaryStat = (
         <div className={ this.styler('stat-primary')}>
-          <StatFormNumber
+          <FormNumber
             className={ this.styler('stat-input', 'stat-input-text') }
             type="text"
             id={ `${this.props.name}-value` }
             inline
             label="MB"
+            labelAfter
             name={ `${this.props.name}-value` }
             value={ this.fromBytes(this.state.primaryStat) }
             min={ this.props.min }
@@ -133,37 +134,3 @@ export default class Stat extends React.Component {
 
 Stat.propTypes = propTypes;
 Stat.defaultProps = defaultProps;
-
-class StatFormNumber extends FormNumber {
-  render() {
-    const props = Object.assign({}, this.props, { validator: this.validateNumber });
-    return <StatFormText { ...props } />;
-  }
-}
-
-
-// Extend FormText for control over layout
-class StatFormText extends FormText {
-  constructor(props) {
-    super(props);
-    this.styler = createStyler(style);
-  }
-
-  render() {
-    const errorClass = !!this.error && 'error';
-    return (
-      <span className={ this.styler(errorClass) }>
-        <input type="text" id={ this.key } value={ this.state.value }
-          onChange={ this.onChange } className={ this.classes }
-        />
-        <label
-          className={ this.styler('stat-input', 'stat-input-label') }
-          htmlFor={ `${this.props.name}-value` }
-        >{ this.props.label }</label>
-        <div>
-          { this.error }
-        </div>
-      </span>
-    );
-  }
-}

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -217,7 +217,8 @@ export default class UsageAndLimits extends React.Component {
     );
   }
 
-  _onSubmit() {
+  _onSubmit(e) {
+    e.preventDefault();
     appActions.updateApp(this.props.app.guid, this.state.partialApp);
     this.setState({ editing: false });
   }

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -172,6 +172,11 @@ export default class UsageAndLimits extends React.Component {
 
   get scale() {
     const onValidate = (err, value) => {
+      if (err) {
+        // No need to update model on error
+        return;
+      }
+
       this._onChange('instances', value);
     };
 

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -206,7 +206,7 @@ export default class UsageAndLimits extends React.Component {
     }
 
     return (
-      <div className={ this.styler('stat-single_box') }>
+      <div className={ this.styler('stat', 'stat-single_box') }>
         <h2 className={ this.styler('stat-header')}>Instances</h2>
 	{ instances }
         <br />

--- a/static_src/test/unit/util/validators.spec.js
+++ b/static_src/test/unit/util/validators.spec.js
@@ -1,16 +1,16 @@
 import '../../global_setup.js';
 
-import { validateNumber } from '../../../util/validators';
+import { validateInteger } from '../../../util/validators';
 
 describe('vaidateNumber', function () {
   it('returns a function', function () {
-    expect(typeof validateNumber()).toBe('function');
+    expect(typeof validateInteger()).toBe('function');
   });
 
   describe('given no options', function () {
     let validator;
     beforeEach(function () {
-      validator = validateNumber();
+      validator = validateInteger();
     });
 
     it('fails for empty', function () {
@@ -48,7 +48,7 @@ describe('vaidateNumber', function () {
     let validator;
 
     beforeEach(function () {
-      validator = validateNumber({ max: 1024 });
+      validator = validateInteger({ max: 1024 });
     });
 
     it('fails for above max', function () {
@@ -71,7 +71,7 @@ describe('vaidateNumber', function () {
     let validator;
 
     beforeEach(function () {
-      validator = validateNumber({ min: 1 });
+      validator = validateInteger({ min: 1 });
     });
 
     it('fails for below min', function () {
@@ -94,7 +94,7 @@ describe('vaidateNumber', function () {
     let validator;
 
     beforeEach(function () {
-      validator = validateNumber({ min: 1, max: 1024 });
+      validator = validateInteger({ min: 1, max: 1024 });
     });
 
     it('fails invalid', function () {

--- a/static_src/test/unit/util/validators.spec.js
+++ b/static_src/test/unit/util/validators.spec.js
@@ -18,8 +18,18 @@ describe('vaidateNumber', function () {
       expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID' });
     });
 
+    it('fails for 1234asdf', function () {
+      const result = validator('1234asdf');
+      expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID' });
+    });
+
     it('fails for NaN', function () {
       const result = validator('Not a number');
+      expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID' });
+    });
+
+    it('fails for float string', function () {
+      const result = validator('13.37');
       expect(result).toEqual({ message: 'Invalid number', type: 'NUMBER_INVALID' });
     });
 
@@ -35,11 +45,6 @@ describe('vaidateNumber', function () {
 
     it('passes for zero', function () {
       const result = validator('0');
-      expect(result).toBe(null);
-    });
-
-    it('passes for float string', function () {
-      const result = validator('13.37');
       expect(result).toBe(null);
     });
   });

--- a/static_src/util/validators.js
+++ b/static_src/util/validators.js
@@ -1,6 +1,6 @@
-export function validateNumber(options) {
+export function validateInteger(options) {
   const { max, min } = options || {};
-  return function _validateNumber(text) {
+  return function _validateInteger(text) {
     const value = parseInt(text, 10);
     if (typeof value !== 'number') {
       return { message: 'Invalid number', type: 'NUMBER_INVALID' };

--- a/static_src/util/validators.js
+++ b/static_src/util/validators.js
@@ -1,7 +1,12 @@
 export function validateInteger(options) {
   const { max, min } = options || {};
   return function _validateInteger(text) {
-    const value = parseInt(text, 10);
+    let value = text || '';
+    if (!/^-?\d+$/.test(String(value).trim())) {
+      return { message: 'Invalid number', type: 'NUMBER_INVALID' };
+    }
+
+    value = parseInt(text, 10);
     if (typeof value !== 'number') {
       return { message: 'Invalid number', type: 'NUMBER_INVALID' };
     }


### PR DESCRIPTION
- Avoids double binding of `partialApp` state with the form state and causing `NaN` to show up in the form
- Make the `FormText` component more configurable in how the elements are laid out
- Remove the custom `StatForm*` components
- Fix error styling on "instances" form