### PR TITLE
Fix app label when no text

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -104,7 +104,7 @@ export default class AppContainer extends React.Component {
     }
 
     if (worstState) {
-      label = <span className={ this.styler('usa-label') }>{ worstState }</span>
+      label = <span className={ this.styler('usa-label') }>{ worstState }</span>;
     }
 
     return label;

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -94,6 +94,7 @@ export default class AppContainer extends React.Component {
   }
 
   get statusUI() {
+    let label;
     let worstState = this.state.app.state;
     if (this.state.app.state === appStates.started) {
       // If the app is started, use the instance state
@@ -102,9 +103,11 @@ export default class AppContainer extends React.Component {
       );
     }
 
-    return (
-      <span className={ this.styler('usa-label') }>{ worstState }</span>
-    );
+    if (worstState) {
+      label = <span className={ this.styler('usa-label') }>{ worstState }</span>
+    }
+
+    return label;
   }
 
   get openApp() {


### PR DESCRIPTION
When there's not label text for an app, the label should not be
rendered at all, otherwise an awkward blue circle appears.

This is what bug looked like:
![screen shot 2017-02-24 at 12 02 30 pm](https://cloud.githubusercontent.com/assets/1701077/23318917/471ca850-fa89-11e6-8f5b-c65de7477154.png)
