### PR TITLE
FormStore

### DIFF
--- a/static_src/actions/form_actions.js
+++ b/static_src/actions/form_actions.js
@@ -1,0 +1,44 @@
+
+/*
+ * Actions for app entities. Any actions such as fetching, creating, updating,
+ * etc should go here.
+ */
+
+import AppDispatcher from '../dispatcher.js';
+import { formActionTypes } from '../constants';
+
+const formActions = {
+  changeField(formGuid, fieldName, fieldValue) {
+    AppDispatcher.handleUIAction({
+      type: formActionTypes.FORM_FIELD_CHANGE,
+      formGuid,
+      fieldName,
+      fieldValue
+    });
+
+    return Promise.resolve();
+  },
+
+  changeFieldSuccess(formGuid, fieldName) {
+    AppDispatcher.handleUIAction({
+      type: formActionTypes.FORM_FIELD_CHANGE_SUCCESS,
+      formGuid,
+      fieldName
+    });
+
+    return Promise.resolve();
+  },
+
+  changeFieldError(formGuid, fieldName, error) {
+    AppDispatcher.handleUIAction({
+      type: formActionTypes.FORM_FIELD_CHANGE_ERROR,
+      formGuid,
+      fieldName,
+      error
+    });
+
+    return Promise.resolve();
+  }
+};
+
+export default formActions;

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -9,6 +9,7 @@ import ReactDOM from 'react-dom';
 import Box from './box.jsx';
 import Action from './action.jsx';
 import { Form, FormText, FormSelect, FormElement, FormError } from './form';
+import FormStore from '../stores/form_store';
 import Loading from './loading.jsx';
 import OrgStore from '../stores/org_store.js';
 import SpaceStore from '../stores/space_store.js';
@@ -36,9 +37,11 @@ export default class CreateServiceInstance extends React.Component {
       createError: ServiceInstanceStore.createError
     };
 
+    // Create the form in the store
+    FormStore.create('create-service-form');
+
     this.validateString = validateString().bind(this);
     this._onChange = this._onChange.bind(this);
-    this._onValidateForm = this._onValidateForm.bind(this);
     this._onValidForm = this._onValidForm.bind(this);
     this._onCancelForm = this._onCancelForm.bind(this);
     this.styler = createStyler(style);
@@ -64,16 +67,14 @@ export default class CreateServiceInstance extends React.Component {
     this.scrollIntoView();
   }
 
-  _onValidateForm(errs) {
-    this.setState({ errs });
-  }
-
-  _onValidForm(values) {
-    serviceActions.createInstance(
-      values.name,
-      values.space,
-      this.props.servicePlan.guid
-    );
+  _onValidForm(errs, values) {
+    this.setState({ errs }, () => {
+      serviceActions.createInstance(
+        values.name.value,
+        values.space.value,
+        this.props.servicePlan.guid
+      );
+    });
   }
 
   _onCancelForm(ev) {
@@ -113,12 +114,11 @@ export default class CreateServiceInstance extends React.Component {
     return (
       <div className = { this.styler('actions-large') }>
         { createError }
-        <Form action="/service_instances"
+        <Form
+          guid="create-service-form"
           classes={ ['test-create_service_instance_form'] }
-          method="post"
           ref="form"
-          onValidate={ this._onValidateForm }
-          onValid={ this._onValidForm }
+          onSubmit={ this._onValidForm }
         >
           <legend>
             Create a service instance for <strong
@@ -128,12 +128,14 @@ export default class CreateServiceInstance extends React.Component {
             { this.servicePlanName }</strong> plan.
           </legend>
           <FormText
+            formGuid="create-service-form"
             classes={ ['test-create_service_instance_name'] }
             label="Choose a name for the service instance"
             name="name"
             validator={ this.validateString }
           />
           <FormSelect
+            formGuid="create-service-form"
             classes={ ['test-create_service_instance_space'] }
             label="Select the space for the service instance"
             name="space"

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -18,6 +18,8 @@ import serviceActions from '../actions/service_actions.js';
 import createStyler from '../util/create_styler';
 import { validateString } from '../util/validators';
 
+const CREATE_SERVICE_INSTANCE_FORM_GUID = 'create-service-form';
+
 function stateSetter() {
   return {
     createError: ServiceInstanceStore.createError,
@@ -38,7 +40,7 @@ export default class CreateServiceInstance extends React.Component {
     };
 
     // Create the form in the store
-    FormStore.create('create-service-form');
+    FormStore.create(CREATE_SERVICE_INSTANCE_FORM_GUID);
 
     this.validateString = validateString().bind(this);
     this._onChange = this._onChange.bind(this);
@@ -115,7 +117,7 @@ export default class CreateServiceInstance extends React.Component {
       <div className = { this.styler('actions-large') }>
         { createError }
         <Form
-          guid="create-service-form"
+          guid={ CREATE_SERVICE_INSTANCE_FORM_GUID }
           classes={ ['test-create_service_instance_form'] }
           ref="form"
           onSubmit={ this._onValidForm }
@@ -128,14 +130,14 @@ export default class CreateServiceInstance extends React.Component {
             { this.servicePlanName }</strong> plan.
           </legend>
           <FormText
-            formGuid="create-service-form"
+            formGuid={ CREATE_SERVICE_INSTANCE_FORM_GUID }
             classes={ ['test-create_service_instance_name'] }
             label="Choose a name for the service instance"
             name="name"
             validator={ this.validateString }
           />
           <FormSelect
-            formGuid="create-service-form"
+            formGuid={ CREATE_SERVICE_INSTANCE_FORM_GUID }
             classes={ ['test-create_service_instance_space'] }
             label="Select the space for the service instance"
             name="space"

--- a/static_src/components/form/form_element.jsx
+++ b/static_src/components/form/form_element.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import formActions from '../../actions/form_actions';
 
 let currid = 0;
 function nextId() {
@@ -10,8 +11,9 @@ function nextId() {
 export default class FormElement extends React.Component {
   constructor(props) {
     super(props);
+    const err = props.validator(this.props.value, props.label);
     this.state = {
-      err: null,
+      err,
       value: this.props.value || ''
     };
 
@@ -19,55 +21,40 @@ export default class FormElement extends React.Component {
       this.state.id = nextId();
     }
 
-    this.componentWillMount = this.componentWillMount.bind(this);
-    this.componentWillUnmount = this.componentWillUnmount.bind(this);
     this.onChange = this.onChange.bind(this);
-  }
-
-  componentWillMount() {
-    if (this.props.attachToForm) {
-      this.props.attachToForm(this);
-    }
-  }
-
-  componentDidMount() {
-    this.validate();
   }
 
   componentWillReceiveProps(props) {
     // If our validator changed, we want to update the error state.
     // TODO we probably also want to notify others about the validation result,
     // but this is a poor place to do it.
-    const err = props.validator(this.state.value, props.label);
-    this.setState({ err });
-  }
-
-  componentWillUnmount() {
-    if (this.props.detatchFromForm) {
-      this.props.detatchFromForm(this);
+    if (this.props.validator !== props.validator) {
+      const err = props.validator(this.state.value, props.label);
+      this.setState({ err, value: props.value });
     }
   }
 
   onChange(e) {
-    this.setState({ value: e.target.value }, () => {
-      this.validate();
+    const value = e.target.value;
+    const err = this.props.validator(value, this.props.label);
+    this.setState({ err, value }, () => {
+      formActions.changeField(this.props.formGuid, this.props.name, value)
+        .then(() => {
+          let promise;
+          if (err) {
+            err.value = value;
+            promise = formActions.changeFieldError(this.props.formGuid, this.props.name, err);
+          } else {
+            promise = formActions.changeFieldSuccess(this.props.formGuid, this.props.name);
+          }
+
+          return promise;
+        });
     });
   }
 
   get classes() {
     return this.props.classes.length ? classNames(...this.props.classes) : this.props.className;
-  }
-
-  validate() {
-    const value = this.state.value;
-    const err = this.props.validator(value, this.props.label);
-    if (err) {
-      err.value = value;
-    }
-
-    this.props.onValidate(err, value);
-    this.setState({ err });
-    return err;
   }
 
   get key() {
@@ -76,12 +63,12 @@ export default class FormElement extends React.Component {
 }
 
 FormElement.propTypes = {
-  attachToForm: React.PropTypes.func,
   classes: React.PropTypes.array,
   className: React.PropTypes.string,
-  detatchFromForm: React.PropTypes.func,
+  formGuid: React.PropTypes.string.isRequired,
   key: React.PropTypes.string,
   label: React.PropTypes.string,
+  name: React.PropTypes.string.isRequired,
   onValidate: React.PropTypes.func,
   validator: React.PropTypes.func,
   value: React.PropTypes.any

--- a/static_src/components/form/form_element.jsx
+++ b/static_src/components/form/form_element.jsx
@@ -11,9 +11,8 @@ function nextId() {
 export default class FormElement extends React.Component {
   constructor(props) {
     super(props);
-    const err = props.validator(this.props.value, props.label);
     this.state = {
-      err,
+      err: null, // Forms should all be initialized without errors
       value: this.props.value || ''
     };
 
@@ -36,7 +35,7 @@ export default class FormElement extends React.Component {
 
   onChange(e) {
     const value = e.target.value;
-    const err = this.props.validator(value, this.props.label);
+    const err = this.props.validator(value, this.props.name);
     this.setState({ err, value }, () => {
       formActions.changeField(this.props.formGuid, this.props.name, value)
         .then(() => {

--- a/static_src/components/form/form_select.jsx
+++ b/static_src/components/form/form_select.jsx
@@ -11,11 +11,6 @@ export default class FormSelect extends FormElement {
     this.state = this.state || {};
     this.state.value = '';
     this.state.err = null;
-    this._handleChange = this._handleChange.bind(this);
-  }
-
-  _handleChange(ev) {
-    this.setState({ value: ev.target.value });
   }
 
   render() {
@@ -32,7 +27,7 @@ export default class FormSelect extends FormElement {
           className={ this.classes }
           name={ this.key }
           id={ this.key }
-          onChange={ this._handleChange }
+          onChange={ this.onChange }
           value={ this.state.value }
         >
           <option value="" key={ `${this.key}-null` }>

--- a/static_src/components/resource_usage.jsx
+++ b/static_src/components/resource_usage.jsx
@@ -9,6 +9,7 @@ import formatBytes from '../util/format_bytes';
 import Stat from './stat.jsx';
 
 const propTypes = {
+  formGuid: React.PropTypes.string,
   max: React.PropTypes.number,
   min: React.PropTypes.number,
   onChange: React.PropTypes.func,
@@ -53,7 +54,8 @@ export default class ResourceUsage extends React.Component {
       max: props.max,
       min: props.min,
       onChange: props.onChange,
-      name: props.name
+      name: props.name,
+      formGuid: props.formGuid
     };
 
     if (props.amountUsed && props.amountTotal) {

--- a/static_src/components/stat.jsx
+++ b/static_src/components/stat.jsx
@@ -17,6 +17,7 @@ const STATES = [
 ];
 
 const propTypes = {
+  formGuid: React.PropTypes.string,
   name: React.PropTypes.string,
   title: React.PropTypes.string,
   editable: React.PropTypes.bool,
@@ -104,13 +105,14 @@ export default class Stat extends React.Component {
       primaryStat = (
         <div className={ this.styler('stat-primary')}>
           <FormNumber
+            formGuid={ this.props.formGuid }
             className={ this.styler('stat-input', 'stat-input-text') }
             type="text"
-            id={ `${this.props.name}-value` }
+            id={ this.props.name }
             inline
             label="MB"
             labelAfter
-            name={ `${this.props.name}-value` }
+            name={ this.props.name }
             value={ this.fromBytes(this.state.primaryStat) }
             min={ this.props.min }
             max={ this.props.max }

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -206,7 +206,6 @@ export default class UsageAndLimits extends React.Component {
 
   _onSubmit(errors, form) {
     if (errors.length) {
-      console.warn({ errors }); // eslint-disable-line no-console
       return;
     }
 

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -36,6 +36,16 @@ const errorActionTypes = keymirror({
   DISMISS: null
 });
 
+const formActionTypes = keymirror({
+  // User has changed a form field
+  FORM_FIELD_CHANGE: null,
+  // The form field change was valid
+  FORM_FIELD_CHANGE_SUCCESS: null,
+  // The form field change is not a valid input
+  FORM_FIELD_CHANGE_ERROR: null
+});
+
+
 const loginActionTypes = keymirror({
   // Action of fetching a login status, whether the user is logged in or not.
   FETCH_STATUS: null,
@@ -296,6 +306,7 @@ export {
   appStates,
   domainActionTypes,
   errorActionTypes,
+  formActionTypes,
   loginActionTypes,
   orgActionTypes,
   pageActionTypes,

--- a/static_src/stores/form_store.js
+++ b/static_src/stores/form_store.js
@@ -1,0 +1,89 @@
+
+import BaseStore from './base_store.js';
+import { formActionTypes } from '../constants.js';
+
+
+export class FormStore extends BaseStore {
+  constructor() {
+    super();
+    this.subscribe(() => this._registerToActions.bind(this));
+  }
+
+  getFormField(formGuid, fieldName) {
+    const form = this.get(formGuid, false);
+    if (!form) {
+      return null;
+    }
+
+    return form.fields[fieldName];
+  }
+
+  create(formGuid, initialData) {
+    const formFields = Object.keys(initialData)
+      .reduce((fields, fieldName) => {
+        const formField = {
+          name: fieldName,
+          value: initialData[fieldName]
+        };
+
+        return { ...fields, [fieldName]: formField };
+      }, {});
+
+    const form = { guid: formGuid, fields: formFields };
+    this.push(form);
+    return form;
+  }
+
+  _registerToActions(action) {
+    switch (action.type) {
+      case formActionTypes.FORM_FIELD_CHANGE: {
+        // Update the form field value
+        const form = this.get(action.formGuid);
+        const changedFormField = Object.assign(
+          {},
+          form.fields[action.fieldName],
+          { value: action.fieldValue }
+        );
+
+        form.fields[action.fieldName] = changedFormField;
+        this.merge('guid', form);
+        break;
+      }
+
+      case formActionTypes.FORM_FIELD_CHANGE_SUCCESS: {
+        // Clear any error
+        const form = this.get(action.formGuid);
+        const changedFormField = Object.assign(
+          {},
+          form.fields[action.fieldName],
+          { error: null }
+        );
+
+        form.fields[action.fieldName] = changedFormField;
+        this.merge('guid', form);
+        break;
+      }
+
+      case formActionTypes.FORM_FIELD_CHANGE_ERROR: {
+        // Set the error
+        const form = this.get(action.formGuid);
+        const changedFormField = Object.assign(
+          {},
+          form.fields[action.fieldName],
+          { error: action.error }
+        );
+
+        form.fields[action.fieldName] = changedFormField;
+        this.merge('guid', form);
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+}
+
+const _formStore = new FormStore();
+
+export default _formStore;

--- a/static_src/stores/form_store.js
+++ b/static_src/stores/form_store.js
@@ -19,7 +19,7 @@ export class FormStore extends BaseStore {
   }
 
   create(formGuid, initialData) {
-    const formFields = Object.keys(initialData)
+    const formFields = Object.keys(initialData || {})
       .reduce((fields, fieldName) => {
         const formField = {
           name: fieldName,


### PR DESCRIPTION
This introduces a `FormStore` to manage forms. Each form must be assigned a unique guid. Components using form can hook into the `onSubmit` handler of the form, or they can subscribe to `FormStore` changes to react to individual form field changes.

Initially we discussed putting the validators in the form model itself, but this ended up being difficult, because it resulted in cascading changes (value in fieldA changes -> validator of formB changes -> error of formB changes). More work would be needed to do this. The advantage is that the actions could handle the success/error actions more transparently, simplifying `FormElement`. The downside is that it's a bit awkward for the component to juggle FormStore changes and then update the validators through a series of form change events (potentially one for each form field).