### PR TITLE
Split skin config for e/w and govcloud

### DIFF
--- a/static_src/actions/error_actions.js
+++ b/static_src/actions/error_actions.js
@@ -38,11 +38,10 @@ export default {
   },
 
   importantDataFetchError(err, entityMessage) {
-    let msg = 'There was an issue connecting to dashboard.cloud.gov, please try again later.';
+    console.error(err);
 
-    if (entityMessage) {
-      msg = `There was an issue connecting to dashboard.cloud.gov, ${entityMessage}`;
-    }
+    const msg = `There was an issue connecting to the dashboard,
+      ${entityMessage || 'please try again later.'}`;
 
     AppDispatcher.handleServerAction({
       type: errorActionTypes.IMPORTANT_FETCH,

--- a/static_src/components/activity_log.jsx
+++ b/static_src/components/activity_log.jsx
@@ -8,7 +8,6 @@ import DomainStore from '../stores/domain_store';
 import PanelActions from './panel_actions.jsx';
 import RouteStore from '../stores/route_store';
 import createStyler from '../util/create_styler';
-import { config } from 'skin';
 import ServiceInstanceStore from '../stores/service_instance_store';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -84,10 +83,6 @@ export default class ActivityLog extends React.Component {
     this.setState(currentState);
   }
 
-  get documentation() {
-    return <config.snippets.logs />;
-  }
-
   showMoreActivity() {
     if (this.state.activity.length > this.props.maxItems &&
         this.state.activity.length >= this.state.maxItems) {
@@ -114,7 +109,6 @@ export default class ActivityLog extends React.Component {
         );
       content = (
         <div>
-          { this.documentation }
           <ul className={ this.styler('activity_log') }>
             { this.state.activity
                 .slice(0, this.state.maxItems)

--- a/static_src/components/global_error.jsx
+++ b/static_src/components/global_error.jsx
@@ -38,7 +38,7 @@ export default class GlobalError extends React.Component {
     const err = this.props.err;
     const link = (config.docs.status) && (
       <span> check <a target="_blank" href={ config.docs.status }>
-        { config.platform_name }'s status</a> or
+        { config.platform.name }'s status</a> or
       </span>
     );
 

--- a/static_src/components/info_logs.jsx
+++ b/static_src/components/info_logs.jsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 
+import { config } from 'skin';
 import PanelActions from './panel_actions.jsx';
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -15,7 +16,7 @@ export default class InfoLogs extends React.Component {
     return (
       <PanelActions>
         <p>
-          View more logs at <a href="https://logs.cloud.gov">logs.cloud.gov</a> (for East/West environment) or <a href="https://logs.fr.cloud.gov">logs.fr.cloud.gov</a> (for GovCloud environment).
+          View more logs at <a href={ config.platform.logs.url }>{ config.platform.logs.name }</a>.
         </p>
       </PanelActions>
     );

--- a/static_src/skins/cloud.gov/index.js
+++ b/static_src/skins/cloud.gov/index.js
@@ -1,0 +1,114 @@
+/**
+ * This file provides deployment specific configuration and content for the
+ * dashboard. If you wish to override anything in this file:
+ *
+ * * Create a new configuration file in `skins/<name>/index.js`
+ * * Import this configuration
+ * * Override any variables you wish to change
+ * * Export the new configuration as a `const` called `config`
+ * * Set the CF_SKIN environment variable to the name of your new skin directory
+ *
+ * Example
+ *
+ * ```
+ * import merge from 'deepmerge';
+ * import { config as baseConfig } from '../cg';
+ *
+ * const newConfig = merge(baseConfig, {
+ *   header: {
+ *     disclaimer: 'My awesome disclaimer',
+ *   },
+ *   github: {
+ *     url: 'https://github.com/best-username/cg-dashboard'
+ *   }
+ * });
+ *
+ * // override the entire list of links
+ * newConfig.header.links = [
+ *   {
+ *     text: 'Help',
+ *     url: 'http://google.com'
+ *   }
+ * ]
+ * ;
+ *
+ * export const config = newConfig;
+ * ```
+ */
+
+import React from 'react';
+
+import InfoActivities from '../../components/info_activities.jsx';
+import InfoEnvironments from '../../components/info_environments.jsx';
+import InfoSandbox from '../../components/info_sandbox.jsx';
+import InfoStructure from '../../components/info_structure.jsx';
+import InfoLogs from '../../components/info_logs.jsx';
+
+export const config = {
+  footer: {
+    author_note: <span>Built and maintained by <a href="https://18f.gsa.gov">18F</a></span>,
+    code_note: <span><a href="https://cloud.gov/docs/ops/repos/">Open source</a> and in the public domain</span>,
+    disclaimer: <span>A United States government platform</span>,
+    links: [
+      {
+        text: 'cloud.gov home',
+        url: 'https://cloud.gov'
+      },
+      {
+        text: 'Contact',
+        url: 'https://cloud.gov/docs/help/'
+      },
+      {
+        text: 'Contribute to cloud.gov',
+        url: 'https://cloud.gov/docs/ops/repos/'
+      }
+    ]
+  },
+  header: {
+    disclaimer: 'An official website of the United States government',
+    show_flag: true,
+    links: [
+      {
+        text: 'Documentation',
+        url: 'https://cloud.gov/docs/'
+      },
+      {
+        text: 'Updates',
+        url: 'https://cloud.gov/updates/'
+      },
+      {
+        text: 'Status',
+        url: 'https://cloudgov.statuspage.io/'
+      },
+      {
+        text: 'Contact',
+        url: 'https://cloud.gov/docs/help/'
+      }
+    ]
+  },
+  docs: {
+    cli: 'https://cloud.gov/docs/getting-started/setup/',
+    concepts_spaces: 'https://cloud.gov/docs/getting-started/concepts/',
+    deploying_apps: 'https://cloud.gov/docs/getting-started/your-first-deploy/',
+    use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/',
+    invite_user: 'https://cloud.gov/docs/apps/managing-teammates',
+    managed_services: 'https://docs.cloud.gov/apps/managed-services/',
+    status: 'https://cloudgov.statuspage.io/'
+  },
+  snippets: {
+    logs: InfoLogs
+  },
+  github: {
+    url: 'https://github.com/18F/cg-dashboard'
+  },
+  platform: {
+    name: 'cloud.gov',
+    logs: {
+      name: 'logs.cloud.gov',
+      url: 'https://logs.cloud.gov'
+    }
+  },
+  home: {
+    tiles: [InfoActivities, InfoStructure, InfoSandbox, InfoEnvironments]
+  }
+};

--- a/static_src/skins/fr.cloud.gov/index.js
+++ b/static_src/skins/fr.cloud.gov/index.js
@@ -101,7 +101,13 @@ export const config = {
   github: {
     url: 'https://github.com/18F/cg-dashboard'
   },
-  platform_name: 'cloud.gov',
+  platform: {
+    name: 'cloud.gov',
+    logs: {
+      name: 'logs.fr.cloud.gov',
+      url: 'https://logs.fr.cloud.gov'
+    }
+  },
   home: {
     tiles: [InfoActivities, InfoStructure, InfoSandbox, InfoEnvironments]
   }


### PR DESCRIPTION
- Avoid referring to dashboard.cloud.gov in govcloud
- Print error in ImportantDataFetchError
- Remove duplicate activity log documentation