### PR TITLE
Fixes infinite loading bug on services

### DIFF
--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -141,16 +141,20 @@ export class ServiceInstanceStore extends BaseStore {
       case serviceActionTypes.SERVICE_INSTANCE_RECEIVED: {
         this._fetching = false;
         const instance = action.serviceInstance;
-        this.merge('guid', instance, () => { });
-        this.emitChange();
+        this.merge('guid', instance, () => {
+          // Always emitchange as fetch state was changed.
+          this.emitChange();
+        });
         break;
       }
 
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
         this._fetchAll = false;
         const services = action.serviceInstances;
-        this.mergeMany('guid', services, () => { });
-        this.emitChange();
+        this.mergeMany('guid', services, () => {
+          // Always emitchange as fetch state was changed.
+          this.emitChange();
+        });
         break;
       }
 

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -141,14 +141,16 @@ export class ServiceInstanceStore extends BaseStore {
       case serviceActionTypes.SERVICE_INSTANCE_RECEIVED: {
         this._fetching = false;
         const instance = action.serviceInstance;
-        this.merge('guid', instance);
+        this.merge('guid', instance, () => { });
+        this.emitChange();
         break;
       }
 
       case serviceActionTypes.SERVICE_INSTANCES_RECEIVED: {
         this._fetchAll = false;
         const services = action.serviceInstances;
-        this.mergeMany('guid', services);
+        this.mergeMany('guid', services, () => { });
+        this.emitChange();
         break;
       }
 

--- a/static_src/stores/service_plan_store.js
+++ b/static_src/stores/service_plan_store.js
@@ -54,8 +54,7 @@ export class ServicePlanStore extends BaseStore {
       case serviceActionTypes.SERVICE_PLAN_RECEIVED: {
         const servicePlan = action.servicePlan;
         const servicePlanReceived = Object.assign({}, servicePlan, { fetching: false });
-        this.merge('guid', servicePlanReceived, () => { });
-        this.emitChange();
+        this.merge('guid', servicePlanReceived);
         break;
       }
 

--- a/static_src/stores/service_plan_store.js
+++ b/static_src/stores/service_plan_store.js
@@ -54,7 +54,8 @@ export class ServicePlanStore extends BaseStore {
       case serviceActionTypes.SERVICE_PLAN_RECEIVED: {
         const servicePlan = action.servicePlan;
         const servicePlanReceived = Object.assign({}, servicePlan, { fetching: false });
-        this.merge('guid', servicePlanReceived);
+        this.merge('guid', servicePlanReceived, () => { });
+        this.emitChange();
         break;
       }
 

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -31,8 +31,10 @@ export class ServiceStore extends BaseStore {
         this._fetchAll = false;
         AppDispatcher.waitFor([ServicePlanStore.dispatchToken]);
         const services = action.services;
-        this.mergeMany('guid', services, () => { });
-        this.emitChange();
+        this.mergeMany('guid', services, () => {
+          // Always emitchange as fetch state was changed.
+          this.emitChange();
+        });
         break;
       }
 

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -31,7 +31,8 @@ export class ServiceStore extends BaseStore {
         this._fetchAll = false;
         AppDispatcher.waitFor([ServicePlanStore.dispatchToken]);
         const services = action.services;
-        this.mergeMany('guid', services);
+        this.mergeMany('guid', services, () => { } );
+        this.emitChange();
         break;
       }
 

--- a/static_src/stores/service_store.js
+++ b/static_src/stores/service_store.js
@@ -31,7 +31,7 @@ export class ServiceStore extends BaseStore {
         this._fetchAll = false;
         AppDispatcher.waitFor([ServicePlanStore.dispatchToken]);
         const services = action.services;
-        this.mergeMany('guid', services, () => { } );
+        this.mergeMany('guid', services, () => { });
         this.emitChange();
         break;
       }


### PR DESCRIPTION
The reason the bug was happening:
The service instance store had a `loading` state set to true even after
it was done loading. I couldn't reproduce, but this may have been the
case with the plan store too.

The stores were not manually emitting
a change on the received events. They assume the `merge` methods
would emit a change. But the `merge` functions only emit changes if
something actually changed. So in stores like the instance store, where
separate fetches are happening, I think the instances were already,
meaning nothing had to be merged, meaning emit change didn't get called.
this meant that the loading state was still true on the store.