### PR TITLE
Expressive empty states

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudgov-dashboard",
-  "version": "1.16.1",
+  "version": "1.16.0",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -1151,6 +1151,11 @@
         }
       }
     },
+    "configstore": {
+      "version": "1.4.0",
+      "from": "configstore@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz"
+    },
     "connect": {
       "version": "3.5.0",
       "from": "connect@>=3.3.5 <4.0.0",
@@ -1367,6 +1372,11 @@
       "from": "deep-equal-ident@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/deep-equal-ident/-/deep-equal-ident-1.1.1.tgz"
     },
+    "deep-extend": {
+      "version": "0.4.1",
+      "from": "deep-extend@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+    },
     "deep-is": {
       "version": "0.1.3",
       "from": "deep-is@>=0.1.3 <0.2.0",
@@ -1473,6 +1483,23 @@
       "version": "0.1.1",
       "from": "duplexer@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+    },
+    "duplexify": {
+      "version": "3.5.0",
+      "from": "duplexify@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.0.0",
+          "from": "end-of-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
+        },
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+        }
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1629,6 +1656,11 @@
       "from": "es6-map@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
+    "es6-promise": {
+      "version": "3.3.1",
+      "from": "es6-promise@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
+    },
     "es6-set": {
       "version": "0.1.4",
       "from": "es6-set@>=0.1.3 <0.2.0",
@@ -1744,6 +1776,18 @@
       "version": "0.3.4",
       "from": "event-emitter@>=0.3.4 <0.4.0",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "from": "event-stream@>=3.3.0 <3.4.0",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "dependencies": {
+        "split": {
+          "version": "0.3.3",
+          "from": "split@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+        }
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -1996,6 +2040,11 @@
       "version": "1.1.1",
       "from": "formatio@1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
+    },
+    "from": {
+      "version": "0.1.7",
+      "from": "from@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz"
     },
     "fs-access": {
       "version": "1.0.0",
@@ -2725,6 +2774,18 @@
       "from": "good-listener@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.1.tgz"
     },
+    "got": {
+      "version": "3.3.1",
+      "from": "got@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "from": "object-assign@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.6",
       "from": "graceful-fs@>=4.1.4 <5.0.0",
@@ -2893,6 +2954,11 @@
       "from": "ignore@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.5.tgz"
     },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "from": "ignore-by-default@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
+    },
     "immutable": {
       "version": "3.8.1",
       "from": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
@@ -2957,6 +3023,11 @@
         }
       }
     },
+    "infinity-agent": {
+      "version": "2.0.3",
+      "from": "infinity-agent@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+    },
     "inflight": {
       "version": "1.0.5",
       "from": "inflight@>=1.0.4 <2.0.0",
@@ -2966,6 +3037,11 @@
       "version": "2.0.3",
       "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "ini": {
+      "version": "1.3.4",
+      "from": "ini@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
@@ -3089,6 +3165,11 @@
       "from": "is-my-json-valid@>=2.12.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz"
     },
+    "is-npm": {
+      "version": "1.0.0",
+      "from": "is-npm@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+    },
     "is-number": {
       "version": "2.1.0",
       "from": "is-number@>=2.1.0 <3.0.0",
@@ -3133,6 +3214,11 @@
       "version": "1.0.2",
       "from": "is-property@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "from": "is-redirect@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
     "is-regex": {
       "version": "1.0.3",
@@ -3475,6 +3561,11 @@
         }
       }
     },
+    "latest-version": {
+      "version": "1.0.1",
+      "from": "latest-version@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz"
+    },
     "lazy-cache": {
       "version": "1.0.4",
       "from": "lazy-cache@>=1.0.3 <2.0.0",
@@ -3517,6 +3608,16 @@
       "from": "lodash@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.1.tgz"
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+    },
     "lodash._baseisequal": {
       "version": "3.0.7",
       "from": "lodash._baseisequal@>=3.0.0 <4.0.0",
@@ -3527,6 +3628,11 @@
       "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
+    },
     "lodash._createcompounder": {
       "version": "3.0.0",
       "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
@@ -3536,6 +3642,11 @@
       "version": "3.9.1",
       "from": "lodash._getnative@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._root": {
       "version": "3.0.1",
@@ -3652,6 +3763,11 @@
       "from": "lodash.reject@>=4.4.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz"
     },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+    },
     "lodash.some": {
       "version": "4.6.0",
       "from": "lodash.some@>=4.4.0 <5.0.0",
@@ -3711,6 +3827,11 @@
       "from": "loud-rejection@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
     },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "from": "lowercase-keys@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+    },
     "lru-cache": {
       "version": "4.0.1",
       "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
@@ -3725,6 +3846,11 @@
       "version": "1.0.1",
       "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "from": "map-stream@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
     },
     "math-expression-evaluator": {
       "version": "1.2.14",
@@ -3835,6 +3961,11 @@
       "from": "negotiator@0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
+    "nested-error-stacks": {
+      "version": "1.0.2",
+      "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz"
+    },
     "nigel": {
       "version": "2.0.2",
       "from": "nigel@>=2.0.0 <3.0.0",
@@ -3902,6 +4033,23 @@
       "version": "1.4.7",
       "from": "node-uuid@>=1.4.7 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
+    "nodemon": {
+      "version": "1.11.0",
+      "from": "nodemon@latest",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.11.0.tgz",
+      "dependencies": {
+        "lodash.assign": {
+          "version": "3.2.0",
+          "from": "lodash.assign@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
+        },
+        "lodash.defaults": {
+          "version": "3.1.2",
+          "from": "lodash.defaults@>=3.1.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz"
+        }
+      }
     },
     "noop2": {
       "version": "2.0.0",
@@ -4092,6 +4240,11 @@
       "from": "osenv@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
+    "package-json": {
+      "version": "1.2.0",
+      "from": "package-json@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz"
+    },
     "pako": {
       "version": "0.2.9",
       "from": "pako@>=0.2.0 <0.3.0",
@@ -4146,6 +4299,11 @@
       "version": "1.1.0",
       "from": "path-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "from": "pause-stream@0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pbkdf2-compat": {
       "version": "2.0.1",
@@ -4455,6 +4613,11 @@
       "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
+    "ps-tree": {
+      "version": "1.1.0",
+      "from": "ps-tree@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz"
+    },
     "pseudomap": {
       "version": "1.0.2",
       "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -4509,6 +4672,18 @@
       "version": "2.1.7",
       "from": "raw-body@>=2.1.7 <2.2.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+    },
+    "rc": {
+      "version": "1.1.7",
+      "from": "rc@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+        }
+      }
     },
     "react": {
       "version": "15.4.2",
@@ -4582,6 +4757,11 @@
       "version": "2.0.0",
       "from": "https://registry.npmjs.org/react-jasmine-matchers/-/react-jasmine-matchers-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/react-jasmine-matchers/-/react-jasmine-matchers-2.0.0.tgz"
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -4659,6 +4839,11 @@
       "version": "2.0.0",
       "from": "regexpu-core@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "from": "registry-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -4865,6 +5050,11 @@
       "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
+    "semver-diff": {
+      "version": "2.1.0",
+      "from": "semver-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz"
+    },
     "set-blocking": {
       "version": "2.0.0",
       "from": "set-blocking@>=2.0.0 <2.1.0",
@@ -4926,6 +5116,11 @@
       "version": "0.0.4",
       "from": "slice-ansi@0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+    },
+    "slide": {
+      "version": "1.1.6",
+      "from": "slide@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
     },
     "smocks": {
       "version": "4.1.0",
@@ -5140,6 +5335,11 @@
       "from": "stream-http@>=2.3.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.5.0.tgz"
     },
+    "stream-shift": {
+      "version": "1.0.0",
+      "from": "stream-shift@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "from": "strict-uri-encode@>=1.0.0 <2.0.0",
@@ -5149,6 +5349,11 @@
       "version": "0.10.31",
       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "string-length": {
+      "version": "1.0.1",
+      "from": "string-length@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz"
     },
     "string-width": {
       "version": "1.0.2",
@@ -5266,6 +5471,11 @@
       "from": "through@>=2.3.8 <2.4.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
+    "timed-out": {
+      "version": "2.0.0",
+      "from": "timed-out@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+    },
     "timers-browserify": {
       "version": "1.4.2",
       "from": "timers-browserify@>=1.0.1 <2.0.0",
@@ -5305,6 +5515,18 @@
           "version": "4.1.0",
           "from": "hoek@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.0.tgz"
+        }
+      }
+    },
+    "touch": {
+      "version": "1.0.0",
+      "from": "touch@1.0.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
         }
       }
     },
@@ -5402,6 +5624,11 @@
       "from": "ultron@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
+    "undefsafe": {
+      "version": "0.0.3",
+      "from": "undefsafe@0.0.3",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz"
+    },
     "uniq": {
       "version": "1.0.1",
       "from": "uniq@>=1.0.1 <2.0.0",
@@ -5421,6 +5648,18 @@
       "version": "1.0.0",
       "from": "unpipe@1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "update-notifier": {
+      "version": "0.5.0",
+      "from": "update-notifier@0.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
+      "dependencies": {
+        "repeating": {
+          "version": "1.1.3",
+          "from": "repeating@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+        }
+      }
     },
     "urijs": {
       "version": "1.16.1",
@@ -5853,6 +6092,18 @@
       "from": "write@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
+    "write-file-atomic": {
+      "version": "1.3.1",
+      "from": "write-file-atomic@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.11 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+        }
+      }
+    },
     "ws": {
       "version": "1.1.1",
       "from": "ws@1.1.1",
@@ -5862,6 +6113,11 @@
       "version": "1.0.0",
       "from": "wtf-8@1.0.0",
       "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
+    },
+    "xdg-basedir": {
+      "version": "2.0.0",
+      "from": "xdg-basedir@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-unit": "NODE_ENV=test karma start --single-run",
     "test-selenium-install": "selenium-standalone install",
     "testing-server": "PORT=8001 npm run testing-server-run",
-    "testing-server-run": "nodemon --watch ./static_src/test/server ./static_src/test/server/server.js",
+    "testing-server-run": "node ./static_src/test/server/server.js",
     "watch-server": "npm run testing-server & npm run watch",
     "watch-test": "NODE_ENV=test karma start --browsers Chrome",
     "watch": "webpack --watch"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.10",
     "node-libs-browser": "^0.5.2",
-    "nodemon": "^1.11.0",
     "normalize.css": "^3.0.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-unit": "NODE_ENV=test karma start --single-run",
     "test-selenium-install": "selenium-standalone install",
     "testing-server": "PORT=8001 npm run testing-server-run",
-    "testing-server-run": "node ./static_src/test/server/server.js",
+    "testing-server-run": "nodemon --watch ./static_src/test/server ./static_src/test/server/server.js",
     "watch-server": "npm run testing-server & npm run watch",
     "watch-test": "NODE_ENV=test karma start --browsers Chrome",
     "watch": "webpack --watch"
@@ -90,6 +90,7 @@
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.10",
     "node-libs-browser": "^0.5.2",
+    "nodemon": "^1.11.0",
     "normalize.css": "^3.0.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-unit": "NODE_ENV=test karma start --single-run",
     "test-selenium-install": "selenium-standalone install",
     "testing-server": "PORT=8001 npm run testing-server-run",
-    "testing-server-run": "node ./static_src/test/server/server.js",
+    "testing-server-run": "nodemon --watch ./static_src/test/server ./static_src/test/server/server.js",
     "watch-server": "npm run testing-server & npm run watch",
     "watch-test": "NODE_ENV=test karma start --browsers Chrome",
     "watch": "webpack --watch"

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -161,6 +161,29 @@ const userActions = {
     return Promise.resolve(status);
   },
 
+  fetchUser(userGuid) {
+    if (!userGuid) {
+      return Promise.reject(new Error('userGuid is required'));
+    }
+
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_FETCH,
+      userGuid
+    });
+
+    return cfApi.fetchUser(userGuid)
+      .then(userActions.receivedUser);
+  },
+
+  receivedUser(user) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.USER_RECEIVED,
+      user
+    });
+
+    return Promise.resolve(user);
+  },
+
   // Meta action to fetch all the pieces of the current user
   fetchCurrentUser() {
     AppDispatcher.handleViewAction({
@@ -170,6 +193,8 @@ const userActions = {
     // TODO add error action
     return userActions.fetchAuthStatus()
       .then(userActions.fetchCurrentUserInfo)
+      .then(userInfo => userActions.fetchUser(userInfo.user_id))
+      // Grab user from store with all merged properties
       .then(() => UserStore.currentUser)
       .then(userActions.receivedCurrentUser);
   },

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -251,8 +251,14 @@ const userActions = {
       .then(userOrgs => userActions.receivedUserOrgs(userGuid, userOrgs, options));
   },
 
-  receivedUserOrgs(userGuid, userOrgs, options) {
+  receivedUserOrgs(userGuid, userOrgs) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.USER_ORGS_RECEIVED,
+      userGuid,
+      userOrgs
+    });
 
+    return Promise.resolve(userOrgs);
   },
 
   // Meta action to fetch all the pieces of the current user

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -273,6 +273,7 @@ const userActions = {
       .then(userInfo =>
         Promise.all([
           userActions.fetchUser(userInfo.user_id),
+          userActions.fetchUserOrgs(userInfo.user_id),
           userActions.fetchUserSpaces(userInfo.user_id, options)
         ])
       )

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -184,6 +184,29 @@ const userActions = {
     return Promise.resolve(user);
   },
 
+  fetchUserSummary(userGuid) {
+    if (!userGuid) {
+      return Promise.reject(new Error('userGuid is required'));
+    }
+
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_SUMMARY_FETCH,
+      userGuid
+    });
+
+    return cfApi.fetchUser(userGuid)
+      .then(userActions.receivedUserSummary);
+  },
+
+  receivedUserSummary(user) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.USER_SUMMARY_RECEIVED,
+      user
+    });
+
+    return Promise.resolve(user);
+  },
+
   fetchUserSpaces(userGuid, options = {}) {
     if (!userGuid) {
       return Promise.reject(new Error('userGuid is required'));
@@ -212,6 +235,24 @@ const userActions = {
     });
 
     return Promise.resolve(userSpaces);
+  },
+
+  fetchUserOrgs(userGuid, options = {}) {
+    if (!userGuid) {
+      return Promise.reject(new Error('userGuid is required'));
+    }
+
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_ORGS_FETCH,
+      userGuid
+    });
+
+    return cfApi.fetchUserOrgs(userGuid, options)
+      .then(userOrgs => userActions.receivedUserOrgs(userGuid, userOrgs, options));
+  },
+
+  receivedUserOrgs(userGuid, userOrgs, options) {
+
   },
 
   // Meta action to fetch all the pieces of the current user

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -184,29 +184,6 @@ const userActions = {
     return Promise.resolve(user);
   },
 
-  fetchUserSummary(userGuid) {
-    if (!userGuid) {
-      return Promise.reject(new Error('userGuid is required'));
-    }
-
-    AppDispatcher.handleViewAction({
-      type: userActionTypes.USER_SUMMARY_FETCH,
-      userGuid
-    });
-
-    return cfApi.fetchUser(userGuid)
-      .then(userActions.receivedUserSummary);
-  },
-
-  receivedUserSummary(user) {
-    AppDispatcher.handleServerAction({
-      type: userActionTypes.USER_SUMMARY_RECEIVED,
-      user
-    });
-
-    return Promise.resolve(user);
-  },
-
   fetchUserSpaces(userGuid, options = {}) {
     if (!userGuid) {
       return Promise.reject(new Error('userGuid is required'));

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -6,7 +6,9 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 import AppQuicklook from './app_quicklook.jsx';
 import ComplexList from './complex_list.jsx';
+import EntityEmpty from './entity_empty.jsx';
 import EntityIcon from './entity_icon.jsx';
+import InfoAppCreate from './info_app_create.jsx';
 import Loading from './loading.jsx';
 import OrgStore from '../stores/org_store.js';
 import SpaceStore from '../stores/space_store.js';
@@ -20,6 +22,8 @@ function stateSetter() {
   const apps = (space && space.apps) ? space.apps : [];
 
   return {
+    currentOrg: OrgStore.get(currentOrgGuid),
+    currentSpace: space,
     apps: apps.sort((a, b) => a.name.localeCompare(b.name)),
     currentOrgGuid,
     currentSpaceGuid,
@@ -65,7 +69,11 @@ export default class AppList extends React.Component {
     );
 
     if (this.state.empty) {
-      content = <h4 className="test-none_message">No apps</h4>;
+      content = (
+        <EntityEmpty callout="You have no apps in this space">
+          <InfoAppCreate space={ this.state.currentSpace } org={ this.state.currentOrg } />
+        </EntityEmpty>
+      );
     } else if (!this.state.loading && this.state.apps.length > 0) {
       content = (
         <ComplexList titleElement={ title }>

--- a/static_src/components/entity_empty.jsx
+++ b/static_src/components/entity_empty.jsx
@@ -1,0 +1,40 @@
+
+import React from 'react';
+
+import PanelDocumentation from './panel_documentation.jsx';
+import createStyler from '../util/create_styler';
+import style from 'cloudgov-style/css/cloudgov-style.css';
+
+
+const propTypes = {
+  callout: React.PropTypes.node,
+  children: React.PropTypes.any
+};
+
+const defaultProps = {
+  children: null
+};
+
+export default class EntityEmpty extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.styler = createStyler(style);
+  }
+
+  render() {
+    const props = this.props;
+    return (
+      <PanelDocumentation>
+        <div className={ this.styler('empty') }>
+          <h4>{ props.callout }</h4>
+          { props.children }
+
+        </div>
+      </PanelDocumentation>
+    );
+  }
+}
+
+EntityEmpty.propTypes = propTypes;
+EntityEmpty.defaultProps = defaultProps;

--- a/static_src/components/info_app_create.jsx
+++ b/static_src/components/info_app_create.jsx
@@ -40,7 +40,6 @@ export default class InfoAppCreate extends React.Component {
     const space = this.props.space || {};
     let content;
 
-<<<<<<< HEAD
     if (this.props.brief) {
       const cliLink = config.docs.cli ?
         <a href={ config.docs.cli }>command line interface (CLI)</a> :

--- a/static_src/components/info_app_create.jsx
+++ b/static_src/components/info_app_create.jsx
@@ -5,11 +5,13 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import { config } from 'skin';
 
 import createStyler from '../util/create_styler';
+import UserStore from '../stores/user_store';
 
 const propTypes = {
   org: React.PropTypes.object,
   space: React.PropTypes.object,
-  brief: React.PropTypes.bool
+  brief: React.PropTypes.bool,
+  user: React.PropTypes.object
 };
 
 const defaultProps = {
@@ -23,11 +25,22 @@ export default class InfoAppCreate extends React.Component {
     this.styler = createStyler(style);
   }
 
-  render() {
+  get noPermission() {
+    return (
+      <p>
+        <em>Space developers</em> can add apps to
+        spaces. Read more about <a href={ config.docs.deploying_apps }>adding
+        apps</a> and <a href={ config.docs.roles }>permissions</a>.
+      </p>
+    );
+  }
+
+  get spaceDeveloper() {
     const org = this.props.org || {};
     const space = this.props.space || {};
     let content;
 
+<<<<<<< HEAD
     if (this.props.brief) {
       const cliLink = config.docs.cli ?
         <a href={ config.docs.cli }>command line interface (CLI)</a> :
@@ -84,6 +97,21 @@ export default class InfoAppCreate extends React.Component {
     }
 
     return content;
+  }
+
+  render() {
+    const space = this.props.space || {};
+    const user = this.props.user || {};
+
+    const content = UserStore.hasRole(user.guid, space.guid, 'space_developer') ?
+      this.spaceDeveloper :
+      this.noPermission;
+
+    return (
+      <div className={ this.styler('info', 'info-app_create') }>
+        { content }
+      </div>
+    );
   }
 }
 

--- a/static_src/components/info_app_create.jsx
+++ b/static_src/components/info_app_create.jsx
@@ -8,10 +8,12 @@ import createStyler from '../util/create_styler';
 
 const propTypes = {
   org: React.PropTypes.object,
-  space: React.PropTypes.object
+  space: React.PropTypes.object,
+  brief: React.PropTypes.bool
 };
 
 const defaultProps = {
+  brief: false
 };
 
 
@@ -24,9 +26,30 @@ export default class InfoAppCreate extends React.Component {
   render() {
     const org = this.props.org || {};
     const space = this.props.space || {};
+    let content;
 
-    return (
-      <div className={ this.styler('info', 'info-app_create') }>
+    if (this.props.brief) {
+      const cliLink = config.docs.cli ?
+        <a href={ config.docs.cli }>command line interface (CLI)</a> :
+        <span>Command line interface (CLI)</span>;
+      const deployingApps = config.docs.deploying_apps &&
+        <a href={ config.docs.deploying_apps}>Read more about adding apps</a>;
+
+      content = (
+      <div>
+        <p>
+          Add a new app to this space in the { cliLink }
+        </p>
+        <pre>
+          <code>$ cf target -o { org.name || '<org>' } -s { space.name || '<space>' }</code><br />
+          <code>$ cf push my-app</code>
+        </pre>
+        { deployingApps }
+      </div>
+      );
+    } else {
+      content = (
+      <div>
         <p>
           Learn how to <a href={ config.docs.deploying_apps }>deploy a new app</a>.
         </p>
@@ -56,6 +79,13 @@ export default class InfoAppCreate extends React.Component {
           <code>$ cf target -o { org.name || '<org>' } -s { space.name || '<space>' }</code><br />
           <code>$ cf push my-app</code>
         </pre>
+      </div>
+      );
+    }
+
+    return (
+      <div className={ this.styler('info', 'info-app_create') }>
+        { content }
       </div>
     );
   }

--- a/static_src/components/info_app_create.jsx
+++ b/static_src/components/info_app_create.jsx
@@ -36,7 +36,7 @@ export default class InfoAppCreate extends React.Component {
         <a href={ config.docs.deploying_apps}>Read more about adding apps</a>;
 
       content = (
-      <div>
+      <div className={ this.styler('info', 'info-app_create') }>
         <p>
           Add a new app to this space in the { cliLink }
         </p>
@@ -49,7 +49,7 @@ export default class InfoAppCreate extends React.Component {
       );
     } else {
       content = (
-      <div>
+      <div className={ this.styler('info', 'info-app_create') }>
         <p>
           Learn how to <a href={ config.docs.deploying_apps }>deploy a new app</a>.
         </p>
@@ -83,11 +83,7 @@ export default class InfoAppCreate extends React.Component {
       );
     }
 
-    return (
-      <div className={ this.styler('info', 'info-app_create') }>
-        { content }
-      </div>
-    );
+    return content;
   }
 }
 

--- a/static_src/components/org_container.jsx
+++ b/static_src/components/org_container.jsx
@@ -1,14 +1,15 @@
 
 import React from 'react';
 
+import { config } from 'skin';
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 
 import AppCountStatus from './app_count_status.jsx';
 import Breadcrumbs from './breadcrumbs.jsx';
-
 import EntityIcon from './entity_icon.jsx';
+import EntityEmpty from './entity_empty.jsx';
 import Loading from './loading.jsx';
 import OrgStore from '../stores/org_store.js';
 import PageHeader from './page_header.jsx';
@@ -18,9 +19,13 @@ import SpaceCountStatus from './space_count_status.jsx';
 import SpaceStore from '../stores/space_store.js';
 import SpaceQuicklook from './space_quicklook.jsx';
 import Users from './users.jsx';
+import UserStore from '../stores/user_store.js';
 
 function stateSetter() {
   const currentOrgGuid = OrgStore.currentOrgGuid;
+  const currentUserCanViewSpace =
+    UserStore.currentUserHasSpaceRoles(SpaceStore.viewPermissionRoles()) ||
+    UserStore.currentUserHasOrgRoles('org_manager');
 
   const org = OrgStore.get(currentOrgGuid);
   const spaces = SpaceStore.getAll()
@@ -28,6 +33,7 @@ function stateSetter() {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return {
+    currentUserCanViewSpace,
     empty: !OrgStore.loading && !SpaceStore.loading && !org,
     loading: OrgStore.loading || SpaceStore.loading,
     org: org || {},
@@ -57,6 +63,43 @@ export default class OrgContainer extends React.Component {
     this.setState(stateSetter());
   }
 
+  get emptyState() {
+    let content;
+    let callout;
+
+    if (this.state.currentUserCanViewSpace) {
+      const spaceLink = config.docs.concepts_spaces ?
+        <a href={ config.docs.concepts_spaces }>Spaces</a> :
+        <span>Spaces</span>;
+      const contactLink = config.docs.contact ?
+        <a href={ config.docs.contact }>contact us</a> :
+        <span>contact us</span>;
+
+      callout = 'You have no spaces in this organization';
+      content = (
+        <p>
+          { spaceLink } are environments for development, deployment, and
+          maintenance of  apps and services. If you think you have spaces you
+          don’t see here, { contactLink }.
+        </p>
+      );
+    } else {
+      callout = 'You don’t have permission to see the spaces in this organization.';
+      content = (
+        <p>
+          Organization auditors and billing managers can’t view spaces.
+          Ask your organization’s administrator to give you these permissions..
+        </p>
+      );
+    }
+
+    return (
+      <EntityEmpty callout={ callout }>
+        { content }
+      </EntityEmpty>
+    );
+  }
+
   allServices() {
     return this.state.spaces.reduce((all, space) => {
       if (space.services && space.services.length) {
@@ -84,6 +127,15 @@ export default class OrgContainer extends React.Component {
         <EntityIcon entity="org" iconSize="large" /> { state.org.name }
       </span>
     );
+    const spaces = !state.spaces.length ? this.emptyState :
+      state.spaces.map((space) => (
+        <SpaceQuicklook
+          key={ space.guid }
+          space={ space }
+          orgGuid={ state.org.guid }
+          showAppDetail
+        />
+      ));
 
     if (state.empty) {
       content = <h4 className="test-none_message">No organizations</h4>;
@@ -115,16 +167,7 @@ export default class OrgContainer extends React.Component {
               </div>
             </div>
           </div>
-
-          { state.spaces.map((space) => (
-            <SpaceQuicklook
-              key={ space.guid }
-              space={ space }
-              orgGuid={ state.org.guid }
-              showAppDetail
-            />
-            )
-          )}
+          { spaces }
         </Panel>
 
         <Panel title="Organization users">

--- a/static_src/components/org_container.jsx
+++ b/static_src/components/org_container.jsx
@@ -23,9 +23,11 @@ import UserStore from '../stores/user_store.js';
 
 function stateSetter() {
   const currentOrgGuid = OrgStore.currentOrgGuid;
+  const currentSpaceGuid = SpaceStore.currentSpaceGuid;
+  const currentUser = UserStore.currentUser;
   const currentUserCanViewSpace =
-    UserStore.currentUserHasSpaceRoles(SpaceStore.viewPermissionRoles()) ||
-    UserStore.currentUserHasOrgRoles('org_manager');
+    UserStore.hasRole(currentUser, currentOrgGuid, 'org_manager') ||
+    UserStore.hasRole(currentUser, currentSpaceGuid, SpaceStore.viewPermissionRoles());
 
   const org = OrgStore.get(currentOrgGuid);
   const spaces = SpaceStore.getAll()

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -5,6 +5,7 @@ import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import { config } from 'skin';
+import EntityEmpty from './entity_empty.jsx'
 import Icon from './icon.jsx';
 import Loading from './loading.jsx';
 import OrgQuicklook from './org_quicklook.jsx';
@@ -62,6 +63,25 @@ export default class OverviewContainer extends React.Component {
       false);
   }
 
+  get emptyState() {
+    const contactMsg = config.docs.contact && (
+      <span>
+        <br />
+        If this isn’t the case, <a href={ config.docs.contact }>contact us</a>.
+      </span>
+    );
+
+    return (
+      <EntityEmpty callout="We can’t find any of your organizations.">
+        <p>
+          If you just joined, your organization may not yet be ready. Sometimes
+          organizations can take up to 20 minutes to appear on your first login.
+          { contactMsg }
+        </p>
+      </EntityEmpty>
+    );
+  }
+
   render() {
     const state = this.state;
     let loading = <Loading text="Loading orgs" />;
@@ -73,20 +93,27 @@ export default class OverviewContainer extends React.Component {
     );
 
     if (state.empty) {
-      content = <h4 className="test-none_message">No organizations</h4>;
+      content = this.emptyState;
     } else if (!state.loading && this.state.orgs.length > 0 || this.anyOrgsOpen()) {
       content = (
+        <div>
+        { state.orgs.map((org) =>
+          <div key={ org.guid } className="test-panel-row-organizations">
+            <OrgQuicklook
+              org={ org }
+              spaces={ this.orgSpaces(org.guid) }
+            />
+          </div>
+        )}
+        </div>
+      );
+    }
+
+    return (
       <div className={ this.styler('grid') }>
         <PageHeader title={ title } />
         <Panel title="Your organizations">
-          { state.orgs.map((org) =>
-            <div key={ org.guid } className="test-panel-row-organizations">
-              <OrgQuicklook
-                org={ org }
-                spaces={ this.orgSpaces(org.guid) }
-              />
-            </div>
-          )}
+          { content }
         </Panel>
         <Panel title="Cheatsheet">
           { config.home.tiles.map((Tile, i) => {
@@ -110,9 +137,6 @@ export default class OverviewContainer extends React.Component {
           })}
         </Panel>
       </div>
-      );
-    }
-
-    return content;
+    );
   }
 }

--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -5,7 +5,7 @@ import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 import { config } from 'skin';
-import EntityEmpty from './entity_empty.jsx'
+import EntityEmpty from './entity_empty.jsx';
 import Icon from './icon.jsx';
 import Loading from './loading.jsx';
 import OrgQuicklook from './org_quicklook.jsx';

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -5,7 +5,6 @@ import AppCountStatus from './app_count_status.jsx';
 import AppList from '../components/app_list.jsx';
 import Breadcrumbs from './breadcrumbs.jsx';
 import EntityIcon from './entity_icon.jsx';
-import InfoAppCreate from './info_app_create.jsx';
 import Loading from './loading.jsx';
 import Marketplace from './marketplace.jsx';
 import OrgStore from '../stores/org_store.js';
@@ -98,7 +97,6 @@ export default class SpaceContainer extends React.Component {
           </div>
 
           <AppList />
-          <InfoAppCreate space={ space } org={ this.state.currentOrg } />
         </Panel>
         <Panel title="Service instances">
           <ServiceInstanceTable />

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -14,6 +14,7 @@ import ServiceCountStatus from './service_count_status.jsx';
 import ServiceInstanceTable from './service_instance_table.jsx';
 import SpaceStore from '../stores/space_store.js';
 import Users from './users.jsx';
+import UserStore from '../stores/user_store';
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -23,7 +24,8 @@ function stateSetter() {
     currentOrg: OrgStore.currentOrg(),
     currentOrgGuid: OrgStore.currentOrgGuid,
     currentSpaceGuid: SpaceStore.currentSpaceGuid,
-    loading: SpaceStore.loading || OrgStore.loading
+    currentUser: UserStore.currentUser,
+    loading: SpaceStore.loading || OrgStore.loading || UserStore.isLoadingCurrentUser
   };
 }
 
@@ -39,11 +41,13 @@ export default class SpaceContainer extends React.Component {
   componentDidMount() {
     OrgStore.addChangeListener(this._onChange);
     SpaceStore.addChangeListener(this._onChange);
+    UserStore.addChangeListener(this._onChange);
   }
 
   componentWillUnmount() {
     OrgStore.removeChangeListener(this._onChange);
     SpaceStore.removeChangeListener(this._onChange);
+    UserStore.removeChangeListener(this._onChange);
   }
 
   _onChange() {
@@ -97,6 +101,11 @@ export default class SpaceContainer extends React.Component {
           </div>
 
           <AppList />
+          <InfoAppCreate
+            space={ space }
+            org={ this.state.currentOrg }
+            user={ this.state.currentUser }
+          />
         </Panel>
         <Panel title="Service instances">
           <ServiceInstanceTable />

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -83,7 +83,6 @@ export default class SpaceContainer extends React.Component {
           </div>
         </div>
         <Panel title="">
-
           <div className={ this.styler('grid', 'panel-overview-header') }>
             <div className={ this.styler('grid-width-8') }>
               <h1 className={ this.styler('panel-title') }>Space overview</h1>

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -5,6 +5,7 @@ import AppCountStatus from './app_count_status.jsx';
 import AppList from '../components/app_list.jsx';
 import Breadcrumbs from './breadcrumbs.jsx';
 import EntityIcon from './entity_icon.jsx';
+import InfoAppCreate from './info_app_create.jsx';
 import Loading from './loading.jsx';
 import Marketplace from './marketplace.jsx';
 import OrgStore from '../stores/org_store.js';

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -47,9 +47,10 @@ export default class SpaceQuicklook extends React.Component {
 
   render() {
     const space = this.props.space;
-    const appsContent = (space.apps && space.apps.length > 0) ?
-      space.apps && space.apps.map((app) =>
-        <ComplexList>
+    console.log('asd;lfasfd;lfasdjl', space.apps);
+    const appsContent = (space.apps && space.apps.length > 0) ? (
+      <ComplexList>
+        { space.apps && space.apps.map((app) =>
            <AppQuicklook
              key={ app.guid }
              app={ app }
@@ -59,9 +60,9 @@ export default class SpaceQuicklook extends React.Component {
              extraInfo={ this.props.showAppDetail ?
                ['state', 'memory', 'diskQuota'] : ['state'] }
            />
-        </ComplexList>
-        )
-       : this.emptyState;
+        )}
+      </ComplexList>
+      ) : this.emptyState;
 
     return (
       <ComplexList className="test-space-quicklook">

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -47,7 +47,6 @@ export default class SpaceQuicklook extends React.Component {
 
   render() {
     const space = this.props.space;
-    console.log('asd;lfasfd;lfasdjl', space.apps);
     const appsContent = (space.apps && space.apps.length > 0) ? (
       <ComplexList>
         { space.apps && space.apps.map((app) =>

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -6,7 +6,10 @@ import createStyler from '../util/create_styler';
 
 import AppQuicklook from './app_quicklook.jsx';
 import ComplexList from './complex_list.jsx';
+import EntityEmpty from './entity_empty.jsx';
 import EntityIcon from './entity_icon.jsx';
+import InfoAppCreate from './info_app_create.jsx';
+import OrgStore from '../stores/org_store.js';
 import { spaceHref } from '../util/url';
 
 const propTypes = {
@@ -31,27 +34,42 @@ export default class SpaceQuicklook extends React.Component {
     return spaceHref(props.orgGuid, props.space.guid);
   }
 
+  get emptyState() {
+    const org = OrgStore.get(this.props.orgGuid);
+    const content = (
+      <EntityEmpty callout="You have no apps in this space">
+        <InfoAppCreate space={ this.props.space } org={ org } brief />
+      </EntityEmpty>
+    );
+
+    return content;
+  }
+
   render() {
     const space = this.props.space;
+    const appsContent = (space.apps && space.apps.length > 0) ?
+      space.apps && space.apps.map((app) =>
+        <ComplexList>
+           <AppQuicklook
+             key={ app.guid }
+             app={ app }
+             orgGuid={ this.props.orgGuid }
+             spaceGuid={ space.guid }
+             spaceName={ space.name }
+             extraInfo={ this.props.showAppDetail ?
+               ['state', 'memory', 'diskQuota'] : ['state'] }
+           />
+        </ComplexList>
+        )
+       : this.emptyState;
+
     return (
       <ComplexList className="test-space-quicklook">
         <h3 className={ this.styler('contents-primary') }>
           <EntityIcon entity="space" iconSize="medium" />
           <a href={ this.spaceHref() }>{ space.name }</a>
         </h3>
-        <ComplexList>
-          { space.apps && space.apps.map((app) =>
-             <AppQuicklook
-               key={ app.guid }
-               app={ app }
-               orgGuid={ this.props.orgGuid }
-               spaceGuid={ space.guid }
-               spaceName={ space.name }
-               extraInfo={ this.props.showAppDetail ?
-                 ['state', 'memory', 'diskQuota'] : ['state'] }
-             />
-          )}
-        </ComplexList>
+        { appsContent }
       </ComplexList>
     );
   }

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 
 import Action from './action.jsx';
+import EntityEmpty from './entity_empty.jsx';
 import Loading from './loading.jsx';
 import PanelDocumentation from './panel_documentation.jsx';
 import UserRoleListControl from './user_role_list_control.jsx';
@@ -74,12 +75,53 @@ export default class UserList extends React.Component {
     );
   }
 
+  get emptyState() {
+    const callout = `There are no users in this ${this.userTypePretty.toLowerCase()}`;
+    const content = config.docs.invite_user &&
+      <a href={ config.docs.invite_user }>Read more about adding users to this space.</a>
+
+    return (
+      <EntityEmpty callout={ callout }>
+        { content }
+      </EntityEmpty>
+    );
+  }
+
+  get onlyOneState() {
+    let content;
+    const callout = `You are the only user in this ${this.userTypePretty.toLowerCase()}`;
+
+    if (this.state.userType === 'org_users') {
+      const readMore = config.docs.invite_user &&
+        <a href={ config.docs.invite_user }>Read more about inviting new users.</a>
+
+      content = (
+        <p>
+          You can invite teammates to get cloud.gov accounts. You can invite
+          anyone you need to work with, including federal employees and
+          federal contractors. { readMore }
+        </p>
+      );
+    } else {
+      const content = config.docs.invite_user &&
+        <a href={ config.docs.invite_user }>Read more about adding users to this space.</a>
+    }
+
+    return (
+      <EntityEmpty callout={ callout }>
+        { content }
+      </EntityEmpty>
+    );
+  }
+
   render() {
     let loading = <Loading text="Loading users" />;
     let content = <div>{ loading }</div>;
 
     if (this.state.empty) {
-      content = <h4 className="test-none_message">No users</h4>;
+      content = this.emptyState;
+    } else if (this.state.users.length === 1) {
+      content = this.onlyOneState;
     } else if (!this.state.loading && this.state.users.length) {
       content = (
       <div>

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -27,11 +27,11 @@ function stateSetter() {
   if (currentType === SPACE_NAME) {
     users = UserStore.getAllInSpace(currentSpaceGuid);
     currentUserAccess = UserStore.hasRole(currentUser.guid, currentSpaceGuid,
-                                          'space_manager')
+                                          'space_manager');
   } else {
     users = UserStore.getAllInOrg(currentOrgGuid);
     currentUserAccess = UserStore.hasRole(currentUser.guid, currentOrgGuid,
-                                          'org_manager')
+                                          'org_manager');
   }
 
   return {

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -25,10 +25,10 @@ function stateSetter() {
 
   if (currentType === SPACE_NAME) {
     users = UserStore.getAllInSpace(currentSpaceGuid);
-    currentUserAccess = UserStore.currentUserHasSpaceRole('space_manager');
+    currentUserAccess = UserStore.currentUserHasSpaceRoles(['space_manager']);
   } else {
     users = UserStore.getAllInOrg(currentOrgGuid);
-    currentUserAccess = UserStore.currentUserHasOrgRole('org_manager');
+    currentUserAccess = UserStore.currentUserHasOrgRoles(['org_manager']);
   }
 
   return {

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -19,16 +19,19 @@ function stateSetter() {
   const currentOrgGuid = OrgStore.currentOrgGuid;
   const currentSpaceGuid = SpaceStore.currentSpaceGuid;
   const currentType = UserStore.currentlyViewedType;
+  const currentUser = UserStore.currentUser;
 
   let users = [];
   let currentUserAccess = false;
 
   if (currentType === SPACE_NAME) {
     users = UserStore.getAllInSpace(currentSpaceGuid);
-    currentUserAccess = UserStore.currentUserHasSpaceRoles(['space_manager']);
+    currentUserAccess = UserStore.hasRole(currentUser.guid, currentSpaceGuid,
+                                          'space_manager')
   } else {
     users = UserStore.getAllInOrg(currentOrgGuid);
-    currentUserAccess = UserStore.currentUserHasOrgRoles(['org_manager']);
+    currentUserAccess = UserStore.hasRole(currentUser.guid, currentOrgGuid,
+                                          'org_manager')
   }
 
   return {

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -230,6 +230,10 @@ const userActionTypes = keymirror({
   ORG_USER_ROLES_RECEIVED: null,
   // Action when all space users were received from the server.
   SPACE_USERS_RECEIVED: null,
+  // User is fetched from the server
+  USER_FETCH: null,
+  // User is received from the server
+  USER_RECEIVED: null,
   // Action to add permissions to a user for a space or org on the server.
   USER_ROLES_ADD: null,
   // Action when user roles are added on the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -234,6 +234,10 @@ const userActionTypes = keymirror({
   USER_FETCH: null,
   // User is received from the server
   USER_RECEIVED: null,
+  // Fetch spaces this user is a member of (developer of).
+  USER_SPACES_FETCH: null,
+  // Receive spaces this user is a member of (developer of).
+  USER_SPACES_RECEIVED: null,
   // Action to add permissions to a user for a space or org on the server.
   USER_ROLES_ADD: null,
   // Action when user roles are added on the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -214,6 +214,10 @@ const appActionTypes = keymirror({
 });
 
 const userActionTypes = keymirror({
+  // Fetch auth status from server
+  AUTH_STATUS_FETCH: null,
+  // Auth status received from server
+  AUTH_STATUS_RECEIVED: null,
   // Action to fetch users belonging to a organization from the server.
   ORG_USERS_FETCH: null,
   // Action to fetch the user roles for an org from the server.
@@ -242,6 +246,14 @@ const userActionTypes = keymirror({
   ERROR_REMOVE_USER: null,
   // Action when the type of users being looked at changes
   USER_CHANGE_VIEWED_TYPE: null,
+  // Meta action that we are fetching the multiple pieces that make up the current user
+  CURRENT_USER_FETCH: null,
+  // Meta action that the current user is loaded
+  CURRENT_USER_RECEIVED: null,
+  // An error occurred while loading the current user
+  CURRENT_USER_ERROR: null,
+  // Current user info fetched from server.
+  CURRENT_USER_INFO_FETCH: null,
   // Action when current user info received from server.
   CURRENT_USER_INFO_RECEIVED: null
 });

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -238,6 +238,10 @@ const userActionTypes = keymirror({
   USER_SPACES_FETCH: null,
   // Receive spaces this user is a member of (developer of).
   USER_SPACES_RECEIVED: null,
+  // Fetch orgss this user is a member of (manager of).
+  USER_ORGS_FETCH: null,
+  // Receive orgss this user is a member of (manager of).
+  USER_ORGS_RECEIVED: null,
   // Action to add permissions to a user for a space or org on the server.
   USER_ROLES_ADD: null,
   // Action when user roles are added on the server.

--- a/static_src/css/main.css
+++ b/static_src/css/main.css
@@ -37,11 +37,3 @@ input[type="radio"] + label::before {
   display: none;
 }
 
-/* TEMPORARY */
-.empty {
-  text-align: center;
-}
-
-.empty p {
-  margin: 1rem auto;
-}

--- a/static_src/css/main.css
+++ b/static_src/css/main.css
@@ -36,4 +36,3 @@ input[type="checkbox"] + label::before,
 input[type="radio"] + label::before {
   display: none;
 }
-

--- a/static_src/css/main.css
+++ b/static_src/css/main.css
@@ -36,3 +36,12 @@ input[type="checkbox"] + label::before,
 input[type="radio"] + label::before {
   display: none;
 }
+
+/* TEMPORARY */
+.empty {
+  text-align: center;
+}
+
+.empty p {
+  margin: 1rem auto;
+}

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -132,8 +132,9 @@ function app(orgGuid, spaceGuid, appGuid) {
     </MainContainer>, mainEl);
 }
 
-function checkAuth() {
-  userActions.fetchCurrentUser();
+function checkAuth(...args) {
+  const [orgGuid, spaceGuid] = args;
+  userActions.fetchCurrentUser({ orgGuid, spaceGuid });
   orgActions.fetchAll();
   spaceActions.fetchAll();
 }

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -25,7 +25,6 @@ import spaceActions from './actions/space_actions.js';
 import serviceActions from './actions/service_actions.js';
 import SpaceContainer from './components/space_container.jsx';
 import { trackPageView } from './util/analytics.js';
-import uaaApi from './util/uaa_api.js';
 import userActions from './actions/user_actions.js';
 
 const mainEl = document.querySelector('.js-app');
@@ -134,9 +133,7 @@ function app(orgGuid, spaceGuid, appGuid) {
 }
 
 function checkAuth() {
-  cfApi.getAuthStatus().then(() => {
-    uaaApi.fetchUserInfo();
-  });
+  userActions.fetchCurrentUser();
   orgActions.fetchAll();
   spaceActions.fetchAll();
 }

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -93,6 +93,7 @@ export const config = {
     deploying_apps: 'https://cloud.gov/docs/getting-started/your-first-deploy/',
     use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/',
     invite_user: 'https://cloud.gov/docs/apps/managing-teammates',
+    roles: 'https://cloud.gov/docs/apps/managing-teammates/#give-roles-to-a-teammate',
     managed_services: 'https://docs.cloud.gov/apps/managed-services/',
     status: 'https://cloudgov.statuspage.io/',
     contact: 'https://cloud.gov/docs/help/'

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -88,6 +88,7 @@ export const config = {
   },
   docs: {
     cli: 'https://cloud.gov/docs/getting-started/setup/',
+    concepts_roles: 'https://docs.cloudfoundry.org/concepts/roles.html',
     concepts_spaces: 'https://cloud.gov/docs/getting-started/concepts/',
     deploying_apps: 'https://cloud.gov/docs/getting-started/your-first-deploy/',
     use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/',

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -93,7 +93,8 @@ export const config = {
     use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/',
     invite_user: 'https://cloud.gov/docs/apps/managing-teammates',
     managed_services: 'https://docs.cloud.gov/apps/managed-services/',
-    status: 'https://cloudgov.statuspage.io/'
+    status: 'https://cloudgov.statuspage.io/',
+    contact: 'https://cloud.gov/docs/help/'
   },
   snippets: {
     logs: InfoLogs

--- a/static_src/stores/space_store.js
+++ b/static_src/stores/space_store.js
@@ -18,6 +18,14 @@ class SpaceStore extends BaseStore {
     this.subscribe(() => this._registerToActions.bind(this));
   }
 
+  viewPermissionRoles() {
+    return [
+      'space_manager',
+      'space_developer',
+      'space_auditor'
+    ];
+  }
+
   get loading() {
     return !!this._loading.length || this._fetchAll;
   }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -206,6 +206,19 @@ class UserStore extends BaseStore {
 
           // Always emit change
           this.emitChange();
+        });
+        break;
+      }
+
+      case userActionTypes.USER_FETCH: {
+        this.merge('guid', { guid: action.userGuid, fetching: true });
+        break;
+      }
+
+      case userActionTypes.USER_RECEIVED: {
+        const receivedUser = Object.assign({}, action.user, { fetching: false });
+        if (action.user) {
+          this.merge('guid', receivedUser);
         }
         break;
       }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -249,19 +249,23 @@ class UserStore extends BaseStore {
     return this._currentViewedType;
   }
 
-  _hasRole(roleToCheck, userType) {
+  _hasRoles(rolesToCheck, userType) {
+    let rolesToCheckWrap = rolesToCheck;
+    if (!Array.isArray(rolesToCheck)) {
+      rolesToCheckWrap = [rolesToCheck];
+    }
     const user = this.currentUser;
     if (!user) return false;
     if (!user[userType]) return false;
-    return !!(user[userType].find((role) => role === roleToCheck));
+    return !!(user[userType].find((role) => rolesToCheckWrap.includes(role)));
   }
 
-  currentUserHasSpaceRole(role) {
-    return this._hasRole(role, 'space_roles');
+  currentUserHasSpaceRoles(roles) {
+    return this._hasRoles(roles, 'space_roles');
   }
 
-  currentUserHasOrgRole(role) {
-    return this._hasRole(role, 'organization_roles');
+  currentUserHasOrgRoles(roles) {
+    return this._hasRoles(roles, 'organization_roles');
   }
 
   get currentUser() {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -224,20 +224,27 @@ export class UserStore extends BaseStore {
         break;
       }
 
-      case userActionTypes.USER_SPACES_RECEIVED: {
+      case userActionTypes.USER_SPACES_RECEIVED:
+      case userActionTypes.USER_ORGS_RECEIVED: {
         const user = this.get(action.userGuid);
         if (!user) {
           break;
         }
 
-        const updatedRoles = action.userSpaces.reduce((roles, userSpace) => {
-          const key = userSpace.guid;
+        const rolesByType = action.userOrgs || action.userSpaces;
+
+        const updatedRoles = rolesByType.reduce((roles, roleByType) => {
+          const key = roleByType.guid;
           // TODO this would be nice if it was an immutable Set
           // We don't check for duplicates, we just continually append.  We're
           // assuming guids are unique between entity types, so user.roles
           // could contain roles for orgs too.
-          const spaceRoles = roles[key] || [];
-          roles[key] = spaceRoles.concat(['space_developer']); // eslint-disable-line
+          const certainRoles = roles[key] || [];
+          if (action.type === userActionTypes.USER_ORGS_RECEIVED) {
+            roles[key] = certainRoles.concat(['org_manager']); // eslint-disable-line
+          } else {
+            roles[key] = certainRoles.concat(['space_developer']); // eslint-disable-line
+          }
           return roles;
         }, user.roles || {});
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -25,7 +25,7 @@ const resourceToRole = {
   }
 };
 
-class UserStore extends BaseStore {
+export class UserStore extends BaseStore {
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));
@@ -33,6 +33,7 @@ class UserStore extends BaseStore {
     this._currentViewedType = 'space_users';
     this._currentUserGuid = null;
     this._error = null;
+    this._loading = {};
   }
 
   _registerToActions(action) {
@@ -223,6 +224,39 @@ class UserStore extends BaseStore {
         break;
       }
 
+      case userActionTypes.USER_SPACES_RECEIVED: {
+        const user = this.get(action.userGuid);
+        if (!user) {
+          break;
+        }
+
+        const updatedRoles = action.userSpaces.reduce((roles, userSpace) => {
+          const key = userSpace.guid;
+          // TODO this would be nice if it was an immutable Set
+          // We don't check for duplicates, we just continually append.  We're
+          // assuming guids are unique between entity types, so user.roles
+          // could contain roles for orgs too.
+          const spaceRoles = roles[key] || [];
+          roles[key] = spaceRoles.concat(['space_developer']); // eslint-disable-line
+          return roles;
+        }, user.roles || {});
+
+        this.merge('guid', { guid: user.guid, roles: updatedRoles });
+        break;
+      }
+
+      case userActionTypes.CURRENT_USER_FETCH: {
+        this._loading.currentUser = true;
+        this.emitChange();
+        break;
+      }
+
+      case userActionTypes.CURRENT_USER_RECEIVED: {
+        this._loading.currentUser = false;
+        this.emitChange();
+        break;
+      }
+
       case userActionTypes.USER_CHANGE_VIEWED_TYPE: {
         if (this._currentViewedType !== action.userType) {
           this._currentViewedType = action.userType;
@@ -269,11 +303,11 @@ class UserStore extends BaseStore {
     return this._currentViewedType;
   }
 
-  _hasRoles(rolesToCheck, userType) {
-    let rolesToCheckWrap = rolesToCheck;
-    if (!Array.isArray(rolesToCheck)) {
-      rolesToCheckWrap = [rolesToCheck];
-    }
+  get isLoadingCurrentUser() {
+    return this._loading.currentUser === true;
+  }
+
+  _hasRole(roleToCheck, userType) {
     const user = this.currentUser;
     if (!user) return false;
     if (!user[userType]) return false;
@@ -286,6 +320,13 @@ class UserStore extends BaseStore {
 
   currentUserHasOrgRoles(roles) {
     return this._hasRoles(roles, 'organization_roles');
+  }
+
+  hasRole(userGuid, entityGuid, role) {
+    const key = entityGuid;
+    const user = this.get(userGuid);
+    const roles = user && user.roles && user.roles[key] || [];
+    return roles.includes(role);
   }
 
   get currentUser() {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -314,6 +314,16 @@ export class UserStore extends BaseStore {
     return this._loading.currentUser === true;
   }
 
+  /*
+   * Returns if a user with userGuid has ANY role within the enity of the
+   * entityGuid.
+   * @param {string} userGuid - The guid of the user.
+   * @param {string} entityGuid - The guid of the entity (space or org) to
+   * check roles for.
+   * @param {string|array} roleToCheck - Either a single role as a string or
+   * an array of roles to check if the user has ANY of the roles.
+   * @return {boolean} Whether the user has the role.
+   */
   hasRole(userGuid, entityGuid, roleToCheck) {
     let wrappedRoles = roleToCheck;
     if (!Array.isArray(roleToCheck)) {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -316,7 +316,7 @@ export class UserStore extends BaseStore {
 
   hasRole(userGuid, entityGuid, roleToCheck) {
     let wrappedRoles = roleToCheck;
-    if (!roleToCheck.length) {
+    if (!Array.isArray(roleToCheck)) {
       wrappedRoles = [roleToCheck];
     }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -308,25 +308,26 @@ export class UserStore extends BaseStore {
   }
 
   _hasRole(roleToCheck, userType) {
+    let wrappedRoleToCheck = roleToCheck;
+    if (!roleToCheck.length) {
+      wrappedRoleToCheck = [roleToCheck];
+    }
     const user = this.currentUser;
     if (!user) return false;
     if (!user[userType]) return false;
-    return !!(user[userType].find((role) => rolesToCheckWrap.includes(role)));
-  }
-
-  currentUserHasSpaceRoles(roles) {
-    return this._hasRoles(roles, 'space_roles');
-  }
-
-  currentUserHasOrgRoles(roles) {
-    return this._hasRoles(roles, 'organization_roles');
+    return !!(user[userType].find((role) => wrappedRoleToCheck.includes(role)));
   }
 
   hasRole(userGuid, entityGuid, role) {
+    let wrappedRoles = role;
+    if (!role.length) {
+      wrappedRoles = [role];
+    }
+
     const key = entityGuid;
     const user = this.get(userGuid);
     const roles = user && user.roles && user.roles[key] || [];
-    return roles.includes(role);
+    return !!roles.find((role) => wrappedRoles.includes(role));
   }
 
   get currentUser() {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -195,9 +195,16 @@ class UserStore extends BaseStore {
       }
 
       case userActionTypes.CURRENT_USER_INFO_RECEIVED: {
-        const user = this.get(action.currentUser.user_id);
-        if (user) {
-          this._currentUserGuid = user.guid;
+        const guid = action.currentUser.user_id;
+        const userInfo = Object.assign(
+          {},
+          action.currentUser,
+          { guid }
+        );
+        this.merge('guid', userInfo, () => {
+          this._currentUserGuid = guid;
+
+          // Always emit change
           this.emitChange();
         }
         break;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -314,10 +314,10 @@ export class UserStore extends BaseStore {
     return this._loading.currentUser === true;
   }
 
-  hasRole(userGuid, entityGuid, role) {
-    let wrappedRoles = role;
-    if (!role.length) {
-      wrappedRoles = [role];
+  hasRole(userGuid, entityGuid, roleToCheck) {
+    let wrappedRoles = roleToCheck;
+    if (!roleToCheck.length) {
+      wrappedRoles = [roleToCheck];
     }
 
     const key = entityGuid;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -307,17 +307,6 @@ export class UserStore extends BaseStore {
     return this._loading.currentUser === true;
   }
 
-  _hasRole(roleToCheck, userType) {
-    let wrappedRoleToCheck = roleToCheck;
-    if (!roleToCheck.length) {
-      wrappedRoleToCheck = [roleToCheck];
-    }
-    const user = this.currentUser;
-    if (!user) return false;
-    if (!user[userType]) return false;
-    return !!(user[userType].find((role) => wrappedRoleToCheck.includes(role)));
-  }
-
   hasRole(userGuid, entityGuid, role) {
     let wrappedRoles = role;
     if (!role.length) {

--- a/static_src/test/.eslintrc
+++ b/static_src/test/.eslintrc
@@ -20,6 +20,7 @@
     "comma-dangle": [2, "never"],
     "func-names": [0, "always"],
     "jasmine/no-spec-dupes": [2, "branch"],
+    "jasmine/no-suite-dupes": [2, "branch"],
     "one-var": 0,
     "one-var-declaration-per-line": 0,
     "prefer-arrow-callback": 0

--- a/static_src/test/global_setup.js
+++ b/static_src/test/global_setup.js
@@ -1,7 +1,8 @@
-
+/* eslint-disable jasmine/no-global-setup,no-console */
 require('babel-polyfill');
 
 import jasmineEnzyme from 'jasmine-enzyme';
+import UserStore from '../stores/user_store';
 
 Function.prototype.bind = Function.prototype.bind || function (thisp) {
   var fn = this;
@@ -243,3 +244,14 @@ afterEach(function () {
   console.warn.restore();
   //console.error.restore();
 });
+
+// TODO Stub out axios.{get,delete,patch,post,put}, all async calls should be
+// stubbed or mocked, otherwise it's an error.
+
+// TODO Stores should have a different singleton strategy so that state can
+// be cleared and managed consistently in tests. Currently, all the singleton
+// stores are listening to dispatch events, which often cause events to be
+// processed twice.
+// UserStore is only an issue because the store calls cfApi. cfApi calls should
+// be moved to the actions.
+UserStore.unsubscribe();

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -22,6 +22,9 @@ var spaceUserRoles = require('./fixtures/space_user_roles.js');
 
 var BASE_URL = '/v2';
 
+const ENV_NO_ORGS = process.env.NO_ORGS || false;
+const ENV_NO_SPACES = process.env.NO_SPACES || false;
+
 function SingleResponse(response) {
   return response;
 }
@@ -103,8 +106,11 @@ module.exports = function api(smocks) {
     label: 'Organizations',
     path: `${BASE_URL}/organizations`,
     handler: function (req, reply) {
-      reply(MultiResponse([]));
-      // reply(MultiResponse(organizations));
+      if (ENV_NO_ORGS) {
+        reply(MultiResponse([]));
+      } else {
+        reply(MultiResponse(organizations));
+      }
     }
   });
 
@@ -188,7 +194,11 @@ module.exports = function api(smocks) {
     label: 'Spaces',
     path: `${BASE_URL}/spaces`,
     handler: function (req, reply) {
-      reply(MultiResponse(spaces));
+      if (ENV_NO_SPACES) {
+        reply(MultiResponse([]));
+      } else {
+        reply(MultiResponse(spaces));
+      }
     }
   });
 

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -39,6 +39,25 @@ function MultiResponse(responses) {
 module.exports = function api(smocks) {
 
   smocks.route({
+    id: 'uaa-userinfo',
+    label: 'UAA user info',
+    path: '/uaa/userinfo',
+    handler: function(req, reply) {
+      reply({
+        user_id: "bba7537f-601d-48c4-9705-4583ba54ea4b",
+        sub: "bba7537f-601d-48c4-9705-4583ba54ea4b",
+        user_name: "fake-personb@gsa.gov",
+        given_name: "fake-personb",
+        family_name: "gsa.gov",
+        email: "fake-personb@gsa.gov",
+        phone_number: null,
+        previous_logon_time: 1489612053883,
+        name: "fake-personb@gsa.gov"
+      });
+    }
+  });
+
+  smocks.route({
     id: 'app-routes',
     label: 'App routes',
     path: `${BASE_URL}/apps/{guid}/routes`,
@@ -161,25 +180,6 @@ module.exports = function api(smocks) {
     path: `${BASE_URL}/organizations/{guid}/user_roles`,
     handler: function (req, reply) {
       reply(MultiResponse(organizationUserRoles));
-    }
-  });
-
-  smocks.route({
-    id: 'uaa-userinfo',
-    label: 'UAA user info',
-    path: '/uaa/userinfo',
-    handler: function(req, reply) {
-      // TODO move to fixtures
-      const firstUser = organizationUsers[0];
-      const currentUser = {
-        email: firstUser.username,
-        family_name: firstUser.username,
-        given_name: firstUser.username,
-        name: firstUser.username,
-        user_id: firstUser.metadata.guid,
-        user_name:firstUser.username
-      };
-      reply(currentUser);
     }
   });
 

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -24,7 +24,7 @@ var BASE_URL = '/v2';
 
 const ENV_NO_ORGS = process.env.NO_ORGS || false;
 const ENV_NO_SPACES = process.env.NO_SPACES || false;
-const ENV_NO_APPS = process.env.NO_APPS || true;
+const ENV_NO_APPS = process.env.NO_APPS || false;
 const ENV_NO_ORG_USERS = process.env.NO_ORG_USERS || false;
 const ENV_NO_SPACE_USERS = process.env.NO_SPACE_USERS || false;
 

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -84,7 +84,8 @@ module.exports = function api(smocks) {
     label: 'Organizations',
     path: `${BASE_URL}/organizations`,
     handler: function (req, reply) {
-      reply(MultiResponse(organizations));
+      reply(MultiResponse([]));
+      // reply(MultiResponse(organizations));
     }
   });
 

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -24,7 +24,7 @@ var BASE_URL = '/v2';
 
 const ENV_NO_ORGS = process.env.NO_ORGS || false;
 const ENV_NO_SPACES = process.env.NO_SPACES || false;
-const ENV_NO_APPS = process.env.NO_APPS || false;
+const ENV_NO_APPS = process.env.NO_APPS || true;
 const ENV_NO_ORG_USERS = process.env.NO_ORG_USERS || false;
 const ENV_NO_SPACE_USERS = process.env.NO_SPACE_USERS || false;
 
@@ -257,6 +257,9 @@ module.exports = function api(smocks) {
       const space = spaceSummaries.find(function(spaceSummary) {
         return spaceSummary.guid === guid;
       });
+      if (ENV_NO_APPS) {
+        space.apps = [];
+      }
       reply(SingleResponse(space));
     }
   });

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -19,6 +19,8 @@ var spaceRoutes = require('./fixtures/space_routes');
 var spaceSummaries = require('./fixtures/space_summaries');
 var spaceQuotaDefinitions = require('./fixtures/space_quota_definitions');
 var spaceUserRoles = require('./fixtures/space_user_roles.js');
+var userOrganizations = require('./fixtures/user_organizations.js');
+var userSpaces = require('./fixtures/user_spaces.js');
 
 var BASE_URL = '/v2';
 
@@ -184,6 +186,37 @@ module.exports = function api(smocks) {
       } else {
         reply(MultiResponse(organizationUsers));
       }
+    }
+  });
+
+  smocks.route({
+    id: 'user',
+    label: 'User',
+    path: `${BASE_URL}/users/{guid}`,
+    handler: function (req, reply) {
+      const guid = req.params.guid;
+      const user = organizationUsers.find((orgUser) =>
+        orgUser.metadata.guid === guid);
+
+      reply(SingleResponse(user));
+    }
+  });
+
+  smocks.route({
+    id: 'user-organizations',
+    label: 'User organizations',
+    path: `${BASE_URL}/users/{guid}/organizations`,
+    handler: function(req, reply) {
+      reply(MultiResponse(userOrganizations));
+    }
+  });
+
+  smocks.route({
+    id: 'user-spaces',
+    label: 'User spaces',
+    path: `${BASE_URL}/users/{guid}/spaces`,
+    handler: function(req, reply) {
+      reply(MultiResponse(userSpaces));
     }
   });
 

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -24,6 +24,9 @@ var BASE_URL = '/v2';
 
 const ENV_NO_ORGS = process.env.NO_ORGS || false;
 const ENV_NO_SPACES = process.env.NO_SPACES || false;
+const ENV_NO_APPS = process.env.NO_APPS || false;
+const ENV_NO_ORG_USERS = process.env.NO_ORG_USERS || false;
+const ENV_NO_SPACE_USERS = process.env.NO_SPACE_USERS || false;
 
 function SingleResponse(response) {
   return response;
@@ -176,7 +179,11 @@ module.exports = function api(smocks) {
     label: 'Organization users',
     path: `${BASE_URL}/organizations/{guid}/users`,
     handler: function (req, reply) {
-      reply(MultiResponse(organizationUsers));
+      if (ENV_NO_ORG_USERS) {
+        reply(MultiResponse([organizationUsers[0]]));
+      } else {
+        reply(MultiResponse(organizationUsers));
+      }
     }
   });
 
@@ -268,7 +275,11 @@ module.exports = function api(smocks) {
     label: 'Space user roles',
     path: `${BASE_URL}/spaces/{guid}/user_roles`,
     handler: function (req, reply) {
-      reply(MultiResponse(spaceUserRoles));
+      if (ENV_NO_SPACE_USERS) {
+        reply(MultiResponse([spaceUserRoles[0]]));
+      } else {
+        reply(MultiResponse(spaceUserRoles));
+      }
     }
   });
 

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -22,7 +22,7 @@ var spaceUserRoles = require('./fixtures/space_user_roles.js');
 
 var BASE_URL = '/v2';
 
-const ENV_NO_ORGS = process.env.NO_ORGS || true;
+const ENV_NO_ORGS = process.env.NO_ORGS || false;
 const ENV_NO_SPACES = process.env.NO_SPACES || false;
 const ENV_NO_APPS = process.env.NO_APPS || false;
 const ENV_NO_ORG_USERS = process.env.NO_ORG_USERS || false;

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -22,7 +22,7 @@ var spaceUserRoles = require('./fixtures/space_user_roles.js');
 
 var BASE_URL = '/v2';
 
-const ENV_NO_ORGS = process.env.NO_ORGS || false;
+const ENV_NO_ORGS = process.env.NO_ORGS || true;
 const ENV_NO_SPACES = process.env.NO_SPACES || false;
 const ENV_NO_APPS = process.env.NO_APPS || false;
 const ENV_NO_ORG_USERS = process.env.NO_ORG_USERS || false;

--- a/static_src/test/server/fixtures/user_organizations.js
+++ b/static_src/test/server/fixtures/user_organizations.js
@@ -1,0 +1,53 @@
+
+const userOrganizations = [
+  {
+    "metadata": {
+      "guid": "cfeb9be5-a61a-4f68-894e-8808ab008aaa",
+      "url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa",
+      "created_at": "2015-03-13T22:37:53Z",
+      "updated_at": "2015-06-25T20:27:02Z"
+    },
+    "entity": {
+      "name": "fake-cf",
+      "billing_enabled": false,
+      "quota_definition_guid": "f7963421-c06e-4847-9913-bcd0e6048fa2",
+      "status": "active",
+      "default_isolation_segment_guid": null,
+      "quota_definition_url": "/v2/quota_definitions/f7963421-c06e-4847-9913-bcd0e6048fa2",
+      "spaces_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/spaces",
+      "domains_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/domains",
+      "private_domains_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/private_domains",
+      "users_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/users",
+      "managers_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/managers",
+      "billing_managers_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/billing_managers",
+      "auditors_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/auditors",
+      "app_events_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/app_events",
+      "space_quota_definitions_url": "/v2/organizations/cfeb9be5-a61a-4f68-894e-8808ab008aaa/space_quota_definitions"
+    }
+  },
+  {
+    "metadata": {
+      "guid": "48b3f8a1-ffe7-4aa8-8e85-94768d6bd250",
+      "url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250",
+      "created_at": "2015-08-14T19:20:03Z",
+      "updated_at": "2016-04-18T18:16:27Z"
+    },
+    "entity": {
+      "name": "fake-cf-deck-testing",
+      "billing_enabled": false,
+      "quota_definition_guid": "f7963421-c06e-4847-9913-bcd0e6048fa2",
+      "status": "active",
+      "default_isolation_segment_guid": null,
+      "quota_definition_url": "/v2/quota_definitions/f7963421-c06e-4847-9913-bcd0e6048fa2",
+      "spaces_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/spaces",
+      "domains_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/domains",
+      "private_domains_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/private_domains",
+      "users_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/users",
+      "managers_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/managers",
+      "billing_managers_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/billing_managers",
+      "auditors_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/auditors",
+      "app_events_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/app_events",
+      "space_quota_definitions_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/space_quota_definitions"
+    }
+  }
+];

--- a/static_src/test/server/fixtures/user_spaces.js
+++ b/static_src/test/server/fixtures/user_spaces.js
@@ -1,0 +1,59 @@
+
+const userSpaces = [
+  {
+    "metadata": {
+      "guid": "82af0edb-8540-4064-82f2-d74df612b794",
+      "url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794",
+      "created_at": "2015-08-14T19:20:11Z",
+      "updated_at": "2015-08-14T19:20:11Z"
+    },
+    "entity": {
+      "name": "dev",
+      "organization_guid": "48b3f8a1-ffe7-4aa8-8e85-94768d6bd250",
+      "space_quota_definition_guid": null,
+      "isolation_segment_guid": null,
+      "allow_ssh": true,
+      "organization_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250",
+      "developers_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/developers",
+      "managers_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/managers",
+      "auditors_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/auditors",
+      "apps_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/apps",
+      "routes_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/routes",
+      "domains_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/domains",
+      "service_instances_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/service_instances",
+      "app_events_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/app_events",
+      "events_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/events",
+      "security_groups_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/security_groups",
+      "staging_security_groups_url": "/v2/spaces/82af0edb-8540-4064-82f2-d74df612b794/staging_security_groups"
+    }
+  },
+  {
+    "metadata": {
+      "guid": "b7e56bba-b01b-4c14-883f-2e6d15284b58",
+      "url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58",
+      "created_at": "2015-09-16T17:41:53Z",
+      "updated_at": "2015-09-16T17:41:53Z"
+    },
+    "entity": {
+      "name": "testSpace01",
+      "organization_guid": "48b3f8a1-ffe7-4aa8-8e85-94768d6bd250",
+      "space_quota_definition_guid": null,
+      "isolation_segment_guid": null,
+      "allow_ssh": true,
+      "organization_url": "/v2/organizations/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250",
+      "developers_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/developers",
+      "managers_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/managers",
+      "auditors_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/auditors",
+      "apps_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/apps",
+      "routes_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/routes",
+      "domains_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/domains",
+      "service_instances_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/service_instances",
+      "app_events_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/app_events",
+      "events_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/events",
+      "security_groups_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/security_groups",
+      "staging_security_groups_url": "/v2/spaces/b7e56bba-b01b-4c14-883f-2e6d15284b58/staging_security_groups"
+    }
+  }
+];
+
+module.exports = userSpaces;

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -448,6 +448,34 @@ describe('userActions', function() {
     });
   });
 
+  describe('receivedUserOrgs()', function () {
+    let userGuid, userOrgs, result;
+
+    beforeEach(function (done) {
+      userGuid = 'user123';
+      userOrgs = [{ guid: 'org123' }, { guid: 'org456' }];
+      sandbox.stub(AppDispatcher, 'handleServerAction');
+
+      userActions.receivedUserOrgs(userGuid, userOrgs)
+        .then(_result => {
+          result = _result;
+        })
+        .then(done, done.fail);
+    });
+
+    it('dispatches USER_ORGS_RECEIVED', function () {
+      expect(AppDispatcher.handleServerAction).toHaveBeenCalledWith(sinon.match({
+        type: userActionTypes.USER_ORGS_RECEIVED,
+        userGuid,
+        userOrgs
+      }));
+    });
+
+    it('resolves the userOrgs', function () {
+      expect(result).toEqual(userOrgs);
+    });
+  });
+
   describe('fetchCurrentUser()', function () {
     beforeEach(function (done) {
       sandbox.stub(userActions, 'fetchAuthStatus').returns(Promise.resolve());

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -423,6 +423,31 @@ describe('userActions', function() {
     });
   });
 
+  describe('fetchUserOrgs()', function () {
+    let userGuid;
+
+    beforeEach(function (done) {
+      userGuid = 'user123';
+      sandbox.stub(cfApi, 'fetchUserOrgs').returns(Promise.resolve([]));
+      sandbox.stub(AppDispatcher, 'handleViewAction');
+
+      userActions.fetchUserOrgs(userGuid)
+        .then(done, done.fail);
+    });
+
+    it('dispatches USER_ORGS_FETCH', function () {
+      expect(AppDispatcher.handleViewAction).toHaveBeenCalledWith(sinon.match({
+        type: userActionTypes.USER_ORGS_FETCH,
+        userGuid
+      }));
+    });
+
+    it('calls cfApi', function () {
+      expect(cfApi.fetchUserOrgs).toHaveBeenCalledOnce();
+      expect(cfApi.fetchUserOrgs).toHaveBeenCalledWith(userGuid);
+    });
+  });
+
   describe('fetchCurrentUser()', function () {
     beforeEach(function (done) {
       sandbox.stub(userActions, 'fetchAuthStatus').returns(Promise.resolve());

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -482,6 +482,7 @@ describe('userActions', function() {
       sandbox.stub(userActions, 'fetchCurrentUserInfo')
         .returns(Promise.resolve({ user_id: 'user123' }));
       sandbox.stub(userActions, 'fetchUser').returns(Promise.resolve());
+      sandbox.stub(userActions, 'fetchUserOrgs').returns(Promise.resolve());
       sandbox.stub(userActions, 'fetchUserSpaces').returns(Promise.resolve());
       sandbox.stub(userActions, 'receivedCurrentUser').returns(Promise.resolve());
       sandbox.stub(AppDispatcher, 'handleViewAction');

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -5,20 +5,20 @@ import Immutable from 'immutable';
 
 import AppDispatcher from '../../../dispatcher.js';
 import cfApi from '../../../util/cf_api.js';
-import UserStore from '../../../stores/user_store.js';
+import { UserStore as _UserStore } from '../../../stores/user_store.js';
 import userActions from '../../../actions/user_actions.js';
 import { userActionTypes } from '../../../constants';
 
-describe('UserStore', function() {
-  var sandbox;
+describe('UserStore', function () {
+  let sandbox, UserStore;
 
   beforeEach(() => {
-    UserStore._data = Immutable.List();
-    UserStore._currentUserGuid = null;
+    UserStore = new _UserStore();
     sandbox = sinon.sandbox.create();
   });
 
   afterEach(() => {
+    UserStore.unsubscribe();
     sandbox.restore();
   });
 
@@ -573,6 +573,115 @@ describe('UserStore', function() {
 
     it('sets user state to non-fetching', function () {
       expect(user.fetching).toBe(false);
+    });
+  });
+
+  describe('USER_SPACES_RECEIVED', function () {
+    let userGuid, userSpaces, user;
+    beforeEach(function () {
+      userGuid = 'user123';
+      userSpaces = [{ guid: 'space123' }, { guid: 'space456' }];
+
+      // User with no roles
+      UserStore.push({ guid: userGuid });
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_SPACES_RECEIVED,
+        userGuid,
+        userSpaces
+      });
+
+      user = UserStore.get(userGuid);
+    });
+
+    it('creates a roles property on user', function () {
+      expect(user.roles).toBeTruthy();
+    });
+
+    it('assigns space_developer role for each space', function () {
+      expect(user.roles).toEqual({
+        space123: ['space_developer'],
+        space456: ['space_developer']
+      });
+    });
+  });
+
+  describe('CURRENT_USER_FETCH', function () {
+    beforeEach(function () {
+      sandbox.spy(UserStore, 'emitChange');
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.CURRENT_USER_FETCH
+      });
+    });
+
+    it('sets loading state true', function () {
+      expect(UserStore.isLoadingCurrentUser).toBe(true);
+    });
+
+    it('sets loading currentUser state true', function () {
+      expect(UserStore._loading.currentUser).toBe(true);
+    });
+
+    it('emits change', function () {
+      expect(UserStore.emitChange).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('CURRENT_USER_RECEIVED', function () {
+    beforeEach(function () {
+      const currentUser = { guid: '1234' };
+      sandbox.spy(UserStore, 'emitChange');
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.CURRENT_USER_RECEIVED,
+        currentUser
+      });
+    });
+
+    it('sets loading state false', function () {
+      expect(UserStore.isLoadingCurrentUser).toBe(false);
+    });
+
+    it('sets loading currentUser state false', function () {
+      expect(UserStore._loading.currentUser).toBe(false);
+    });
+
+    it('emits change', function () {
+      expect(UserStore.emitChange).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('hasRole()', function () {
+    describe('user with space_developer role', function () {
+      let user, space;
+
+      beforeEach(function () {
+        space = { guid: 'space1234' };
+        user = {
+          guid: 'user123',
+          roles: {
+            [space.guid]: ['space_developer']
+          }
+        };
+
+        UserStore.push(user);
+      });
+
+      it('returns true for space_developer', function () {
+        expect(UserStore.hasRole(user.guid, space.guid, 'space_developer')).toBe(true);
+      });
+
+      it('returns false for space_manager', function () {
+        expect(UserStore.hasRole(user.guid, space.guid, 'space_manager')).toBe(false);
+      });
+
+      it('reutrns false for another space', function () {
+        expect(UserStore.hasRole(user.guid, 'otherspace123', 'space_developer')).toBe(false);
+      });
+
+      it('returns false for another user', function () {
+        expect(UserStore.hasRole('otheruser123', space.guid, 'space_developer')).toBe(false);
+      });
     });
   });
 });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -447,90 +447,6 @@ describe('UserStore', function () {
     });
   });
 
-  describe('currentUserhasSpaceRoles()', function() {
-    it('should call _hasRoles() with role and userType of space', function() {
-      const spy = sandbox.spy(UserStore, '_hasRoles');
-      const testRoles = ['space'];
-
-      UserStore.currentUserHasSpaceRoles(testRoles);
-
-      expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(testRoles, 'space_roles');
-    });
-  });
-
-  describe('currentUserHasOrgRoles()', function() {
-    it('should call _hasRoles() with role and userType of org', function() {
-      const spy = sandbox.spy(UserStore, '_hasRoles');
-      const testRoles = ['person'];
-
-      UserStore.currentUserHasOrgRoles(testRoles);
-
-      expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(testRoles, 'organization_roles');
-    });
-  });
-
-  describe('_hasRoles()', function() {
-    it('should return false if user not found', function() {
-      const roles = ['test'];
-      UserStore._currentUserGuid = 'alkdsjf';
-      const actual = UserStore._hasRoles(roles, 'organization_roles');
-
-      expect(actual).toBeFalsy();
-    });
-
-    it('should still work when passed one role', function() {
-      const roles = 'test';
-      UserStore._currentUserGuid = 'alkdsjf';
-      const actual = UserStore._hasRoles(roles, 'organization_roles');
-
-      expect(actual).toBeFalsy();
-    });
-
-    it('should return false if user doesn\'t have role', function() {
-      const userGuid = 'adfadsfa';
-      const user = { guid: userGuid, user_name: 'fakeuser', organization_roles: [
-        'iron_throne_manager']};
-      const role = 'vale_manager';
-
-      UserStore._currentUserGuid = userGuid;
-      UserStore.push(user);
-
-      const actual = UserStore._hasRoles(role, 'organization_roles');
-
-      expect(actual).toBeFalsy();
-    });
-
-    it('should return false if user doesn\'t have the role type', function() {
-      const userGuid = 'adfadsfa';
-      const user = { guid: userGuid, user_name: 'fakeuser' };
-      const role = 'vale_manager';
-
-      UserStore._currentUserGuid = userGuid;
-      UserStore.push(user);
-
-      const actual = UserStore._hasRoles(role, 'organization_roles');
-
-      expect(actual).toBeFalsy();
-    });
-
-    it('should true if it finds the role on the user', function() {
-      const role = 'highgarden_manager';
-      const userGuid = 'adfadsfa';
-      const user = { guid: userGuid, user_name: 'fakeuser', organization_roles: [
-        'iron_throne_manager', role]};
-
-      UserStore._currentUserGuid = userGuid;
-      UserStore.push(user);
-
-      const actual = UserStore._hasRoles(role, 'organization_roles');
-
-      expect(actual).toBeTruthy();
-
-    });
-  });
-
   describe('getAllInOrg()', function() {
     it('should find all users that have the org guid passed in', function() {
       var orgGuid = 'asdfa';
@@ -652,15 +568,17 @@ describe('UserStore', function () {
   });
 
   describe('hasRole()', function () {
-    describe('user with space_developer role', function () {
-      let user, space;
+    describe('user with space_developer and org roles', function () {
+      let user, space, org;
 
       beforeEach(function () {
+        org = { guid: 'org1234' };
         space = { guid: 'space1234' };
         user = {
           guid: 'user123',
           roles: {
-            [space.guid]: ['space_developer']
+            [space.guid]: ['space_developer'],
+            [org.guid]: ['org_manager', 'org_auditor']
           }
         };
 
@@ -675,7 +593,19 @@ describe('UserStore', function () {
         expect(UserStore.hasRole(user.guid, space.guid, 'space_manager')).toBe(false);
       });
 
-      it('reutrns false for another space', function () {
+      it('returns true for org_manager', function() {
+        expect(UserStore.hasRole(user.guid, org.guid, 'org_manager')).toBe(true);
+      });
+
+      it('returns true for org_manager and org_auditor', function() {
+        expect(UserStore.hasRole(user.guid, org.guid, ['org_manager', 'org_auditor'])).toBe(true);
+      });
+
+      it('returns true for org_manager and org_developer', function() {
+        expect(UserStore.hasRole(user.guid, org.guid, ['org_manager', 'org_developer'])).toBe(true);
+      });
+
+      it('returns false for another space', function () {
         expect(UserStore.hasRole(user.guid, 'otherspace123', 'space_developer')).toBe(false);
       });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -445,35 +445,43 @@ describe('UserStore', function() {
     });
   });
 
-  describe('currentUserHasSpaceRole()', function() {
-    it('should call _hasRole() with role and userType of space', function() {
-      const spy = sandbox.spy(UserStore, '_hasRole');
-      const testRole = 'space';
+  describe('currentUserhasSpaceRoles()', function() {
+    it('should call _hasRoles() with role and userType of space', function() {
+      const spy = sandbox.spy(UserStore, '_hasRoles');
+      const testRoles = ['space'];
 
-      UserStore.currentUserHasSpaceRole(testRole);
+      UserStore.currentUserHasSpaceRoles(testRoles);
 
       expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(testRole, 'space_roles');
+      expect(spy).toHaveBeenCalledWith(testRoles, 'space_roles');
     });
   });
 
-  describe('currentUserHasOrgRole()', function() {
-    it('should call _hasRole() with role and userType of org', function() {
-      const spy = sandbox.spy(UserStore, '_hasRole');
-      const testRole = 'person';
+  describe('currentUserHasOrgRoles()', function() {
+    it('should call _hasRoles() with role and userType of org', function() {
+      const spy = sandbox.spy(UserStore, '_hasRoles');
+      const testRoles = ['person'];
 
-      UserStore.currentUserHasOrgRole(testRole);
+      UserStore.currentUserHasOrgRoles(testRoles);
 
       expect(spy).toHaveBeenCalledOnce();
-      expect(spy).toHaveBeenCalledWith(testRole, 'organization_roles');
+      expect(spy).toHaveBeenCalledWith(testRoles, 'organization_roles');
     });
   });
 
-  describe('_hasRole()', function() {
+  describe('_hasRoles()', function() {
     it('should return false if user not found', function() {
-      const role = 'test';
+      const roles = ['test'];
       UserStore._currentUserGuid = 'alkdsjf';
-      const actual = UserStore._hasRole(role, 'organization_roles');
+      const actual = UserStore._hasRoles(roles, 'organization_roles');
+
+      expect(actual).toBeFalsy();
+    });
+
+    it('should still work when passed one role', function() {
+      const roles = 'test';
+      UserStore._currentUserGuid = 'alkdsjf';
+      const actual = UserStore._hasRoles(roles, 'organization_roles');
 
       expect(actual).toBeFalsy();
     });
@@ -487,7 +495,7 @@ describe('UserStore', function() {
       UserStore._currentUserGuid = userGuid;
       UserStore.push(user);
 
-      const actual = UserStore._hasRole(role, 'organization_roles');
+      const actual = UserStore._hasRoles(role, 'organization_roles');
 
       expect(actual).toBeFalsy();
     });
@@ -500,7 +508,7 @@ describe('UserStore', function() {
       UserStore._currentUserGuid = userGuid;
       UserStore.push(user);
 
-      const actual = UserStore._hasRole(role, 'organization_roles');
+      const actual = UserStore._hasRoles(role, 'organization_roles');
 
       expect(actual).toBeFalsy();
     });
@@ -514,7 +522,7 @@ describe('UserStore', function() {
       UserStore._currentUserGuid = userGuid;
       UserStore.push(user);
 
-      const actual = UserStore._hasRole(role, 'organization_roles');
+      const actual = UserStore._hasRoles(role, 'organization_roles');
 
       expect(actual).toBeTruthy();
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -543,4 +543,36 @@ describe('UserStore', function() {
       expect(actual[0]).toEqual(testUser);
     });
   });
+
+  describe('USER_FETCH', function () {
+    let user;
+    beforeEach(function () {
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_FETCH,
+        userGuid: '123'
+      });
+
+      user = UserStore.get('123');
+    });
+
+    it('sets user state to fetching', function () {
+      expect(user.fetching).toBe(true);
+    });
+  });
+
+  describe('USER_RECEIVED', function () {
+    let user;
+    beforeEach(function () {
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_RECEIVED,
+        user: { guid: '123' }
+      });
+
+      user = UserStore.get('123');
+    });
+
+    it('sets user state to non-fetching', function () {
+      expect(user.fetching).toBe(false);
+    });
+  });
 });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -492,11 +492,12 @@ describe('UserStore', function () {
     });
   });
 
-  describe('USER_SPACES_RECEIVED', function () {
-    let userGuid, userSpaces, user;
+  describe('USER_SPACES_RECEIVED|USER_ORGS_RECEIVED', function () {
+    let userGuid, userSpaces, userOrgs, user;
     beforeEach(function () {
       userGuid = 'user123';
       userSpaces = [{ guid: 'space123' }, { guid: 'space456' }];
+      userOrgs = [{ guid: 'org123' }];
 
       // User with no roles
       UserStore.push({ guid: userGuid });
@@ -505,6 +506,12 @@ describe('UserStore', function () {
         type: userActionTypes.USER_SPACES_RECEIVED,
         userGuid,
         userSpaces
+      });
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_ORGS_RECEIVED,
+        userGuid,
+        userOrgs
       });
 
       user = UserStore.get(userGuid);
@@ -517,7 +524,16 @@ describe('UserStore', function () {
     it('assigns space_developer role for each space', function () {
       expect(user.roles).toEqual({
         space123: ['space_developer'],
-        space456: ['space_developer']
+        space456: ['space_developer'],
+        org123: ['org_manager']
+      });
+    });
+
+    it('assigns org_manager role for each org', function () {
+      expect(user.roles).toEqual({
+        space123: ['space_developer'],
+        space456: ['space_developer'],
+        org123: ['org_manager']
       });
     });
   });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -401,33 +401,35 @@ describe('UserStore', function() {
     });
   });
 
-  describe('on current user info received', function() {
-    it('should emit a change event if user found', function() {
+  describe('on current user info received', function () {
+    it('should emit a change event always', function () {
       const userGuid = 'zxsdkfjasdfladsf';
       const user = { user_id: userGuid, user_name: 'mr' };
       const existingUser = { guid: userGuid };
       const spy = sandbox.spy(UserStore, 'emitChange');
-      userActions.receivedCurrentUserInfo(user);
-
-      expect(spy).not.toHaveBeenCalled();
 
       UserStore._data = Immutable.fromJS([existingUser]);
-      userActions.receivedCurrentUserInfo(user);
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.CURRENT_USER_INFO_RECEIVED,
+        currentUser: user
+      });
 
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set the currentUser to user object if exists', function() {
+    it('should merge the currentUser', function () {
       const userGuid = 'zxsdkfjasdfladsf';
       const currentUserInfo = { user_id: userGuid, user_name: 'mr' };
       const existingUser = { guid: userGuid };
       UserStore._data = Immutable.fromJS([existingUser]);
 
-      userActions.receivedCurrentUserInfo(currentUserInfo);
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.CURRENT_USER_INFO_RECEIVED,
+        currentUser: currentUserInfo
+      });
 
       const actual = UserStore.currentUser;
-
-      expect(actual).toEqual(existingUser);
+      expect(actual).toEqual({ ...currentUserInfo, ...existingUser });
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -1383,4 +1383,20 @@ describe('cfApi', function() {
       }).catch(done.fail);
     });
   });
+
+  describe('fetchUser()', function () {
+    let userGuid;
+
+    beforeEach(function (done) {
+      userGuid = 'user123';
+      sandbox.stub(http, 'get').returns(Promise.resolve({ data: { entity: { guid: 'user123' } } }));
+
+      cfApi.fetchUser(userGuid).then(done, done.fail);
+    });
+
+    it('calls user endpoint', function () {
+      expect(http.get).toHaveBeenCalledOnce();
+      expect(http.get).toHaveBeenCalledWith(sinon.match(`/users/${userGuid}`));
+    });
+  });
 });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -1399,4 +1399,49 @@ describe('cfApi', function() {
       expect(http.get).toHaveBeenCalledWith(sinon.match(`/users/${userGuid}`));
     });
   });
+
+  describe('fetchUserSpaces()', function () {
+    let user, space, result;
+    beforeEach(function (done) {
+      user = { guid: 'user123' };
+      space = { guid: 'space123' };
+      sandbox.stub(http, 'get').returns(Promise.resolve({
+        data: {
+          resources: [{ metadata: space, entity: {} }]
+        }
+      }));
+
+      cfApi.fetchUserSpaces(user.guid)
+        .then(_result => {
+          result = _result;
+        })
+        .then(done, done.fail);
+    });
+
+    it('calls user spaces endpoint', function () {
+      expect(http.get).toHaveBeenCalledWith(sinon.match(`/users/${user.guid}/spaces`));
+    });
+
+    it('resolves with list of spaces', function () {
+      expect(result).toEqual([space]);
+    });
+
+    describe('given orgGuid', function () {
+      let orgGuid;
+      beforeEach(function (done) {
+        orgGuid = 'org123';
+
+        cfApi.fetchUserSpaces(user.guid, { orgGuid })
+          .then(done, done.fail);
+      });
+
+      it('includes query parameter for organization_guid', function () {
+        expect(http.get)
+          .toHaveBeenCalledWith(
+            sinon.match.string,
+            sinon.match({ params: { q: `organization_guid:${orgGuid}` } })
+          );
+      });
+    });
+  });
 });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -1444,4 +1444,23 @@ describe('cfApi', function() {
       });
     });
   });
+
+  describe('fetchUserOrgs()', function () {
+    let userGuid;
+    let fetchAllPagesStub;
+
+    beforeEach(function (done) {
+      userGuid = 'user123';
+      fetchAllPagesStub = sandbox.stub(cfApi, 'fetchAllPages').returns(
+        Promise.resolve({ guid: userGuid }));
+
+      cfApi.fetchUserOrgs(userGuid).then(done, done.fail);
+    });
+
+    it('calls user endpoint', function () {
+      expect(fetchAllPagesStub).toHaveBeenCalledOnce();
+      expect(fetchAllPagesStub).toHaveBeenCalledWith(
+        `/users/${userGuid}/organizations`);
+    });
+  });
 });

--- a/static_src/test/unit/util/uaa_api.spec.js
+++ b/static_src/test/unit/util/uaa_api.spec.js
@@ -19,18 +19,6 @@ function createPromise(res, err) {
 
 describe('uaaApi', function() {
   let sandbox;
-  const errorFetchRes = { message: 'error' };
-
-  function fetchErrorSetup() {
-    var stub = sandbox.stub(http, 'get'),
-        spy = sandbox.spy(errorActions, 'errorFetch'),
-        expected = errorFetchRes;
-
-    let testPromise = createPromise(true, expected);
-    stub.returns(testPromise);
-
-    return spy;
-  };
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -40,32 +28,16 @@ describe('uaaApi', function() {
     sandbox.restore();
   });
 
-  describe('fetchUserInfo()', function() {
-    it('should call an http get request for uaa user info', function(done) {
-      var spy = sandbox.spy(http, 'get');
+  describe('fetchUserInfo()', function () {
+    beforeEach(function (done) {
+      sandbox.stub(http, 'get').returns(Promise.resolve({ data: { user_id: 'user123' } }));
 
-      uaaApi.fetchUserInfo().then(() => {
-        expect(spy).toHaveBeenCalledOnce();
-        let actual = spy.getCall(0).args[0];
-        expect(actual).toMatch('userinfo');
-        done();
-      });
+      uaaApi.fetchUserInfo().then(done, done.fail);
     });
 
-    it('should call a user action current user info received on success',
-        function(done) {
-      const expected = { user_id: 'zcxcvbxcvb', user_name: 'brain' };
-      let stub = sandbox.stub(http, 'get');
-      let spy = sandbox.spy(userActions, 'receivedCurrentUserInfo');
-
-      let testPromise = createPromise({data: expected});
-      stub.returns(testPromise);
-
-      uaaApi.fetchUserInfo().then(() => {
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(expected);
-        done();
-      });
+    it('should call an http get request for uaa user info', function () {
+      expect(http.get).toHaveBeenCalledOnce();
+      expect(http.get).toHaveBeenCalledWith(sinon.match(/\/userinfo$/));
     });
   });
 });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -513,7 +513,6 @@ export default {
   },
 
   fetchUser(userGuid) {
-    return http.get(`${APIV}/users/${userGuid}`)
-      .then(res => res.data);
+    return this.fetchOne(`/users/${userGuid}`);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -514,5 +514,14 @@ export default {
 
   fetchUser(userGuid) {
     return this.fetchOne(`/users/${userGuid}`);
+  },
+
+  fetchUserSpaces(userGuid, options = {}) {
+    const data = {};
+    if (options.orgGuid) {
+      data.q = `organization_guid:${options.orgGuid}`;
+    }
+
+    return this.fetchAllPages(`/users/${userGuid}/spaces`, data, results => results);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -3,7 +3,6 @@ import http from 'axios';
 import { noticeError } from '../util/analytics.js';
 import domainActions from '../actions/domain_actions.js';
 import errorActions from '../actions/error_actions.js';
-import loginActions from '../actions/login_actions.js';
 import quotaActions from '../actions/quota_actions.js';
 import routeActions from '../actions/route_actions.js';
 import userActions from '../actions/user_actions.js';
@@ -132,11 +131,12 @@ export default {
   },
 
   getAuthStatus() {
-    return http.get(`${APIV}/authstatus`).then((res) => {
-      loginActions.receivedStatus(res.data.status);
-    }).catch(() => {
-      loginActions.receivedStatus(false);
-    });
+    return http.get(`${APIV}/authstatus`)
+      .then(res => res.data.status)
+      // Note: the getAuthStatus call will return 401 when not logged in, so
+      // failure here means the user was likely not logged in. Although there
+      // could be the additional problem that there was a problem with the req.
+      .catch(() => false);
   },
 
   fetchOrgLinks(guid) {
@@ -510,5 +510,10 @@ export default {
         handleError(err);
         return Promise.reject(err);
       });
+  },
+
+  fetchUser(userGuid) {
+    return http.get(`${APIV}/users/${userGuid}`)
+      .then(res => res.data);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -526,6 +526,7 @@ export default {
   },
 
   fetchUserOrgs(userGuid) {
-    return this.fetchAllPages(`/users/${userGuid}/organizations`, results => results);
+    return this.fetchAllPages(`/users/${userGuid}/organizations`,
+      (results) => Promise.resolve(results));
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -525,7 +525,7 @@ export default {
     return this.fetchAllPages(`/users/${userGuid}/spaces`, data, results => results);
   },
 
-  fetchUserOrgs(userGuid, options = {}) {
+  fetchUserOrgs(userGuid) {
     return this.fetchAllPages(`/users/${userGuid}/organizations`);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -523,5 +523,9 @@ export default {
     }
 
     return this.fetchAllPages(`/users/${userGuid}/spaces`, data, results => results);
+  },
+
+  fetchUserOrgs(userGuid, options = {}) {
+    return this.fetchAllPages(`/users/${userGuid}/organizations`);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -526,6 +526,6 @@ export default {
   },
 
   fetchUserOrgs(userGuid) {
-    return this.fetchAllPages(`/users/${userGuid}/organizations`);
+    return this.fetchAllPages(`/users/${userGuid}/organizations`, results => results);
   }
 };

--- a/static_src/util/uaa_api.js
+++ b/static_src/util/uaa_api.js
@@ -1,16 +1,11 @@
 
 import http from 'axios';
-import errorActions from '../actions/error_actions.js';
-import userActions from '../actions/user_actions.js';
 
 const URL = '/uaa';
 
 export default {
   fetchUserInfo() {
-    return http.get(`${URL}/userinfo`).then((res) => {
-      userActions.receivedCurrentUserInfo(res.data);
-    }).catch((err) => {
-      errorActions.errorFetch(err);
-    });
+    return http.get(`${URL}/userinfo`)
+      .then(res => res.data);
   }
 };


### PR DESCRIPTION
Adds empty states for:
- no orgs
- no users
- just one user
- no spaces

Modifies the existing no apps state for pages like overview where there are many side by side.

Still needs services, which is a larger one and not required for usability testing, so don't need for this iteration.


Merged in #965 
Requires https://github.com/18F/cg-style/pull/313
Ref https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-556

![image](https://cloud.githubusercontent.com/assets/1701077/24130518/455b0040-0da6-11e7-9bb1-2d88cde042b7.png)

![image](https://cloud.githubusercontent.com/assets/1701077/24130535/5c2d25aa-0da6-11e7-8ef1-09815675fa51.png)
