### PR TITLE
Dockerize w/ npm link to cg-style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,5 @@
-FROM ubuntu:17.04
+FROM node:6
 
-# use bash in place of sh
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+VOLUME /usr/local/lib/node_modules
 
-# Based on guidance at http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html
-WORKDIR /cg-dashboard
-
-# Install packages necessary for installing nvm
-RUN apt-get update && apt-get install -y -q --no-install-recommends \
-        build-essential \
-        curl \
-        libssl-dev \
-        ca-certificates \
-        python \
-        python-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV NVM_DIR /cg-dashboard/.nvm
-
-# Install nvm
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash
-
-# Add nvm.sh to .bashrc for startup
-RUN echo "source ${NVM_DIR}/nvm.sh" > /root/.bashrc
-
-COPY ./docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
+WORKDIR /cg-dashboard/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,25 @@
 version: '2'
 services:
   app:
-    build: .
-    volumes:
-    - nvm:/cg-dashboard/.nvm
-    - node-modules:/cg-dashboard/node_modules
-    - .:/cg-dashboard
+    extends:
+      file: docker-services.yml
+      service: base_app
     command: npm run testing-server
     ports:
     - 8001:8001
   watch:
-    build: .
-    volumes:
-    - nvm:/cg-dashboard/.nvm
-    - node-modules:/cg-dashboard/node_modules
-    - .:/cg-dashboard
+    extends:
+      file: docker-services.yml
+      service: base_app
+    command: npm run watch
+  watch_cg_style:
+    extends:
+      file: docker-services.yml
+      service: base_app
+    working_dir: /cg-style
     command: npm run watch
 volumes:
   node-modules:
-  nvm:
+  cg-style-node-modules:
+  npm-cache:
+  global-node-modules:

--- a/docker-services.yml
+++ b/docker-services.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  base_app:
+    build: .
+    volumes:
+    - global-node-modules:/usr/local/lib/node_modules
+    - npm-cache:/root/.npm
+    - node-modules:/cg-dashboard/node_modules
+    - .:/cg-dashboard
+    - cg-style-node-modules:/cg-style/node_modules
+    - ../cg-style:/cg-style

--- a/dockerizing-notes.md
+++ b/dockerizing-notes.md
@@ -1,16 +1,17 @@
 # Dockerizing Notes
 
-- `nvm` is run when the container starts (via `docker-entrypoint.sh`) and will
-  use the project's `.nvmrc` file to determine which node version to install
-  and use.
 - Fixed the issue with `npm install` that respects `npm-shrinkwrap.json`. the
   problem was not being able to build the same fsevents due to not having
   python in the container.
 
 ## Running
 
+You will first need to ensure that `../cg-style` exists relative
+to your cg-dashboard checkout and contains a checkout of
+[`cg-style`](https://github.com/18F/cg-style).
+
 1. `docker-compose build`
-1. `docker-compose run app npm install`
+1. `docker-compose run app ./setup-npm-link.sh`
 1. Visit `localhost:8001` (or `app.cgdashboard.docker` if using `dinghy`)
 
 ## Other stuff:
@@ -19,6 +20,7 @@
 
 ## TODO:
 
-* figure out what is needed for also developing `cg-style` (team usually uses `npm link`)
 * figure out why the shrinkwrap doesn't work -- looks like it has to do
   with fsevents not building due to missing python in the container
+* add a test verifying that `.nvmrc` specifies the same node version
+  as the `Dockerfile`.

--- a/setup-npm-link.sh
+++ b/setup-npm-link.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+set -e
+
+export CG_DASHBOARD_DIR=$(pwd)
+export CG_STYLE_DIR='../cg-style'
+
+if [ ! -d "$CG_STYLE_DIR" ]
+then
+  echo "ERROR"
+  echo
+  echo "Please ensure that $CG_STYLE_DIR exists relative to this "
+  echo "directory and has a git checkout of "
+  echo "https://github.com/18F/cg-style in it."
+  exit 1
+fi
+
+cd $CG_STYLE_DIR
+npm install
+npm link
+
+cd $CG_DASHBOARD_DIR
+npm link cloudgov-style
+npm install --no-shrinkwrap


### PR DESCRIPTION
**Note: this is a PR against #1036, not the main branch.**

This adds support for `npm link`ing cg-style with cg-dashboard.

It assumes, though, that you have cg-style checked out relative to the dashboard directory at `../cg-style`.

It runs OK on docker OS X native, but might not run on `dinghy` due to the differences between the way that the two do file permissions and stuff.

I also reverted the `nvm` stuff because it made the docker setup easier to understand (oy sorry @jseppi)... I think a better solution, unless nvm is *really* needed in the container, may be to simply add a static test to ensure that `.nvmrc` and `Dockerfile` specify the same node version (we do this in CALC all over the place).