### PR TITLE
Show alternative expressive empty-state in empty space when user is not SpaceDeveloper

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -161,6 +161,29 @@ const userActions = {
     return Promise.resolve(status);
   },
 
+  fetchUser(userGuid) {
+    if (!userGuid) {
+      return Promise.reject(new Error('userGuid is required'));
+    }
+
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_FETCH,
+      userGuid
+    });
+
+    return cfApi.fetchUser(userGuid)
+      .then(userActions.receivedUser);
+  },
+
+  receivedUser(user) {
+    AppDispatcher.handleServerAction({
+      type: userActionTypes.USER_RECEIVED,
+      user
+    });
+
+    return Promise.resolve(user);
+  },
+
   // Meta action to fetch all the pieces of the current user
   fetchCurrentUser() {
     AppDispatcher.handleViewAction({
@@ -170,6 +193,8 @@ const userActions = {
     // TODO add error action
     return userActions.fetchAuthStatus()
       .then(userActions.fetchCurrentUserInfo)
+      .then(userInfo => userActions.fetchUser(userInfo.user_id))
+      // Grab user from store with all merged properties
       .then(() => UserStore.currentUser)
       .then(userActions.receivedCurrentUser);
   },

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -65,7 +65,7 @@ export default class AppList extends React.Component {
     );
 
     if (this.state.empty) {
-      content = <h4 className="test-none_message">No apps</h4>;
+      content = <h4 className="test-none_message">You have no apps in this space</h4>;
     } else if (!this.state.loading && this.state.apps.length > 0) {
       content = (
         <ComplexList titleElement={ title }>

--- a/static_src/components/info_app_create.jsx
+++ b/static_src/components/info_app_create.jsx
@@ -5,10 +5,12 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import { config } from 'skin';
 
 import createStyler from '../util/create_styler';
+import UserStore from '../stores/user_store';
 
 const propTypes = {
   org: React.PropTypes.object,
-  space: React.PropTypes.object
+  space: React.PropTypes.object,
+  user: React.PropTypes.object
 };
 
 const defaultProps = {
@@ -21,12 +23,22 @@ export default class InfoAppCreate extends React.Component {
     this.styler = createStyler(style);
   }
 
-  render() {
+  get noPermission() {
+    return (
+      <p>
+        <em>Space developers</em> can add apps to
+        spaces. Read more about <a href={ config.docs.deploying_apps }>adding
+        apps</a> and <a href={ config.docs.roles }>permissions</a>.
+      </p>
+    );
+  }
+
+  get spaceDeveloper() {
     const org = this.props.org || {};
     const space = this.props.space || {};
 
     return (
-      <div className={ this.styler('info', 'info-app_create') }>
+      <div>
         <p>
           Learn how to <a href={ config.docs.deploying_apps }>deploy a new app</a>.
         </p>
@@ -56,6 +68,21 @@ export default class InfoAppCreate extends React.Component {
           <code>$ cf target -o { org.name || '<org>' } -s { space.name || '<space>' }</code><br />
           <code>$ cf push my-app</code>
         </pre>
+      </div>
+    );
+  }
+
+  render() {
+    const space = this.props.space || {};
+    const user = this.props.user || {};
+
+    const content = UserStore.hasRole(user.guid, space.guid, 'space_developer') ?
+      this.spaceDeveloper :
+      this.noPermission;
+
+    return (
+      <div className={ this.styler('info', 'info-app_create') }>
+        { content }
       </div>
     );
   }

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -15,6 +15,7 @@ import ServiceCountStatus from './service_count_status.jsx';
 import ServiceInstanceTable from './service_instance_table.jsx';
 import SpaceStore from '../stores/space_store.js';
 import Users from './users.jsx';
+import UserStore from '../stores/user_store';
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -24,7 +25,8 @@ function stateSetter() {
     currentOrg: OrgStore.currentOrg(),
     currentOrgGuid: OrgStore.currentOrgGuid,
     currentSpaceGuid: SpaceStore.currentSpaceGuid,
-    loading: SpaceStore.loading || OrgStore.loading
+    currentUser: UserStore.currentUser,
+    loading: SpaceStore.loading || OrgStore.loading || UserStore.isLoadingCurrentUser
   };
 }
 
@@ -40,11 +42,13 @@ export default class SpaceContainer extends React.Component {
   componentDidMount() {
     OrgStore.addChangeListener(this._onChange);
     SpaceStore.addChangeListener(this._onChange);
+    UserStore.addChangeListener(this._onChange);
   }
 
   componentWillUnmount() {
     OrgStore.removeChangeListener(this._onChange);
     SpaceStore.removeChangeListener(this._onChange);
+    UserStore.removeChangeListener(this._onChange);
   }
 
   _onChange() {
@@ -99,7 +103,11 @@ export default class SpaceContainer extends React.Component {
           </div>
 
           <AppList />
-          <InfoAppCreate space={ space } org={ this.state.currentOrg } />
+          <InfoAppCreate
+            space={ space }
+            org={ this.state.currentOrg }
+            user={ this.state.currentUser }
+          />
         </Panel>
         <Panel title="Service instances">
           <ServiceInstanceTable />

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -230,6 +230,10 @@ const userActionTypes = keymirror({
   ORG_USER_ROLES_RECEIVED: null,
   // Action when all space users were received from the server.
   SPACE_USERS_RECEIVED: null,
+  // User is fetched from the server
+  USER_FETCH: null,
+  // User is received from the server
+  USER_RECEIVED: null,
   // Action to add permissions to a user for a space or org on the server.
   USER_ROLES_ADD: null,
   // Action when user roles are added on the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -234,6 +234,10 @@ const userActionTypes = keymirror({
   USER_FETCH: null,
   // User is received from the server
   USER_RECEIVED: null,
+  // Fetch spaces this user is a member of (developer of).
+  USER_SPACES_FETCH: null,
+  // Receive spaces this user is a member of (developer of).
+  USER_SPACES_RECEIVED: null,
   // Action to add permissions to a user for a space or org on the server.
   USER_ROLES_ADD: null,
   // Action when user roles are added on the server.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -214,6 +214,10 @@ const appActionTypes = keymirror({
 });
 
 const userActionTypes = keymirror({
+  // Fetch auth status from server
+  AUTH_STATUS_FETCH: null,
+  // Auth status received from server
+  AUTH_STATUS_RECEIVED: null,
   // Action to fetch users belonging to a organization from the server.
   ORG_USERS_FETCH: null,
   // Action to fetch the user roles for an org from the server.
@@ -242,6 +246,14 @@ const userActionTypes = keymirror({
   ERROR_REMOVE_USER: null,
   // Action when the type of users being looked at changes
   USER_CHANGE_VIEWED_TYPE: null,
+  // Meta action that we are fetching the multiple pieces that make up the current user
+  CURRENT_USER_FETCH: null,
+  // Meta action that the current user is loaded
+  CURRENT_USER_RECEIVED: null,
+  // An error occurred while loading the current user
+  CURRENT_USER_ERROR: null,
+  // Current user info fetched from server.
+  CURRENT_USER_INFO_FETCH: null,
   // Action when current user info received from server.
   CURRENT_USER_INFO_RECEIVED: null
 });

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -132,8 +132,9 @@ function app(orgGuid, spaceGuid, appGuid) {
     </MainContainer>, mainEl);
 }
 
-function checkAuth() {
-  userActions.fetchCurrentUser();
+function checkAuth(...args) {
+  const [orgGuid, spaceGuid] = args;
+  userActions.fetchCurrentUser({ orgGuid, spaceGuid });
   orgActions.fetchAll();
   spaceActions.fetchAll();
 }

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -25,7 +25,6 @@ import spaceActions from './actions/space_actions.js';
 import serviceActions from './actions/service_actions.js';
 import SpaceContainer from './components/space_container.jsx';
 import { trackPageView } from './util/analytics.js';
-import uaaApi from './util/uaa_api.js';
 import userActions from './actions/user_actions.js';
 
 const mainEl = document.querySelector('.js-app');
@@ -134,9 +133,7 @@ function app(orgGuid, spaceGuid, appGuid) {
 }
 
 function checkAuth() {
-  cfApi.getAuthStatus().then(() => {
-    uaaApi.fetchUserInfo();
-  });
+  userActions.fetchCurrentUser();
   orgActions.fetchAll();
   spaceActions.fetchAll();
 }

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -92,6 +92,7 @@ export const config = {
     deploying_apps: 'https://cloud.gov/docs/getting-started/your-first-deploy/',
     use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/',
     invite_user: 'https://cloud.gov/docs/apps/managing-teammates',
+    roles: 'https://cloud.gov/docs/apps/managing-teammates/#give-roles-to-a-teammate',
     managed_services: 'https://docs.cloud.gov/apps/managed-services/',
     status: 'https://cloudgov.statuspage.io/'
   },

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -206,6 +206,19 @@ class UserStore extends BaseStore {
 
           // Always emit change
           this.emitChange();
+        });
+        break;
+      }
+
+      case userActionTypes.USER_FETCH: {
+        this.merge('guid', { guid: action.userGuid, fetching: true });
+        break;
+      }
+
+      case userActionTypes.USER_RECEIVED: {
+        const receivedUser = Object.assign({}, action.user, { fetching: false });
+        if (action.user) {
+          this.merge('guid', receivedUser);
         }
         break;
       }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -195,9 +195,16 @@ class UserStore extends BaseStore {
       }
 
       case userActionTypes.CURRENT_USER_INFO_RECEIVED: {
-        const user = this.get(action.currentUser.user_id);
-        if (user) {
-          this._currentUserGuid = user.guid;
+        const guid = action.currentUser.user_id;
+        const userInfo = Object.assign(
+          {},
+          action.currentUser,
+          { guid }
+        );
+        this.merge('guid', userInfo, () => {
+          this._currentUserGuid = guid;
+
+          // Always emit change
           this.emitChange();
         }
         break;

--- a/static_src/test/.eslintrc
+++ b/static_src/test/.eslintrc
@@ -20,6 +20,7 @@
     "comma-dangle": [2, "never"],
     "func-names": [0, "always"],
     "jasmine/no-spec-dupes": [2, "branch"],
+    "jasmine/no-suite-dupes": [2, "branch"],
     "one-var": 0,
     "one-var-declaration-per-line": 0,
     "prefer-arrow-callback": 0

--- a/static_src/test/global_setup.js
+++ b/static_src/test/global_setup.js
@@ -1,7 +1,8 @@
-
+/* eslint-disable jasmine/no-global-setup,no-console */
 require('babel-polyfill');
 
 import jasmineEnzyme from 'jasmine-enzyme';
+import UserStore from '../stores/user_store';
 
 Function.prototype.bind = Function.prototype.bind || function (thisp) {
   var fn = this;
@@ -243,3 +244,14 @@ afterEach(function () {
   console.warn.restore();
   //console.error.restore();
 });
+
+// TODO Stub out axios.{get,delete,patch,post,put}, all async calls should be
+// stubbed or mocked, otherwise it's an error.
+
+// TODO Stores should have a different singleton strategy so that state can
+// be cleared and managed consistently in tests. Currently, all the singleton
+// stores are listening to dispatch events, which often cause events to be
+// processed twice.
+// UserStore is only an issue because the store calls cfApi. cfApi calls should
+// be moved to the actions.
+UserStore.unsubscribe();

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -535,4 +535,36 @@ describe('UserStore', function() {
       expect(actual[0]).toEqual(testUser);
     });
   });
+
+  describe('USER_FETCH', function () {
+    let user;
+    beforeEach(function () {
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_FETCH,
+        userGuid: '123'
+      });
+
+      user = UserStore.get('123');
+    });
+
+    it('sets user state to fetching', function () {
+      expect(user.fetching).toBe(true);
+    });
+  });
+
+  describe('USER_RECEIVED', function () {
+    let user;
+    beforeEach(function () {
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_RECEIVED,
+        user: { guid: '123' }
+      });
+
+      user = UserStore.get('123');
+    });
+
+    it('sets user state to non-fetching', function () {
+      expect(user.fetching).toBe(false);
+    });
+  });
 });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -401,33 +401,35 @@ describe('UserStore', function() {
     });
   });
 
-  describe('on current user info received', function() {
-    it('should emit a change event if user found', function() {
+  describe('on current user info received', function () {
+    it('should emit a change event always', function () {
       const userGuid = 'zxsdkfjasdfladsf';
       const user = { user_id: userGuid, user_name: 'mr' };
       const existingUser = { guid: userGuid };
       const spy = sandbox.spy(UserStore, 'emitChange');
-      userActions.receivedCurrentUserInfo(user);
-
-      expect(spy).not.toHaveBeenCalled();
 
       UserStore._data = Immutable.fromJS([existingUser]);
-      userActions.receivedCurrentUserInfo(user);
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.CURRENT_USER_INFO_RECEIVED,
+        currentUser: user
+      });
 
       expect(spy).toHaveBeenCalledOnce();
     });
 
-    it('should set the currentUser to user object if exists', function() {
+    it('should merge the currentUser', function () {
       const userGuid = 'zxsdkfjasdfladsf';
       const currentUserInfo = { user_id: userGuid, user_name: 'mr' };
       const existingUser = { guid: userGuid };
       UserStore._data = Immutable.fromJS([existingUser]);
 
-      userActions.receivedCurrentUserInfo(currentUserInfo);
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.CURRENT_USER_INFO_RECEIVED,
+        currentUser: currentUserInfo
+      });
 
       const actual = UserStore.currentUser;
-
-      expect(actual).toEqual(existingUser);
+      expect(actual).toEqual({ ...currentUserInfo, ...existingUser });
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -1383,4 +1383,20 @@ describe('cfApi', function() {
       }).catch(done.fail);
     });
   });
+
+  describe('fetchUser()', function () {
+    let userGuid;
+
+    beforeEach(function (done) {
+      userGuid = 'user123';
+      sandbox.stub(http, 'get').returns(Promise.resolve({ data: { entity: { guid: 'user123' } } }));
+
+      cfApi.fetchUser(userGuid).then(done, done.fail);
+    });
+
+    it('calls user endpoint', function () {
+      expect(http.get).toHaveBeenCalledOnce();
+      expect(http.get).toHaveBeenCalledWith(sinon.match(`/users/${userGuid}`));
+    });
+  });
 });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -1399,4 +1399,49 @@ describe('cfApi', function() {
       expect(http.get).toHaveBeenCalledWith(sinon.match(`/users/${userGuid}`));
     });
   });
+
+  describe('fetchUserSpaces()', function () {
+    let user, space, result;
+    beforeEach(function (done) {
+      user = { guid: 'user123' };
+      space = { guid: 'space123' };
+      sandbox.stub(http, 'get').returns(Promise.resolve({
+        data: {
+          resources: [{ metadata: space, entity: {} }]
+        }
+      }));
+
+      cfApi.fetchUserSpaces(user.guid)
+        .then(_result => {
+          result = _result;
+        })
+        .then(done, done.fail);
+    });
+
+    it('calls user spaces endpoint', function () {
+      expect(http.get).toHaveBeenCalledWith(sinon.match(`/users/${user.guid}/spaces`));
+    });
+
+    it('resolves with list of spaces', function () {
+      expect(result).toEqual([space]);
+    });
+
+    describe('given orgGuid', function () {
+      let orgGuid;
+      beforeEach(function (done) {
+        orgGuid = 'org123';
+
+        cfApi.fetchUserSpaces(user.guid, { orgGuid })
+          .then(done, done.fail);
+      });
+
+      it('includes query parameter for organization_guid', function () {
+        expect(http.get)
+          .toHaveBeenCalledWith(
+            sinon.match.string,
+            sinon.match({ params: { q: `organization_guid:${orgGuid}` } })
+          );
+      });
+    });
+  });
 });

--- a/static_src/test/unit/util/uaa_api.spec.js
+++ b/static_src/test/unit/util/uaa_api.spec.js
@@ -19,18 +19,6 @@ function createPromise(res, err) {
 
 describe('uaaApi', function() {
   let sandbox;
-  const errorFetchRes = { message: 'error' };
-
-  function fetchErrorSetup() {
-    var stub = sandbox.stub(http, 'get'),
-        spy = sandbox.spy(errorActions, 'errorFetch'),
-        expected = errorFetchRes;
-
-    let testPromise = createPromise(true, expected);
-    stub.returns(testPromise);
-
-    return spy;
-  };
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
@@ -40,32 +28,16 @@ describe('uaaApi', function() {
     sandbox.restore();
   });
 
-  describe('fetchUserInfo()', function() {
-    it('should call an http get request for uaa user info', function(done) {
-      var spy = sandbox.spy(http, 'get');
+  describe('fetchUserInfo()', function () {
+    beforeEach(function (done) {
+      sandbox.stub(http, 'get').returns(Promise.resolve({ data: { user_id: 'user123' } }));
 
-      uaaApi.fetchUserInfo().then(() => {
-        expect(spy).toHaveBeenCalledOnce();
-        let actual = spy.getCall(0).args[0];
-        expect(actual).toMatch('userinfo');
-        done();
-      });
+      uaaApi.fetchUserInfo().then(done, done.fail);
     });
 
-    it('should call a user action current user info received on success',
-        function(done) {
-      const expected = { user_id: 'zcxcvbxcvb', user_name: 'brain' };
-      let stub = sandbox.stub(http, 'get');
-      let spy = sandbox.spy(userActions, 'receivedCurrentUserInfo');
-
-      let testPromise = createPromise({data: expected});
-      stub.returns(testPromise);
-
-      uaaApi.fetchUserInfo().then(() => {
-        expect(spy).toHaveBeenCalledOnce();
-        expect(spy).toHaveBeenCalledWith(expected);
-        done();
-      });
+    it('should call an http get request for uaa user info', function () {
+      expect(http.get).toHaveBeenCalledOnce();
+      expect(http.get).toHaveBeenCalledWith(sinon.match(/\/userinfo$/));
     });
   });
 });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -513,7 +513,6 @@ export default {
   },
 
   fetchUser(userGuid) {
-    return http.get(`${APIV}/users/${userGuid}`)
-      .then(res => res.data);
+    return this.fetchOne(`/users/${userGuid}`);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -514,5 +514,14 @@ export default {
 
   fetchUser(userGuid) {
     return this.fetchOne(`/users/${userGuid}`);
+  },
+
+  fetchUserSpaces(userGuid, options = {}) {
+    const data = {};
+    if (options.orgGuid) {
+      data.q = `organization_guid:${options.orgGuid}`;
+    }
+
+    return this.fetchAllPages(`/users/${userGuid}/spaces`, data, results => results);
   }
 };

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -3,7 +3,6 @@ import http from 'axios';
 import { noticeError } from '../util/analytics.js';
 import domainActions from '../actions/domain_actions.js';
 import errorActions from '../actions/error_actions.js';
-import loginActions from '../actions/login_actions.js';
 import quotaActions from '../actions/quota_actions.js';
 import routeActions from '../actions/route_actions.js';
 import userActions from '../actions/user_actions.js';
@@ -132,11 +131,12 @@ export default {
   },
 
   getAuthStatus() {
-    return http.get(`${APIV}/authstatus`).then((res) => {
-      loginActions.receivedStatus(res.data.status);
-    }).catch(() => {
-      loginActions.receivedStatus(false);
-    });
+    return http.get(`${APIV}/authstatus`)
+      .then(res => res.data.status)
+      // Note: the getAuthStatus call will return 401 when not logged in, so
+      // failure here means the user was likely not logged in. Although there
+      // could be the additional problem that there was a problem with the req.
+      .catch(() => false);
   },
 
   fetchOrgLinks(guid) {
@@ -510,5 +510,10 @@ export default {
         handleError(err);
         return Promise.reject(err);
       });
+  },
+
+  fetchUser(userGuid) {
+    return http.get(`${APIV}/users/${userGuid}`)
+      .then(res => res.data);
   }
 };

--- a/static_src/util/uaa_api.js
+++ b/static_src/util/uaa_api.js
@@ -1,16 +1,11 @@
 
 import http from 'axios';
-import errorActions from '../actions/error_actions.js';
-import userActions from '../actions/user_actions.js';
 
 const URL = '/uaa';
 
 export default {
   fetchUserInfo() {
-    return http.get(`${URL}/userinfo`).then((res) => {
-      userActions.receivedCurrentUserInfo(res.data);
-    }).catch((err) => {
-      errorActions.errorFetch(err);
-    });
+    return http.get(`${URL}/userinfo`)
+      .then(res => res.data);
   }
 };


### PR DESCRIPTION
When the user is not a SpaceDeveloper, we don't want to prompt them to create an app if they don't have permission to. Instead, we show them tips about assigning roles and how permissions work.