### PR TITLE
Fix proxy returning invalid JSON when values contain '%'

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -40,5 +40,5 @@ func (c *APIContext) UserProfile(rw web.ResponseWriter, req *web.Request) {
 // AuthStatus simply returns authorized. This endpoint is just a quick endpoint to indicate that if a
 // user can reach here after passing through the OAuth Middleware, they are authorized.
 func (c *APIContext) AuthStatus(rw web.ResponseWriter, req *web.Request) {
-	fmt.Fprintf(rw, "{\"status\": \"authorized\"}")
+	rw.Write([]byte("{\"status\": \"authorized\"}"))
 }

--- a/controllers/log.go
+++ b/controllers/log.go
@@ -28,13 +28,13 @@ func (c *LogContext) RecentLogs(rw web.ResponseWriter, req *web.Request) {
 
 // logMessageResponseHandler is a response handler that constructs log messages structs from the response
 // given by the loggregator.
-func (c *LogContext) logMessageResponseHandler(rw *http.ResponseWriter, response *http.Response) {
+func (c *LogContext) logMessageResponseHandler(rw http.ResponseWriter, response *http.Response) {
 	messages, err := c.ParseLogMessages(&(response.Body), response.Header.Get("Content-Type"))
 	if err != nil {
-		fmt.Fprintf(*rw, err.Error())
+		rw.Write([]byte(err.Error()))
 		return
 	}
-	fmt.Fprintf(*rw, messages.String())
+	rw.Write([]byte(messages.String()))
 	return
 
 }

--- a/controllers/root.go
+++ b/controllers/root.go
@@ -27,7 +27,7 @@ func (c *Context) Index(w web.ResponseWriter, r *web.Request) {
 // Ping is just a test endpoint to show that indeed the service is alive.
 // TODO. Remove.
 func (c *Context) Ping(rw web.ResponseWriter, req *web.Request) {
-	fmt.Fprintf(rw, "{\"status\": \"alive\", \"build-info\": \""+c.Settings.BuildInfo+"\"}")
+	rw.Write([]byte("{\"status\": \"alive\", \"build-info\": \"" + c.Settings.BuildInfo + "\"}"))
 }
 
 // LoginHandshake is the handler where we authenticate the user and the user authorizes this application access to information.

--- a/controllers/secure.go
+++ b/controllers/secure.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"fmt"
 	"github.com/18F/cg-dashboard/helpers"
 	"github.com/gocraft/web"
 	"golang.org/x/oauth2"
@@ -18,7 +17,7 @@ type SecureContext struct {
 }
 
 // ResponseHandler is a type declaration for the function that will handle the response for the given request.
-type ResponseHandler func(*http.ResponseWriter, *http.Response)
+type ResponseHandler func(http.ResponseWriter, *http.Response)
 
 // OAuth is a middle ware that checks whether or not the user has a valid token.
 // If the token is present and still valid, it just passes it on.
@@ -70,25 +69,25 @@ func (c *SecureContext) submitRequest(rw http.ResponseWriter, req *http.Request,
 	if err != nil {
 		log.Println(err)
 		rw.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(rw, "unknown error. try again")
+		rw.Write([]byte("unknown error. try again"))
 		return
 	}
 	// Should return the same status.
 	rw.WriteHeader(res.StatusCode)
-	responseHandler(&rw, res)
+	responseHandler(rw, res)
 }
 
 // GenericResponseHandler is a normal handler for responses received from the proxy requests.
-func (c *SecureContext) GenericResponseHandler(rw *http.ResponseWriter, response *http.Response) {
+func (c *SecureContext) GenericResponseHandler(rw http.ResponseWriter, response *http.Response) {
 	// Read the body.
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Println(err)
-		(*rw).WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(*rw, "unknown error. try again")
+		rw.WriteHeader(http.StatusInternalServerError)
+		rw.Write([]byte("unknown error. try again"))
 		return
 	}
 
 	// Write the body into response that is going back to the frontend.
-	fmt.Fprintf(*rw, string(body))
+        rw.Write(body)
 }

--- a/controllers/secure_test.go
+++ b/controllers/secure_test.go
@@ -66,7 +66,7 @@ func TestOAuth(t *testing.T) {
 		apiRouter := secureRouter.Subrouter(controllers.APIContext{}, "/v2")
 		apiRouter.Middleware((*controllers.APIContext).OAuth)
 		apiRouter.Get("/test", func(c *controllers.APIContext, rw web.ResponseWriter, r *web.Request) {
-			fmt.Fprintf(rw, "test")
+			rw.Write([]byte("test"))
 		})
 
 		// Make the request and check.

--- a/controllers/secure_test.go
+++ b/controllers/secure_test.go
@@ -101,6 +101,23 @@ var proxyTests = []BasicProxyTest{
 		Response:      "test",
 		ResponseCode:  http.StatusOK,
 	},
+	{
+		BasicSecureTest: BasicSecureTest{
+			BasicConsoleUnitTest: BasicConsoleUnitTest{
+				TestName:    "Proxy response containing format string",
+				SessionData: ValidTokenData,
+				EnvVars:     MockCompleteEnvVars,
+			},
+			ExpectedResponse: "hello%world",
+			ExpectedCode:     http.StatusOK,
+		},
+		// What the "external" server will send back to the proxy.
+		RequestMethod: "GET",
+		RequestPath:   "/test",
+		ExpectedPath:  "/test",
+		Response:      "hello%world",
+		ResponseCode:  http.StatusOK,
+	},
 }
 
 func TestProxy(t *testing.T) {


### PR DESCRIPTION
https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-3903

We're using `fmt.Fprintf` to write data from the API to our response. This will take format strings (`"%s"`) and attempt to replace them with values from an empty dictionary resulting in the original strings ending up like `"%!s"(MISSING)` and breaking JSON. This data is not meant to be string formatted, and should be written directly to the response as binary data (since it isn't necessarily even string data).

We've also switched to using `io.Copy` for a more efficient writing of response data.

Thanks @jcscottiii for pairing with me on this.