### PR TITLE
Cache static assets

### DIFF
--- a/controllers/root.go
+++ b/controllers/root.go
@@ -17,7 +17,7 @@ type Context struct {
 	templates *template.Template
 }
 
-// Provides caching middleware for static assets.
+// StaticMiddleware provides simple caching middleware for static assets.
 func StaticMiddleware(path string) func(web.ResponseWriter, *web.Request, web.NextMiddlewareFunc) {
 	staticMiddleware := web.StaticMiddleware(path)
 	return func(rw web.ResponseWriter, r *web.Request, next web.NextMiddlewareFunc) {

--- a/controllers/root.go
+++ b/controllers/root.go
@@ -17,6 +17,18 @@ type Context struct {
 	templates *template.Template
 }
 
+// Provides caching middleware for static assets.
+func StaticMiddleware(path string) func(web.ResponseWriter, *web.Request, web.NextMiddlewareFunc) {
+	staticMiddleware := web.StaticMiddleware(path)
+	return func(rw web.ResponseWriter, r *web.Request, next web.NextMiddlewareFunc) {
+		// We want clients to cache these assets but it's important that they are
+		// up to date. If the javascript bundle does not match the server API,
+		// undefined behavior could happen.
+		rw.Header().Set("Cache-Control", "public, must-revalidate")
+		staticMiddleware(rw, r, next)
+	}
+}
+
 // Index serves index.html
 func (c *Context) Index(w web.ResponseWriter, r *web.Request) {
 	c.templates.ExecuteTemplate(w, "index.html", map[string]interface{}{

--- a/controllers/routes.go
+++ b/controllers/routes.go
@@ -63,7 +63,7 @@ func InitRouter(settings *helpers.Settings, templates *template.Template) *web.R
 
 	// Frontend Route Initialization
 	// Set up static file serving to load from the static folder.
-	router.Middleware(web.StaticMiddleware("static"))
+	router.Middleware(StaticMiddleware("static"))
 
 	return router
 }

--- a/controllers/secure.go
+++ b/controllers/secure.go
@@ -45,10 +45,7 @@ func (c *SecureContext) LoginRequired(rw web.ResponseWriter, r *web.Request, nex
 	}
 
 	// Don't cache anything
-	// right now, there's a problem where when you initially logout and then
-	// revisit the server, you will get a bad view due to a caching issue.
-	// for now, we clear the cache for everything.
-	// TODO: revist and cache static assets.
+	// TODO: Come up with a better caching strategy. We should be able to to cache most API responses.
 	rw.Header().Set("cache-control", "no-cache, no-store, must-revalidate, private")
 	rw.Header().Set("pragma", "no-cache")
 	rw.Header().Set("expires", "-1")


### PR DESCRIPTION
Allow static assets to be cached by the browser, but ensure the browser
revalidates to make sure it has the latest javascript.

This should result in the browser requesting the asset with an `if-modified-`
header. The server will respond with 304 if the asset is still valid, or send
the asset if it's not.

It's important that the javascript is up to date. Otherwise it could mismatch
the server code and cause undefined behavior.