### PR TITLE
Allow BaseElement to accept selector or WebElement

### DIFF
--- a/static_src/test/functional/pageobjects/base.element.js
+++ b/static_src/test/functional/pageobjects/base.element.js
@@ -10,9 +10,18 @@
  * to deal with a single component.
  **/
 
+import assert from 'assert';
+
 export default class BaseElement {
-  constructor(browser, webElement) {
+  constructor(browser, webElementOrSelector) {
     this.browser = browser;
+
+    let webElement = webElementOrSelector;
+    if (typeof webElementOrSelector === 'string') {
+      webElement = browser.element(webElementOrSelector);
+    }
+
+    assert(webElement.value, `Element '${webElement.selector}' does not exist in the DOM.`);
     this.webElementId = webElement.value.ELEMENT;
   }
 


### PR DESCRIPTION
Sometimes selectors are hard to write (because webdriver does not support all
selectors), so you want to traverse to the target element using WebElements.

Selectors are convenient, so accept both and give a helpful error message.