### PR TITLE
Bump go to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Learn more about [cloud.gov](https://cloud.gov).
 ## Tech Stack
 
 ### Backend Server [![Go Code Coverage Status](https://coveralls.io/repos/18F/cg-dashboard/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/cg-dashboard?branch=master)
-- `Go` (version 1.6.2)
+- `Go` (version 1.8)
 
 ### Front end application
 - `Node` (version 6.x.x)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    GODIST: "go1.6.linux-amd64.tar.gz"
+    GODIST: "go1.8.linux-amd64.tar.gz"
     WS: "/home/ubuntu/.go_workspace/src/github.com/18F/cg-dashboard"
     CF_API: "https://api.cloud.gov"
     CF_ORGANIZATION: "cf"

--- a/manifests/manifest-base.yml
+++ b/manifests/manifest-base.yml
@@ -6,7 +6,7 @@ services:
 - dashboard-redis
 env:
   GA_TRACKING_ID: UA-48605964-34
-  GOVERSION: go1.6.3
+  GOVERSION: go1.8
   GOPACKAGENAME: github.com/18F/cg-dashboard
   GO15VENDOREXPERIMENT: 1
   SESSION_BACKEND: redis

--- a/static_src/test/server/fixtures/space_summaries.js
+++ b/static_src/test/server/fixtures/space_summaries.js
@@ -518,8 +518,7 @@ const spaceSummaries = [
           CONSOLE_LOG_URL: "https://loggregator.cloud.gov/",
           CONSOLE_UAA_URL: "https://uaa.cloud.gov/",
           GO15VENDOREXPERIMENT: 1,
-          GOPACKAGENAME: "github.com/18F/cg-dashboard",
-          GOVERSION: "go1.6.3"
+          GOPACKAGENAME: "github.com/18F/cg-dashboard"
         },
         memory: 256,
         instances: 1,
@@ -657,8 +656,7 @@ const spaceSummaries = [
           CONSOLE_LOG_URL: "https://loggregator.cloud.gov/",
           CONSOLE_UAA_URL: "https://uaa.cloud.gov/",
           GO15VENDOREXPERIMENT: 1,
-          GOPACKAGENAME: "github.com/18F/cg-dashboard",
-          GOVERSION: "go1.6.3"
+          GOPACKAGENAME: "github.com/18F/cg-dashboard"
         },
         memory: 256,
         instances: 1,
@@ -722,8 +720,7 @@ const spaceSummaries = [
           CONSOLE_LOG_URL: "https://loggregator.cloud.gov/",
           CONSOLE_UAA_URL: "https://uaa.cloud.gov/",
           GO15VENDOREXPERIMENT: 1,
-          GOPACKAGENAME: "github.com/18F/cg-dashboard",
-          GOVERSION: "go1.6.3"
+          GOPACKAGENAME: "github.com/18F/cg-dashboard"
         },
         memory: 256,
         instances: 1,


### PR DESCRIPTION
Go 1.6 is no longer supported. 1.8.1 was just released but the buildpack doesn't support it as of this moment.