### PR TITLE
Fix spaces page on testing-server

### DIFF
--- a/static_src/test/server/fixtures/user_organizations.js
+++ b/static_src/test/server/fixtures/user_organizations.js
@@ -51,3 +51,5 @@ const userOrganizations = [
     }
   }
 ];
+
+module.exports = userOrganizations;


### PR DESCRIPTION
Space page shows loading indicator indefinitely because it is waiting for the
current user to load. The current user never loads because the user orgs request
fails because the testing server wasn't export the fixture correctly.

cc @jcscottiii @rememberlenny 