### PR TITLE
Ensure service instances always show up

### DIFF
--- a/static_src/actions/error_actions.js
+++ b/static_src/actions/error_actions.js
@@ -57,6 +57,8 @@ export default {
       msg,
       err
     });
+
+    return Promise.resolve(err);
   },
 
   clearErrors() {


### PR DESCRIPTION
Even after the service plans API request fails. This ensures that
the UI will load when it doesnt' strictly require the service plans.

I decided to expand out the nested promise and call the received
action there rather then in the outer scope, which ends up in the
catch statement. Now the service instances are received no matter
what happens with the plan requests.

Ref https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-4485