### PR TITLE
Remove misleading `if`

### DIFF
--- a/static_src/components/form/form.jsx
+++ b/static_src/components/form/form.jsx
@@ -53,15 +53,14 @@ export default class Form extends React.Component {
     }
 
     e.preventDefault();
+    // Only show error message after form was submitted
     const model = this.state.model;
     const errors = Object.keys(model && model.fields || {})
       .map(fieldName => model.fields[fieldName].error)
       .filter(error => !!error);
 
-    if (errors) {
-      // Only show error message after form was submitted
-      this.setState({ errors });
-    }
+    // Update errors state (clear/set)
+    this.setState({ errors });
 
     this.props.onSubmit(errors, this.state.model.fields);
   }


### PR DESCRIPTION
`errors` is always an array. We want to update the state regardless of the
change in case form errors were fixed or new ones appeared.

This doesn't change the logic, even an empty array is truthy, so it just removes
the unnecessary `if`.

Thanks @cmc333333 for catching this.