### PR TITLE
Remove dedent from functional tests for urls

### DIFF
--- a/static_src/test/functional/global_error.spec.js
+++ b/static_src/test/functional/global_error.spec.js
@@ -1,18 +1,16 @@
 
-import dedent from 'dedent';
-
 import BreadcrumbsElement from './pageobjects/breadcrumbs.element';
 import GlobalErrorsElement from './pageobjects/global_errors.element';
 
-const crashedAppUrl = dedent`/#
-  /org/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250
-  /spaces/82af0edb-8540-4064-82f2-d74df612b794
-  /apps/7fa78964-4d44-4a2a-8d26-7468b7cbf67d`;
+const crashedAppUrl = '/#' +
+  '/org/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250' +
+  '/spaces/82af0edb-8540-4064-82f2-d74df612b794' +
+  '/apps/7fa78964-4d44-4a2a-8d26-7468b7cbf67d';
 
-const brokenDataAppUrl = dedent`/#
-  /org/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250/
-  spaces/82af0edb-8540-4064-82f2-d74df612b794/
-  apps/3c37ff32-d954-4f9f-b730-15e22442fd82`;
+const brokenDataAppUrl = '/#' +
+  '/org/48b3f8a1-ffe7-4aa8-8e85-94768d6bd250' +
+  '/spaces/82af0edb-8540-4064-82f2-d74df612b794' +
+  '/apps/3c37ff32-d954-4f9f-b730-15e22442fd82';
 
 function getErrorsComponent() {
   return new GlobalErrorsElement(


### PR DESCRIPTION
Up until webdriverio 4.8.0, the use of dedent to construct urls did not
matter. However with this commit
https://github.com/webdriverio/webdriverio/commit/877e276fe4b5f03600a1d1d2fbeb3563398753c2
which changes how url works, it now keeps the literal newline
characters and will try to encode them into the url causing the url to
look like `/#%0A/org/orgguid`.

This problem only came up recently because 4.8.0 just came out and
according to our package.json we have `"webdriverio": "^4.6.1"`. This
means that upgrading to 4.8.0 on the next build was completely
acceptable.

Example of what happens without the PR now with webdriverio4.8.0
![image](https://cloud.githubusercontent.com/assets/7788930/25706415/6382b218-30ae-11e7-8848-f2a39b694310.png)
