### PR TITLE
Add Detailed Ping about components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Then edit the file `~/.env/cg-dashboard` and provide the proper values. When you
 
 #### Codecheck
 
+You need to have Docker installed and active within your environment as the
+unit tests use Docker for short term real instances.
+
 To run the go tests:
 
     $ ./codecheck.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  services:
+    - docker
   environment:
     GODIST: "go1.8.linux-amd64.tar.gz"
     WS: "/home/ubuntu/.go_workspace/src/github.com/18F/cg-dashboard"

--- a/controllers/root.go
+++ b/controllers/root.go
@@ -53,7 +53,13 @@ type sessionStoreHealth struct {
 }
 
 func createPingData(c *Context) []byte {
-	p := pingData{Status: "alive",
+	storeUp := c.Settings.SessionBackendHealthCheck()
+	overallStatus := "alive"
+	// if the session storage is out, we have an outage.
+	if !storeUp {
+		overallStatus = "outage"
+	}
+	p := pingData{Status: overallStatus,
 		BuildInfo: c.Settings.BuildInfo,
 		SessionStoreHealth: sessionStoreHealth{
 			StoreType: c.Settings.SessionBackend,

--- a/controllers/root.go
+++ b/controllers/root.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -40,10 +41,39 @@ func (c *Context) Index(w web.ResponseWriter, r *web.Request) {
 	})
 }
 
+type pingData struct {
+	Status             string             `json:"status"`
+	BuildInfo          string             `json:"build-info"`
+	SessionStoreHealth sessionStoreHealth `json:"session-store-health"`
+}
+
+type sessionStoreHealth struct {
+	StoreType string `json:"store-type"`
+	StoreUp   bool   `json:"store-up"`
+}
+
+func createPingData(c *Context) []byte {
+	p := pingData{Status: "alive",
+		BuildInfo: c.Settings.BuildInfo,
+		SessionStoreHealth: sessionStoreHealth{
+			StoreType: c.Settings.SessionBackend,
+			StoreUp:   c.Settings.SessionBackendHealthCheck(),
+		},
+	}
+	pingBody, err := json.Marshal(p)
+	// Would only ever come up when adding new fields to pingData and it
+	// wasn't tested properly. This will only happen when trying to marshal things
+	// that don't result in proper JSON.
+	if err != nil {
+		return []byte("\"status\": \"error\": \"data\": \"" + err.Error() + "\"")
+	}
+	return pingBody
+}
+
 // Ping is just a test endpoint to show that indeed the service is alive.
 // TODO. Remove.
 func (c *Context) Ping(rw web.ResponseWriter, req *web.Request) {
-	rw.Write([]byte("{\"status\": \"alive\", \"build-info\": \"" + c.Settings.BuildInfo + "\"}"))
+	rw.Write(createPingData(c))
 }
 
 // LoginHandshake is the handler where we authenticate the user and the user authorizes this application access to information.

--- a/controllers/root_test.go
+++ b/controllers/root_test.go
@@ -1,6 +1,7 @@
 package controllers_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -15,8 +16,35 @@ func TestPing(t *testing.T) {
 	env, _ := cfenv.Current()
 	router, _, _ := controllers.InitApp(GetMockCompleteEnvVars(), env)
 	router.ServeHTTP(response, request)
-	if response.Body.String() != "{\"status\": \"alive\", \"build-info\": \"developer-build\"}" {
-		t.Errorf("Expected alive. Found %s\n", response.Body.String())
+	expectedResponse := `{"status":"alive","build-info":"developer-build","session-store-health":{"store-type":"file","store-up":true}}`
+	if response.Body.String() != expectedResponse {
+		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
+	}
+}
+
+func TestPingWithRedis(t *testing.T) {
+	// Create a request
+	response, request := NewTestRequest("GET", "/ping", nil)
+	// Start up redis.
+	redisUri, cleanUpRedis := CreateTestRedis()
+	os.Setenv("REDIS_URI", redisUri)
+	envVars := GetMockCompleteEnvVars()
+	envVars.SessionBackend = "redis"
+	env, _ := cfenv.Current()
+	router, _, _ := controllers.InitApp(envVars, env)
+	router.ServeHTTP(response, request)
+	expectedResponse := `{"status":"alive","build-info":"developer-build","session-store-health":{"store-type":"redis","store-up":true}}`
+	if response.Body.String() != expectedResponse {
+		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
+	}
+	// Remove redis.
+	cleanUpRedis()
+	// Try ping again.
+	response, request = NewTestRequest("GET", "/ping", nil)
+	router.ServeHTTP(response, request)
+	expectedResponse = `{"status":"alive","build-info":"developer-build","session-store-health":{"store-type":"redis","store-up":false}}`
+	if response.Body.String() != expectedResponse {
+		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
 	}
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,14 @@
-hash: 21b3b7794093d7bc40e681fabff2fd9bf9bb8f7ee8eb933070dfc4431e5562a0
-updated: 2016-12-31T12:15:06.088081013-05:00
+hash: 55d43c5a5553f2686740429b087b586d17dbbbf4f7a2d475e62ae8a7e5d61c59
+updated: 2017-05-09T10:27:06.112832183-04:00
 imports:
+- name: github.com/Azure/go-ansiterm
+  version: fa152c58bc15761d0200cb75fe958b89a9d4888e
+  subpackages:
+  - winterm
 - name: github.com/boj/redistore
   version: fc113767cd6b051980f260d6dbe84b2740c46ab0
+- name: github.com/cenk/backoff
+  version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc
 - name: github.com/cloudfoundry-community/go-cfenv
   version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
 - name: github.com/cloudfoundry/loggregatorlib
@@ -10,6 +16,42 @@ imports:
   subpackages:
   - logmessage
   - signature
+- name: github.com/docker/docker
+  version: 4845c567eb35d68f35b0b1713a09b0c8d47fe67e
+  subpackages:
+  - api/types
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/filters
+  - api/types/mount
+  - api/types/network
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/versions
+  - opts
+  - pkg/archive
+  - pkg/fileutils
+  - pkg/homedir
+  - pkg/idtools
+  - pkg/ioutils
+  - pkg/jsonlog
+  - pkg/jsonmessage
+  - pkg/longpath
+  - pkg/pools
+  - pkg/promise
+  - pkg/stdcopy
+  - pkg/system
+  - pkg/term
+  - pkg/term/windows
+- name: github.com/docker/go-connections
+  version: e15c02316c12de00874640cd76311849de2aeed5
+  subpackages:
+  - nat
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/fsouza/go-dockerclient
+  version: 30d142bbfdec74e09ecb4bdb89a44440ae4662ac
 - name: github.com/garyburd/redigo
   version: 827b38687c49d680c6bd9ac6114111b98cc16cdf
   subpackages:
@@ -33,10 +75,25 @@ imports:
   version: 667fe4e3466a040b780561fe9b51a83a3753eefc
 - name: github.com/gorilla/sessions
   version: ca9ada44574153444b00d3fd9c8559e4cc95f896
+- name: github.com/hashicorp/go-cleanhttp
+  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+- name: github.com/Microsoft/go-winio
+  version: d311c76e775b5092c023569caacdbb4e569c3243
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
+- name: github.com/Nvveen/Gotty
+  version: cd527374f1e5bff4938207604a14f2e38a9cf512
+- name: github.com/opencontainers/runc
+  version: 2daa11574b12d2dd7f6dad3ffaa302871f21bd12
+  subpackages:
+  - libcontainer/system
+  - libcontainer/user
+- name: github.com/ory/dockertest
+  version: 9d0647ae761f96a6738c5afb49688d22979b21ff
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+- name: github.com/Sirupsen/logrus
+  version: 5b60b3d3ee017ed00bcd0225fcca7acab767844b
 - name: github.com/yvasiyarov/go-metrics
   version: c25f46c4b94079672242ec48a545e7ca9ebe3aec
 - name: github.com/yvasiyarov/gorelic
@@ -47,6 +104,7 @@ imports:
   version: 96dbb961a39ddccf16860cdd355bfa639c497f23
   subpackages:
   - context
+  - context/ctxhttp
 - name: golang.org/x/oauth2
   version: e86e2718db89775a4604abc10a5d3a5672e7336e
   subpackages:
@@ -56,6 +114,7 @@ imports:
   version: a408501be4d17ee978c04a618e7a1b22af058c0e
   subpackages:
   - unix
+  - windows
 - name: google.golang.org/appengine
   version: e234e71924d4aa52444bc76f2f831f13fa1eca60
   subpackages:
@@ -66,6 +125,4 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,5 @@ import:
   version: ~1.4.0
 - package: github.com/boj/redistore
   version: ~1.2.0
+- package: github.com/ory/dockertest
+  version: v3.0.7

--- a/helpers/settings.go
+++ b/helpers/settings.go
@@ -9,10 +9,16 @@ import (
 
 	"github.com/boj/redistore"
 	"github.com/cloudfoundry-community/go-cfenv"
+	"github.com/garyburd/redigo/redis"
 	"github.com/gorilla/sessions"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	// 7 days at most.
+	expirationConstant = 60 * 60 * 24 * 7
 )
 
 // Settings is the object to hold global values and objects for the service.
@@ -43,6 +49,10 @@ type Settings struct {
 	SecureCookies bool
 	// URL where this app is hosted
 	AppURL string
+	// Type of session backend
+	SessionBackend string
+	// Returns whether the backend is up.
+	SessionBackendHealthCheck func() bool
 }
 
 // InitSettings attempts to populate all the fields of the Settings struct. It will return an error if it fails,
@@ -115,11 +125,26 @@ func (s *Settings) InitSettings(envVars EnvVars, env *cfenv.App) error {
 		store.SetMaxLength(4096 * 4)
 		store.Options = &sessions.Options{
 			HttpOnly: true,
-			MaxAge:   60 * 60 * 24 * 7,
+			MaxAge:   expirationConstant,
 			Path:     "/",
 			Secure:   s.SecureCookies,
 		}
 		s.Sessions = store
+		s.SessionBackend = envVars.SessionBackend
+		s.SessionBackendHealthCheck = func() bool {
+			c, err := redis.Dial("tcp", address)
+			if err != nil {
+				return false
+			}
+			defer c.Close()
+			if password != "" {
+				if _, err := c.Do("AUTH", password); err != nil {
+					c.Close()
+					return false
+				}
+			}
+			return true
+		}
 	default:
 		store := sessions.NewFilesystemStore("", []byte(envVars.SessionKey))
 		store.MaxLength(4096 * 4)
@@ -127,11 +152,13 @@ func (s *Settings) InitSettings(envVars EnvVars, env *cfenv.App) error {
 			HttpOnly: true,
 			// TODO remove this; work-around for
 			// https://github.com/gorilla/sessions/issues/96
-			MaxAge: 60 * 60 * 24 * 7,
+			MaxAge: expirationConstant,
 			Path:   "/",
 			Secure: s.SecureCookies,
 		}
 		s.Sessions = store
+		s.SessionBackend = "file"
+		s.SessionBackendHealthCheck = func() bool { return true }
 	}
 
 	// Want to save a struct into the session. Have to register it.


### PR DESCRIPTION
In order to make sure we have detailed info about uptime of dependent components, we want to report that via the /ping endpoint