### PR TITLE
Use 500 code in case /ping has bad news

### DIFF
--- a/controllers/root_test.go
+++ b/controllers/root_test.go
@@ -20,6 +20,9 @@ func TestPing(t *testing.T) {
 	if response.Body.String() != expectedResponse {
 		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
 	}
+	if response.Code != 200 {
+		t.Errorf("Expected code %d. Found %d", 200, response.Code)
+	}
 }
 
 func TestPingWithRedis(t *testing.T) {
@@ -40,6 +43,9 @@ func TestPingWithRedis(t *testing.T) {
 	if response.Body.String() != expectedResponse {
 		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
 	}
+	if response.Code != 200 {
+		t.Errorf("Expected code %d. Found %d", 200, response.Code)
+	}
 	// Remove redis.
 	cleanUpRedis()
 
@@ -49,6 +55,9 @@ func TestPingWithRedis(t *testing.T) {
 	expectedResponse = `{"status":"outage","build-info":"developer-build","session-store-health":{"store-type":"redis","store-up":false}}`
 	if response.Body.String() != expectedResponse {
 		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
+	}
+	if response.Code != 500 {
+		t.Errorf("Expected code %d. Found %d", 500, response.Code)
 	}
 }
 


### PR DESCRIPTION
NewRelic costs to do detailed analysis of the ping response.
Instead, we can just return 500 in the case we detect something has
failed internally.

Also, added a log statement if there is an error to the logs so we can review logs later on to see what's happened.