### PR TITLE
update to use deployer accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,15 @@ uaac client add <your-client-id> \
 
 
 ### CI
-This project uses CircleCI
-- The following environment variables need to be set in plain text in the global env section:
-  - `CONSOLE_API_URL`, `CONSOLE_UAA_URL`, `CONSOLE_LOG_URL`, `CONSOLE_LOGIN_URL`, `CONSOLE_HOSTNAME="http://localhost:9999"`, `CONSOLE_TEST_ORG_NAME`, `CONSOLE_TEST_SPACE_NAME`, and `CONSOLE_TEST_APP_NAME`
+This project uses CircleCI.
+- You will need to setup the credentials to deploy to the `dashboard-prod` and `dashboard-stage` spaces.
+  - In both spaces run: `cf create-service cloud-gov-service-account space-deployer dashboard-deployer`
+  - You will get the link for that space's credentials by running `cf service dashboard-deployer`
+  - You will need to set these [**secret**](https://circleci.com/docs/1.0/environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git) variables in the [CircleCI UI](https://circleci.com/gh/18F/cg-dashboard/edit#env-vars).
+    - `CF_USERNAME_PROD_SPACE` - The username for the `dashboard-prod` deployer
+    - `CF_PASSWORD_PROD_SPACE` - The password for the `dashboard-prod` deployer
+    - `CF_USERNAME_STAGE_SPACE` - The username for the `dashboard-stage` deployer
+    - `CF_PASSWORD_STAGE_SPACE` - The password for the `dashboard-stage` deployer
 - In case you fork this project for your own use (no need to do this if forking to make a pull request), you will need to use the CircleCI CLI UI to set the variables
 
 

--- a/deploy/circle_deploy.sh
+++ b/deploy/circle_deploy.sh
@@ -23,6 +23,7 @@ cf install-plugin -f /home/ubuntu/.go_workspace/bin/autopilot
 # Only the organization, api, deployer account password differ.
 
 
+
 if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]
 then
 	CF_MANIFEST="manifest-prod.yml"
@@ -43,14 +44,30 @@ else
   exit 1
 fi
 
+# We use the deployer-account broker and setup.
+if [ "$CF_SPACE" == "dashboard-prod" ]
+then
+	CF_USERNAME=$CF_USERNAME_PROD_SPACE
+	CF_PASSWORD=$CF_PASSWORD_PROD_SPACE
+elif [ "$CF_SPACE" == "dashboard-stage" ]
+then
+	CF_USERNAME=$CF_USERNAME_STAGE_SPACE
+	CF_PASSWORD=$CF_PASSWORD_STAGE_SPACE
+else
+	echo "Unknown space. Do not know how to deploy $CF_SPACE."
+	exit 1
+fi
+
 echo env:      $manifest_env
 echo manifest: $CF_MANIFEST
 echo space:    $CF_SPACE
 
 if [ $manifest_env == govcloud ]; then
   CF_API=$CF_API_GC
-  CF_PASSWORD=$CF_PASSWORD_GC
   CF_ORGANIZATION=$CF_ORGANIZATION_GC
+else
+	echo "We only support deploying to govcloud, quitting." >&2
+	exit 1
 fi
 
 function deploy () {

--- a/deploy/circle_deploy.sh
+++ b/deploy/circle_deploy.sh
@@ -44,7 +44,10 @@ else
   exit 1
 fi
 
-# We use the deployer-account broker and setup.
+# We use the deployer-account broker to get the credentials of
+# our deployer accounts.
+# Currently, the deployer accounts are scoped to a single space.
+# As a result, we will filter by space for which credentials to use.
 if [ "$CF_SPACE" == "dashboard-prod" ]
 then
 	CF_USERNAME=$CF_USERNAME_PROD_SPACE


### PR DESCRIPTION
In order to easily update the credentials for the deployer, let's use our broker.

Also:
Prior to this, we had a dedicated user account `cgdeck-deployer` that did the deploys. Those creds may have been in TravisCI during the latest leak (even though it has been forever since we used Travis). But instead of trying to that account's password changed, we can just get the creds rotated whenever by using the deployer broker.

That `cgdeck-deployer` account has been deleted.

We also stop deploying to E/W