### PR TITLE
Add more env vars that can be loaded via UPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ In each space that you plan on deploying, you need to create a `user-provided-se
 Run:
 ```
 # For applications without New Relic monitoring
-cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret", "SESSION_KEY": "a-really-long-secure-value"}'
+cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret", "SESSION_KEY": "a-really-long-secure-value", "SMTP_HOST": "smtp.host.com", "SMTP_PORT": "25", "SMTP_USER": "username", "SMTP_PASS": "password", "SMTP_FROM": "from@address.com"}'
 
 # For applications with New Relic monitoring
-cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret","CONSOLE_NEW_RELIC_LICENSE":"your-new-relic-license", "SESSION_KEY": "a-really-long-secure-value"}'
+cf cups dashboard-ups -p '{"CONSOLE_CLIENT_ID":"your-client-id","CONSOLE_CLIENT_SECRET":"your-client-secret","CONSOLE_NEW_RELIC_LICENSE":"your-new-relic-license", "SESSION_KEY": "a-really-long-secure-value", "SMTP_HOST": "smtp.host.com", "SMTP_PORT": "25", "SMTP_USER": "username", "SMTP_PASS": "password", "SMTP_FROM": "from@address.com"}'
 ```
 
 Create a redis service instance:

--- a/server.go
+++ b/server.go
@@ -97,6 +97,26 @@ func loadUPSVars(envVars *helpers.EnvVars, cfEnv *cfenv.App) {
 			fmt.Println("Replacing " + helpers.SessionKeyEnvVar)
 			replaceEnvVar(envVars, helpers.SessionKeyEnvVar, sessionKey)
 		}
+		if smtpFrom, found := cfUPS.Credentials[helpers.SMTPFromEnvVar]; found {
+			fmt.Println("Replacing " + helpers.SMTPFromEnvVar)
+			replaceEnvVar(envVars, helpers.SMTPFromEnvVar, smtpFrom)
+		}
+		if smtpHost, found := cfUPS.Credentials[helpers.SMTPHostEnvVar]; found {
+			fmt.Println("Replacing " + helpers.SMTPHostEnvVar)
+			replaceEnvVar(envVars, helpers.SMTPHostEnvVar, smtpHost)
+		}
+		if smtpPass, found := cfUPS.Credentials[helpers.SMTPPassEnvVar]; found {
+			fmt.Println("Replacing " + helpers.SMTPPassEnvVar)
+			replaceEnvVar(envVars, helpers.SMTPPassEnvVar, smtpPass)
+		}
+		if smtpPort, found := cfUPS.Credentials[helpers.SMTPPortEnvVar]; found {
+			fmt.Println("Replacing " + helpers.SMTPPortEnvVar)
+			replaceEnvVar(envVars, helpers.SMTPPortEnvVar, smtpPort)
+		}
+		if smtpUser, found := cfUPS.Credentials[helpers.SMTPUserEnvVar]; found {
+			fmt.Println("Replacing " + helpers.SMTPUserEnvVar)
+			replaceEnvVar(envVars, helpers.SMTPUserEnvVar, smtpUser)
+		}
 
 	} else {
 		fmt.Println("CF Env error: " + err.Error())


### PR DESCRIPTION
Currently, there's no way to read sensitive SMTP creds via UPS. This PR fixes that.

Also, it's blocking successful deploys without this code.