### PR TITLE
Fix redis health check ping.

### DIFF
--- a/helpers/testhelpers/docker/docker.go
+++ b/helpers/testhelpers/docker/docker.go
@@ -12,7 +12,7 @@ import (
 
 // CreateTestRedis creates a actual redis instance with docker.
 // Useful for unit tests.
-func CreateTestRedis() (string, func()) {
+func CreateTestRedis() (string, func(), func(), func()) {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		log.Fatalf("Could not connect to docker: %s", err)
@@ -31,7 +31,10 @@ func CreateTestRedis() (string, func()) {
 	}); err != nil {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
-	return "redis://" + hostnameAndPort, func() { pool.Purge(resource) }
+	return "redis://" + hostnameAndPort,
+		func() { pool.Purge(resource) },
+		func() { pool.Client.PauseContainer(resource.Container.ID) },
+		func() { pool.Client.UnpauseContainer(resource.Container.ID) }
 }
 
 // CreateTestMailCatcher creates a actual redis instance with docker.


### PR DESCRIPTION
Previous to this PR, we witnessed a failed redis ping but after redis
recovered, the health check /ping never corrected itself.
Incident: https://alerts.newrelic.com/accounts/907948/incidents/6561272

Test Case added: To prove this out, I initially added a test case where
the redis instance came back online and expected the health check to
recover. However it did not.

This is because previously, the /ping endpoint the redis client instance
for the ping was using the 1) default config and was a single Go obj.

The single Go obj did not know how to reconnect after a failed
connection.
Fix: this was fixed by using the same redis pool as the session store.

The default config did not use any time outs so any requests to redis
would wait forever.
Fix: Added timeouts for the read, write and connection attempts.

Also, during the debug, went back through the logs to see what was the exact error. Added more debug statements upon failure to make it easier when reviewing logs. https://github.com/18F/cg-dashboard/pull/1109/files#diff-661525df772e761479305d75690a20adR192