### PR TITLE
Fix user management permission issues

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -88,7 +88,7 @@ const userActions = {
       entityType
     });
 
-    api(
+    return api(
       userGuid,
       entityGuid,
       roles

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -73,19 +73,19 @@ const userActions = {
     });
   },
 
-  addUserRoles(roles, userGuid, entityGuid, resourceType) {
+  addUserRoles(roles, userGuid, entityGuid, entityType) {
     const apiMethodMap = {
       org: cfApi.putOrgUserPermissions,
       space: cfApi.putSpaceUserPermissions
     };
-    const api = apiMethodMap[resourceType];
+    const api = apiMethodMap[entityType];
 
     AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLES_ADD,
       roles,
       userGuid,
       entityGuid,
-      resourceType
+      entityType
     });
 
     api(
@@ -97,38 +97,38 @@ const userActions = {
         roles,
         userGuid,
         entityGuid,
-        resourceType);
+        entityType);
     }).catch((err) => {
       window.console.error(err);
     });
   },
 
-  addedUserRoles(roles, userGuid, entityGuid, resourceType) {
+  addedUserRoles(roles, userGuid, entityGuid, entityType) {
     AppDispatcher.handleServerAction({
       type: userActionTypes.USER_ROLES_ADDED,
       roles,
       userGuid,
       entityGuid,
-      resourceType
+      entityType
     });
   },
 
-  deleteUserRoles(roles, userGuid, entityGuid, resourceType) {
+  deleteUserRoles(roles, userGuid, entityGuid, entityType) {
     AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLES_DELETE,
       roles,
       userGuid,
       entityGuid,
-      resourceType
+      entityType
     });
   },
 
-  deletedUserRoles(roles, userGuid, resourceType) {
+  deletedUserRoles(roles, userGuid, entityType) {
     AppDispatcher.handleServerAction({
       type: userActionTypes.USER_ROLES_DELETED,
       roles,
       userGuid,
-      resourceType
+      entityType
     });
   },
 

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -266,61 +266,6 @@ const userActions = {
     return Promise.resolve(user);
   },
 
-  fetchUserSpaces(userGuid, options = {}) {
-    if (!userGuid) {
-      return Promise.reject(new Error('userGuid is required'));
-    }
-
-    // orgGuid s optional for filtering
-    const { orgGuid } = options;
-    AppDispatcher.handleViewAction({
-      type: userActionTypes.USER_SPACES_FETCH,
-      userGuid,
-      orgGuid
-    });
-
-    return cfApi.fetchUserSpaces(userGuid, options)
-      .then(userSpaces => userActions.receivedUserSpaces(userGuid, userSpaces, options));
-  },
-
-  // Optionally specify orgGuid if filtered for spaces belonging to orgGuid
-  receivedUserSpaces(userGuid, userSpaces, options = {}) {
-    const { orgGuid } = options;
-    AppDispatcher.handleServerAction({
-      type: userActionTypes.USER_SPACES_RECEIVED,
-      userGuid,
-      userSpaces,
-      orgGuid
-    });
-
-    return Promise.resolve(userSpaces);
-  },
-
-  fetchUserOrgs(userGuid, options = {}) {
-    if (!userGuid) {
-      return Promise.reject(new Error('userGuid is required'));
-    }
-
-    AppDispatcher.handleViewAction({
-      type: userActionTypes.USER_ORGS_FETCH,
-      userGuid
-    });
-
-    return cfApi.fetchUserOrgs(userGuid, options)
-      .then(userOrgs => userActions.receivedUserOrgs(userGuid, userOrgs, options));
-  },
-
-  receivedUserOrgs(userGuid, userOrgs) {
-    AppDispatcher.handleServerAction({
-      type: userActionTypes.USER_ORGS_RECEIVED,
-      userGuid,
-      userOrgs
-    });
-
-    return Promise.resolve(userOrgs);
-  },
-
-  // Meta action to fetch all the pieces of the current user
   fetchCurrentUser(options = {}) {
     AppDispatcher.handleViewAction({
       type: userActionTypes.CURRENT_USER_FETCH
@@ -332,8 +277,6 @@ const userActions = {
       .then(userInfo =>
         Promise.all([
           userActions.fetchUser(userInfo.user_id),
-          userActions.fetchUserOrgs(userInfo.user_id),
-          userActions.fetchUserSpaces(userInfo.user_id, options),
           userActions.fetchCurrentUserUaaInfo(userInfo.user_id)
         ])
       )

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -74,21 +74,41 @@ const userActions = {
   },
 
   addUserRoles(roles, userGuid, resourceGuid, resourceType) {
-    AppDispatcher.handleViewAction({
+    const apiMethodMap = {
+      org: cfApi.putOrgUserPermissions,
+      space: cfApi.putSpaceUserPermissions
+    };
+    const api = apiMethodMap[resourceType];
 
+    AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLES_ADD,
       roles,
       userGuid,
       resourceGuid,
       resourceType
     });
+
+    api(
+      userGuid,
+      resourceGuid,
+      roles
+    ).then(() => {
+      userActions.addedUserRoles(
+        roles,
+        userGuid,
+        resourceGuid,
+        resourceType);
+    }).catch((err) => {
+      window.console.error(err);
+    });
   },
 
-  addedUserRoles(roles, userGuid, resourceType) {
+  addedUserRoles(roles, userGuid, resourceGuid, resourceType) {
     AppDispatcher.handleServerAction({
       type: userActionTypes.USER_ROLES_ADDED,
       roles,
       userGuid,
+      resourceGuid,
       resourceType
     });
   },

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -73,7 +73,7 @@ const userActions = {
     });
   },
 
-  addUserRoles(roles, userGuid, resourceGuid, resourceType) {
+  addUserRoles(roles, userGuid, entityGuid, resourceType) {
     const apiMethodMap = {
       org: cfApi.putOrgUserPermissions,
       space: cfApi.putSpaceUserPermissions
@@ -84,41 +84,41 @@ const userActions = {
       type: userActionTypes.USER_ROLES_ADD,
       roles,
       userGuid,
-      resourceGuid,
+      entityGuid,
       resourceType
     });
 
     api(
       userGuid,
-      resourceGuid,
+      entityGuid,
       roles
     ).then(() => {
       userActions.addedUserRoles(
         roles,
         userGuid,
-        resourceGuid,
+        entityGuid,
         resourceType);
     }).catch((err) => {
       window.console.error(err);
     });
   },
 
-  addedUserRoles(roles, userGuid, resourceGuid, resourceType) {
+  addedUserRoles(roles, userGuid, entityGuid, resourceType) {
     AppDispatcher.handleServerAction({
       type: userActionTypes.USER_ROLES_ADDED,
       roles,
       userGuid,
-      resourceGuid,
+      entityGuid,
       resourceType
     });
   },
 
-  deleteUserRoles(roles, userGuid, resourceGuid, resourceType) {
+  deleteUserRoles(roles, userGuid, entityGuid, resourceType) {
     AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLES_DELETE,
       roles,
       userGuid,
-      resourceGuid,
+      entityGuid,
       resourceType
     });
   },

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -266,7 +266,7 @@ const userActions = {
     return Promise.resolve(user);
   },
 
-  fetchCurrentUser(options = {}) {
+  fetchCurrentUser() {
     AppDispatcher.handleViewAction({
       type: userActionTypes.CURRENT_USER_FETCH
     });

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -143,11 +143,12 @@ const userActions = {
     });
   },
 
-  deletedUserRoles(roles, userGuid, entityType) {
+  deletedUserRoles(roles, userGuid, entityGuid, entityType) {
     AppDispatcher.handleServerAction({
       type: userActionTypes.USER_ROLES_DELETED,
       roles,
       userGuid,
+      entityGuid,
       entityType
     });
   },

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -114,12 +114,32 @@ const userActions = {
   },
 
   deleteUserRoles(roles, userGuid, entityGuid, entityType) {
+    const apiMethodMap = {
+      org: cfApi.deleteOrgUserPermissions,
+      space: cfApi.deleteSpaceUserPermissions
+    };
+    const api = apiMethodMap[entityType];
+
     AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLES_DELETE,
       roles,
       userGuid,
       entityGuid,
       entityType
+    });
+
+    return api(
+      userGuid,
+      entityGuid,
+      roles
+    ).then(() => {
+      userActions.deletedUserRoles(
+        roles,
+        userGuid,
+        entityGuid,
+        entityType);
+    }).catch((err) => {
+      window.console.error(err);
     });
   },
 

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -26,9 +26,9 @@ const userActions = {
     });
   },
 
-  fetchSpaceUsers(spaceGuid) {
+  fetchSpaceUserRoles(spaceGuid) {
     AppDispatcher.handleViewAction({
-      type: userActionTypes.SPACE_USERS_FETCH,
+      type: userActionTypes.SPACE_USER_ROLES_FETCH,
       spaceGuid
     });
   },
@@ -49,9 +49,9 @@ const userActions = {
     });
   },
 
-  receivedSpaceUsers(users, spaceGuid) {
+  receivedSpaceUserRoles(users, spaceGuid) {
     AppDispatcher.handleServerAction({
-      type: userActionTypes.SPACE_USERS_RECEIVED,
+      type: userActionTypes.SPACE_USER_ROLES_RECEIVED,
       users,
       spaceGuid
     });

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -19,27 +19,33 @@ import { config } from 'skin';
 import formatDateTime from '../util/format_date';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
-function stateSetter(props) {
-  return {
-    users: props.initialUsers,
-    userType: props.initialUserType,
-    currentUserAccess: props.initialCurrentUserAccess,
-    empty: props.initialEmpty,
-    loading: props.initialLoading
-  };
-}
+const propTypes = {
+  users: React.PropTypes.array,
+  userType: React.PropTypes.string,
+  entityGuid: React.PropTypes.string,
+  currentUserAccess: React.PropTypes.bool,
+  empty: React.PropTypes.bool,
+  loading: React.PropTypes.bool,
+  // Set to a function when there should be a remove button.
+  onRemove: React.PropTypes.func,
+  onRemovePermissions: React.PropTypes.func,
+  onAddPermissions: React.PropTypes.func
+};
+
+const defaultProps = {
+  users: [],
+  userType: 'space_users',
+  currentUserAccess: false,
+  empty: false,
+  loading: false
+};
 
 export default class UserList extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = stateSetter(props);
     this.styler = createStyler(style);
     this._handleDelete = this._handleDelete.bind(this);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.setState(stateSetter(nextProps));
   }
 
   _handleDelete(userGuid, ev) {
@@ -61,7 +67,7 @@ export default class UserList extends React.Component {
   }
 
   get userTypePretty() {
-    return (this.state.userType === 'org_users') ? 'Organization' : 'Space';
+    return (this.props.userType === 'org_users') ? 'Organization' : 'Space';
   }
 
   get documentation() {
@@ -95,7 +101,7 @@ export default class UserList extends React.Component {
     let content;
     const callout = `You are the only user in this ${this.userTypePretty.toLowerCase()}`;
 
-    if (this.state.userType === 'org_users') {
+    if (this.props.userType === 'org_users') {
       const readMore = config.docs.invite_user &&
         <a href={ config.docs.invite_user }>Read more about inviting new users.</a>
 
@@ -122,20 +128,20 @@ export default class UserList extends React.Component {
     let loading = <Loading text="Loading users" />;
     let content = <div>{ loading }</div>;
 
-    if (this.state.empty) {
+    if (this.props.empty) {
       content = this.emptyState;
-    } else if (this.state.users.length === 1) {
+    } else if (this.props.users.length === 1) {
       content = this.onlyOneState;
-    } else if (!this.state.loading && this.state.users.length) {
+    } else if (!this.props.loading && this.props.users.length) {
       content = (
       <div className="test-user_list">
         { this.documentation }
         <ComplexList>
-          { this.state.users.map((user) => {
+          { this.props.users.map((user) => {
             let actions;
             if (this.props.onRemove) {
               let button = <span></span>;
-              if (this.state.currentUserAccess) {
+              if (this.props.currentUserAccess) {
                 button = (
                   <Action
                     style="base"
@@ -156,10 +162,11 @@ export default class UserList extends React.Component {
                 <ElasticLineItem>{ user.username }</ElasticLineItem>
                 <ElasticLineItem key={ `${user.guid}-role` } align="end">
                   <UserRoleListControl
-                    initialUserType={ this.state.userType }
-                    initialCurrentUserAccess={ this.state.currentUserAccess }
+                    userType={ this.props.userType }
+                    currentUserAccess={ this.props.currentUserAccess }
                     onAddPermissions={ this.props.onAddPermissions }
                     onRemovePermissions={ this.props.onRemovePermissions }
+                    entityGuid={ this.props.entityGuid }
                     user={ user }
                   />
                 </ElasticLineItem>
@@ -178,25 +185,7 @@ export default class UserList extends React.Component {
     </div>
     );
   }
-
 }
 
-UserList.propTypes = {
-  initialUsers: React.PropTypes.array,
-  initialUserType: React.PropTypes.string,
-  initialCurrentUserAccess: React.PropTypes.bool,
-  initialEmpty: React.PropTypes.bool,
-  initialLoading: React.PropTypes.bool,
-  // Set to a function when there should be a remove button.
-  onRemove: React.PropTypes.func,
-  onRemovePermissions: React.PropTypes.func,
-  onAddPermissions: React.PropTypes.func
-};
-
-UserList.defaultProps = {
-  initialUsers: [],
-  initialUserType: 'space_users',
-  initialCurrentUserAccess: false,
-  initialEmpty: false,
-  initialLoading: false
-};
+UserList.propTypes = propTypes;
+UserList.defaultProps = defaultProps;

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -31,29 +31,32 @@ const roleToResource = {
   space_auditor: 'auditors'
 };
 
+const propTypes = {
+  user: React.PropTypes.object.isRequired,
+  userType: React.PropTypes.string,
+  currentUserAccess: React.PropTypes.bool,
+  entityGuid: React.PropTypes.string,
+  onRemovePermissions: React.PropTypes.func,
+  onAddPermissions: React.PropTypes.func,
+};
+
+const defaultProps = {
+  userType: 'space_users',
+  currentUserAccess: false,
+  onRemovePermissions: function defaultRemove() { },
+  onAddPermissions: function defaultAdd() { }
+};
+
 export default class UserRoleListControl extends React.Component {
   constructor(props) {
     super(props);
     this.props = props;
-    this.state = {
-      user: props.user,
-      userType: props.initialUserType,
-      currentUserAccess: props.initialCurrentUserAccess
-    };
     this._onChange = this._onChange.bind(this);
     this.checkRole = this.checkRole.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      user: nextProps.user,
-      userType: nextProps.initialUserType,
-      currentUserAccess: nextProps.initialCurrentUserAccess
-    });
-  }
-
   checkRole(roleKey) {
-    return (this.roles.indexOf(roleKey) > -1);
+    return (this.roles().indexOf(roleKey) > -1);
   }
 
   _onChange(roleKey, checked) {
@@ -64,15 +67,16 @@ export default class UserRoleListControl extends React.Component {
     handler(resource, this.props.user.guid);
   }
 
-  get roles() {
-    const rolesOnType = (this.state.userType === 'space_users') ?
-      this.props.user.space_roles :
-      this.props.user.organization_roles;
-    return rolesOnType || [];
+  roles() {
+    const roles = this.props.user.roles;
+    if (!roles) return [];
+    return roles ?
+      (roles[this.props.entityGuid] || []) :
+      []
   }
 
   get roleMap() {
-    return roleMapping[this.state.userType];
+    return roleMapping[this.props.userType];
   }
 
 
@@ -86,7 +90,7 @@ export default class UserRoleListControl extends React.Component {
               roleName={ role.label }
               roleKey={ role.key }
               initialValue={ this.checkRole(role.key) }
-              initialEnableControl={ this.state.currentUserAccess }
+              initialEnableControl={ this.props.currentUserAccess }
               onChange={ this._onChange.bind(this, role.key) }
               userId={ this.props.user.guid }
             />
@@ -97,16 +101,5 @@ export default class UserRoleListControl extends React.Component {
     );
   }
 }
-UserRoleListControl.propTypes = {
-  user: React.PropTypes.object.isRequired,
-  initialUserType: React.PropTypes.string,
-  initialCurrentUserAccess: React.PropTypes.bool,
-  onRemovePermissions: React.PropTypes.func,
-  onAddPermissions: React.PropTypes.func,
-};
-UserRoleListControl.defaultProps = {
-  initialUserType: 'space_users',
-  initialCurrentUserAccess: false,
-  onRemovePermissions: function defaultRemove() { },
-  onAddPermissions: function defaultAdd() { }
-};
+UserRoleListControl.propTypes = propTypes;
+UserRoleListControl.defaultProps = defaultProps;

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -131,12 +131,12 @@ export default class Users extends React.Component {
     return (
       <div className="test-users">
         { errorMessage }
+        <UsersInvite error={ this.state.userInviteError } />
         <div>
           <div>
             { content }
           </div>
         </div>
-        <UsersInvite error={ this.state.userInviteError } />
       </div>
     );
   }

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -85,17 +85,17 @@ export default class Users extends React.Component {
     userActions.addUserRoles(roleKey,
                                 userGuid,
                                 this.entityGuid,
-                                this.resourceType);
+                                this.entityType);
   }
 
   handleRemovePermissions(roleKey, userGuid) {
     userActions.deleteUserRoles(roleKey,
                                 userGuid,
                                 this.entityGuid,
-                                this.resourceType);
+                                this.entityType);
   }
 
-  get resourceType() {
+  get entityType() {
     return this.state.currentType === ORG_NAME ? 'org' : 'space';
   }
 

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -84,14 +84,14 @@ export default class Users extends React.Component {
   handleAddPermissions(roleKey, userGuid) {
     userActions.addUserRoles(roleKey,
                                 userGuid,
-                                this.resourceGuid,
+                                this.entityGuid,
                                 this.resourceType);
   }
 
   handleRemovePermissions(roleKey, userGuid) {
     userActions.deleteUserRoles(roleKey,
                                 userGuid,
-                                this.resourceGuid,
+                                this.entityGuid,
                                 this.resourceType);
   }
 
@@ -99,10 +99,10 @@ export default class Users extends React.Component {
     return this.state.currentType === ORG_NAME ? 'org' : 'space';
   }
 
-  get resourceGuid() {
-    const resourceGuid = this.state.currentType === ORG_NAME ?
+  get entityGuid() {
+    const entityGuid = this.state.currentType === ORG_NAME ?
       this.state.currentOrgGuid : this.state.currentSpaceGuid;
-    return resourceGuid;
+    return entityGuid;
   }
 
   render() {

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -24,13 +24,16 @@ function stateSetter() {
 
   let users = [];
   let currentUserAccess = false;
+  let entityGuid;
 
   if (currentType === SPACE_NAME) {
     users = UserStore.getAllInSpace(currentSpaceGuid);
+    entityGuid = currentSpaceGuid;
     currentUserAccess = UserStore.hasRole(currentUser.guid, currentSpaceGuid,
                                           'space_manager');
   } else {
     users = UserStore.getAllInOrg(currentOrgGuid);
+    entityGuid = currentOrgGuid;
     currentUserAccess = UserStore.hasRole(currentUser.guid, currentOrgGuid,
                                           'org_manager');
   }
@@ -40,6 +43,7 @@ function stateSetter() {
     currentUserAccess,
     currentOrgGuid,
     currentSpaceGuid,
+    entityGuid,
     currentType,
     loading: UserStore.loading,
     empty: !UserStore.loading && !users.length,
@@ -110,11 +114,12 @@ export default class Users extends React.Component {
     }
 
     let content = (<UserList
-      initialUsers={ this.state.users }
-      initialUserType= { this.state.currentType }
-      initialCurrentUserAccess={ this.state.currentUserAccess }
-      initialEmpty={ this.state.empty }
-      initialLoading={ this.state.loading }
+      users={ this.state.users }
+      userType= { this.state.currentType }
+      entityGuid={ this.state.entityGuid }
+      currentUserAccess={ this.state.currentUserAccess }
+      empty={ this.state.empty }
+      loading={ this.state.loading }
       onRemove={ removeHandler }
       onAddPermissions={ this.handleAddPermissions }
       onRemovePermissions={ this.handleRemovePermissions }

--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -46,10 +46,6 @@ export default class UsersInvite extends React.Component {
   render() {
     return (
       <div className="test-users-invite">
-        <h2>User invite</h2>
-        <PanelDocumentation description>
-          <p>Organizational Managers can add new users below.</p>
-        </PanelDocumentation>
         <Form
           guid={ USERS_INVITE_FORM_GUID }
           classes={ ['users_invite_form'] }
@@ -57,10 +53,14 @@ export default class UsersInvite extends React.Component {
           onSubmit={ this._onValidForm }
           errorOverride={ this.errorMessage }
         >
+          <h3>User invite</h3>
+          <PanelDocumentation description>
+            <p>Organizational Managers can add new users below.</p>
+          </PanelDocumentation>
           <FormText
             formGuid={ USERS_INVITE_FORM_GUID }
             classes={ ['test-users_invite_name'] }
-            label="User's email"
+            label="Email address"
             name="email"
             validator={ this.validateString }
           />

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -223,13 +223,13 @@ const userActionTypes = keymirror({
   // Action to fetch the user roles for an org from the server.
   ORG_USER_ROLES_FETCH: null,
   // Action to fetch users belonging to a space from the server.
-  SPACE_USERS_FETCH: null,
+  SPACE_USER_ROLES_FETCH: null,
   // Action when all organization users were received from the server.
   ORG_USERS_RECEIVED: null,
   // Action when all org user roles were received from the server.
   ORG_USER_ROLES_RECEIVED: null,
   // Action when all space users were received from the server.
-  SPACE_USERS_RECEIVED: null,
+  SPACE_USER_ROLES_RECEIVED: null,
   // User is fetched from the server
   USER_FETCH: null,
   // User is received from the server

--- a/static_src/routes.js
+++ b/static_src/routes.js
@@ -94,7 +94,7 @@ export function space(orgGuid, spaceGuid, next) {
   serviceActions.fetchAllInstances(spaceGuid);
   userActions.changeCurrentlyViewedType('space_users');
   userActions.fetchOrgUsers(orgGuid);
-  userActions.fetchSpaceUsers(spaceGuid);
+  userActions.fetchSpaceUserRoles(spaceGuid);
   orgActions.fetch(orgGuid);
   serviceActions.fetchAllServices(orgGuid);
 

--- a/static_src/routes.js
+++ b/static_src/routes.js
@@ -93,6 +93,7 @@ export function space(orgGuid, spaceGuid, next) {
   spaceActions.fetch(spaceGuid);
   serviceActions.fetchAllInstances(spaceGuid);
   userActions.changeCurrentlyViewedType('space_users');
+  userActions.fetchOrgUsers(orgGuid);
   userActions.fetchSpaceUsers(spaceGuid);
   orgActions.fetch(orgGuid);
   serviceActions.fetchAllServices(orgGuid);

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -281,34 +281,6 @@ export class UserStore extends BaseStore {
         break;
       }
 
-      case userActionTypes.USER_SPACES_RECEIVED:
-      case userActionTypes.USER_ORGS_RECEIVED: {
-        const user = this.get(action.userGuid);
-        if (!user) {
-          break;
-        }
-
-        const rolesByType = action.userOrgs || action.userSpaces;
-
-        const updatedRoles = rolesByType.reduce((roles, roleByType) => {
-          const key = roleByType.guid;
-          // TODO this would be nice if it was an immutable Set
-          // We don't check for duplicates, we just continually append.  We're
-          // assuming guids are unique between entity types, so user.roles
-          // could contain roles for orgs too.
-          const certainRoles = roles[key] || [];
-          if (action.type === userActionTypes.USER_ORGS_RECEIVED) {
-            roles[key] = certainRoles.concat(['org_manager']); // eslint-disable-line
-          } else {
-            roles[key] = certainRoles.concat(['space_manager']); // eslint-disable-line
-          }
-          return roles;
-        }, user.roles || {});
-
-        this.merge('guid', { guid: user.guid, roles: updatedRoles });
-        break;
-      }
-
       case userActionTypes.CURRENT_USER_FETCH: {
         this._loading.currentUser = true;
         this.emitChange();

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -81,7 +81,9 @@ export class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_ORG_ASSOCIATED: {
-        const user = Object.assign({}, { orgGuid: action.orgGuid }, action.user);
+        const user = Object.assign({},
+          { roles: { [action.orgGuid]: [] } },
+          action.user);
         this._inviteInputActive = true;
         if (user.guid) {
           this.merge('guid', user, () => {});
@@ -263,14 +265,14 @@ export class UserStore extends BaseStore {
    */
   getAllInSpace(spaceGuid) {
     const usersInSpace = this._data.filter((user) =>
-      !!user.get('roles') && !!user.get('roles').get(spaceGuid).size
+      !!user.get('roles') && !!user.get('roles').get(spaceGuid)
     );
     return usersInSpace.toJS();
   }
 
   getAllInOrg(orgGuid) {
     const usersInOrg = this._data.filter((user) =>
-      !!user.get('roles') && !!user.get('roles').get(orgGuid).size
+      !!user.get('roles') && !!user.get('roles').get(orgGuid)
     );
     return usersInOrg.toJS();
   }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -61,8 +61,6 @@ export class UserStore extends BaseStore {
       case userActionTypes.ORG_USER_ROLES_RECEIVED: {
         const orgGuid = action.orgGuid;
         const orgUserRoles = action.orgUserRoles;
-        console.log('fasldjkfasdlkjfasdl;kfj', orgUserRoles);
-        debugger;
         const updatedUsers = orgUserRoles.map((orgUserRole) => {
           let user = Object.assign({}, this.get(orgUserRole.guid));
           if (!user) user = { guid: orgUserRole.guid };

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -98,8 +98,8 @@ export class UserStore extends BaseStore {
       case userActionTypes.USER_ROLES_ADDED: {
         const user = this.get(action.userGuid);
         if (user) {
-          const role = this.getResourceToRole(action.roles, action.resourceType);
-          const userRole = (action.resourceType === 'space') ? user.space_roles :
+          const role = this.getResourceToRole(action.roles, action.entityType);
+          const userRole = (action.entityType === 'space') ? user.space_roles :
             user.organization_roles;
           if (userRole && userRole.indexOf(role) === -1) {
             userRole.push(role);
@@ -116,7 +116,7 @@ export class UserStore extends BaseStore {
           org: cfApi.deleteOrgUserPermissions,
           space: cfApi.deleteSpaceUserPermissions
         };
-        const api = apiMethodMap[action.resourceType];
+        const api = apiMethodMap[action.entityType];
 
         api(
           action.userGuid,
@@ -126,7 +126,7 @@ export class UserStore extends BaseStore {
           userActions.deletedUserRoles(
             action.roles,
             action.userGuid,
-            action.resourceType);
+            action.entityType);
         }).catch((err) => {
           window.console.error(err);
         });
@@ -136,8 +136,8 @@ export class UserStore extends BaseStore {
       case userActionTypes.USER_ROLES_DELETED: {
         const user = this.get(action.userGuid);
         if (user) {
-          const role = this.getResourceToRole(action.roles, action.resourceType);
-          const userRole = (action.resourceType === 'space') ? user.space_roles :
+          const role = this.getResourceToRole(action.roles, action.entityType);
+          const userRole = (action.entityType === 'space') ? user.space_roles :
             user.organization_roles;
           const idx = userRole && userRole.indexOf(role);
           if (idx > -1) {
@@ -297,11 +297,11 @@ export class UserStore extends BaseStore {
     return this._error;
   }
 
-  getResourceToRole(resource, resourceType) {
-    if (resourceType !== 'space' && resourceType !== 'org') {
-      throw new Error(`unknown resource type ${resourceType}`);
+  getResourceToRole(resource, entityType) {
+    if (entityType !== 'space' && entityType !== 'org') {
+      throw new Error(`unknown resource type ${entityType}`);
     }
-    const role = resourceToRole[resourceType][resource] || resource;
+    const role = resourceToRole[entityType][resource] || resource;
     return role;
   }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -78,6 +78,26 @@ export class UserStore extends BaseStore {
         break;
       }
 
+      case userActionTypes.SPACE_USER_ROLES_RECEIVED: {
+        const spaceGuid = action.spaceGuid;
+        const spaceUserRoles = action.users;
+        const updatedUsers = spaceUserRoles.map((spaceUserRole) => {
+          let user = Object.assign({}, this.get(spaceUserRole.guid) || {}, spaceUserRole);
+          user.roles = spaceUserRoles.space_roles;
+          if (!user.roles) user.roles = {};
+          const updatingRoles = spaceUserRole.space_roles || [];
+
+          user.roles[spaceGuid] = updatingRoles;
+          // Remove Cloud Foundry's data structure for roles, as we use our own
+          // roles property hashed by guid.
+          delete user.space_roles;
+          return user;
+        });
+        this.mergeMany('guid', updatedUsers, () => { });
+        this.emitChange();
+        break;
+      }
+
       case userActionTypes.USER_INVITE_FETCH: {
         this._inviteError = null;
         this.emitChange();

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -298,17 +298,17 @@ export class UserStore extends BaseStore {
    * Get all users in a certain space
    */
   getAllInSpace(spaceGuid) {
-    const inSpace = this._data.filter((user) =>
-      user.get('spaceGuid') === spaceGuid
+    const usersInSpace = this._data.filter((user) =>
+      !!user.get('roles') && !!user.get('roles').get(spaceGuid).size
     );
-    return inSpace.toJS();
+    return usersInSpace.toJS();
   }
 
   getAllInOrg(orgGuid) {
-    const inOrg = this._data.filter((user) =>
-      user.get('orgGuid') === orgGuid
+    const usersInOrg = this._data.filter((user) =>
+      !!user.get('roles') && !!user.get('roles').get(orgGuid).size
     );
-    return inOrg.toJS();
+    return usersInOrg.toJS();
   }
 
   getError() {
@@ -383,5 +383,6 @@ export class UserStore extends BaseStore {
 }
 
 const _UserStore = new UserStore();
+console.log(_UserStore);
 
 export default _UserStore;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -348,6 +348,5 @@ export class UserStore extends BaseStore {
 }
 
 const _UserStore = new UserStore();
-console.log(_UserStore);
 
 export default _UserStore;

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -92,24 +92,6 @@ export class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_ROLES_ADD: {
-        const apiMethodMap = {
-          org: cfApi.putOrgUserPermissions,
-          space: cfApi.putSpaceUserPermissions
-        };
-        const api = apiMethodMap[action.resourceType];
-
-        api(
-          action.userGuid,
-          action.resourceGuid,
-          action.roles
-        ).then(() => {
-          userActions.addedUserRoles(
-            action.roles,
-            action.userGuid,
-            action.resourceType);
-        }).catch((err) => {
-          window.console.error(err);
-        });
         break;
       }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -112,24 +112,6 @@ export class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_ROLES_DELETE: {
-        const apiMethodMap = {
-          org: cfApi.deleteOrgUserPermissions,
-          space: cfApi.deleteSpaceUserPermissions
-        };
-        const api = apiMethodMap[action.entityType];
-
-        api(
-          action.userGuid,
-          action.entityGuid,
-          action.roles
-        ).then(() => {
-          userActions.deletedUserRoles(
-            action.roles,
-            action.userGuid,
-            action.entityType);
-        }).catch((err) => {
-          window.console.error(err);
-        });
         break;
       }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -8,7 +8,6 @@ import Immutable from 'immutable';
 
 import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
-import userActions from '../actions/user_actions.js';
 import { userActionTypes } from '../constants.js';
 
 // TODO why is this role mapping needed?

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -97,13 +97,13 @@ export class UserStore extends BaseStore {
 
       case userActionTypes.USER_ROLES_ADDED: {
         const user = this.get(action.userGuid);
+        const addedRole = action.roles;
         if (user) {
-          const role = this.getResourceToRole(action.roles, action.entityType);
-          const userRole = (action.entityType === 'space') ? user.space_roles :
-            user.organization_roles;
-          if (userRole && userRole.indexOf(role) === -1) {
-            userRole.push(role);
-          }
+          if (!user.roles) user.roles = {};
+          const updatedRoles = new Set(user.roles[action.entityGuid] || []);
+          updatedRoles.add(addedRole);
+          user.roles[action.entityGuid] = Array.from(updatedRoles);
+
           this.merge('guid', user, (changed) => {
             if (changed) this.emitChange();
           });

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -59,10 +59,23 @@ export class UserStore extends BaseStore {
       }
 
       case userActionTypes.ORG_USER_ROLES_RECEIVED: {
-        const updates = action.orgUserRoles;
-        if (updates.length) {
-          this.mergeMany('guid', updates, () => { });
-        }
+        const orgGuid = action.orgGuid;
+        const orgUserRoles = action.orgUserRoles;
+        console.log('fasldjkfasdlkjfasdl;kfj', orgUserRoles);
+        debugger;
+        const updatedUsers = orgUserRoles.map((orgUserRole) => {
+          let user = Object.assign({}, this.get(orgUserRole.guid));
+          if (!user) user = { guid: orgUserRole.guid };
+          if (!user.roles) user.roles = {};
+          if (!user.roles[orgGuid]) user.roles[orgGuid] = [];
+          const updatingRoles = orgUserRole.organization_roles.reduce(
+            (roles, role) => roles.add(role)
+          , new Set(user.roles[orgGuid] || []));
+
+          user.roles[orgGuid] = Array.from(updatingRoles);
+          return user;
+        });
+        this.mergeMany('guid', updatedUsers, () => { });
         this.emitChange();
         break;
       }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -117,13 +117,14 @@ export class UserStore extends BaseStore {
 
       case userActionTypes.USER_ROLES_DELETED: {
         const user = this.get(action.userGuid);
+        const deletedRole = action.roles;
         if (user) {
-          const role = this.getResourceToRole(action.roles, action.entityType);
-          const userRole = (action.entityType === 'space') ? user.space_roles :
-            user.organization_roles;
-          const idx = userRole && userRole.indexOf(role);
-          if (idx > -1) {
-            userRole.splice(idx, 1);
+          const roles = user.roles && user.roles[action.entityGuid];
+          if (roles) {
+            const idx = deletedRole && roles.indexOf(deletedRole);
+            if (idx > -1) {
+              roles.splice(idx, 1);
+            }
           }
 
           this.merge('guid', user, (changed) => {

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -52,8 +52,8 @@ export class UserStore extends BaseStore {
         break;
       }
 
-      case userActionTypes.SPACE_USERS_FETCH: {
-        this.load([cfApi.fetchSpaceUsers(action.spaceGuid)]);
+      case userActionTypes.SPACE_USER_ROLES_FETCH: {
+        this.load([cfApi.fetchSpaceUserRoles(action.spaceGuid)]);
         this.emitChange();
         break;
       }
@@ -172,29 +172,20 @@ export class UserStore extends BaseStore {
         break;
       }
 
-      case userActionTypes.SPACE_USERS_RECEIVED:
       case userActionTypes.ORG_USERS_RECEIVED: {
-        let updates = action.users;
-        updates = updates.map((update) => {
-          const updateCopy = Object.assign({}, update);
-          if (action.orgGuid) {
-            updateCopy.orgGuid = action.orgGuid;
+        const orgGuid = action.orgGuid;
+        const orgUsers = action.users;
+
+        const updatedUsers = orgUsers.map((orgUser) =>
+          Object.assign({}, orgUser, { orgGuid })
+        );
+
+        this.mergeMany('guid', updatedUsers, (changed) => {
+          if (changed) {
+            this._error = null;
           }
-          if (action.spaceGuid) {
-            updateCopy.spaceGuid = action.spaceGuid;
-          }
-          return updateCopy;
-        });
-        if (updates.length) {
-          this.mergeMany('guid', updates, (changed) => {
-            if (changed) {
-              this._error = null;
-            }
-            this.emitChange();
-          });
-        } else {
           this.emitChange();
-        }
+        });
         break;
       }
 

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -120,7 +120,7 @@ export class UserStore extends BaseStore {
 
         api(
           action.userGuid,
-          action.resourceGuid,
+          action.entityGuid,
           action.roles
         ).then(() => {
           userActions.deletedUserRoles(

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -333,7 +333,7 @@ export class UserStore extends BaseStore {
 
   mergeRoles(roles, entityGuid, entityType) {
     return roles.map((role) => {
-      let user = Object.assign({}, this.get(role.guid) || { guid: role.guid });
+      const user = Object.assign({}, this.get(role.guid) || { guid: role.guid });
       if (!user.roles) user.roles = {};
       const updatingRoles = role[entityType] || [];
 

--- a/static_src/test/functional/user_invite.spec.js
+++ b/static_src/test/functional/user_invite.spec.js
@@ -38,17 +38,13 @@ describe('User roles', function () {
 
     it('should be able to submit an email address and see on user list', function () {
       const existingUserCount = userInviteElement.countNumberOfUsers();
-      const user = userInviteElement.getUserByIndex(existingUserCount - 1);
+      let user = userInviteElement.getUserByIndex(existingUserCount - 1);
       expect(user.getText()).not.toMatch(/fake-persona@gsa.gov/);
       userInviteElement.inputToInviteForm(email);
       userInviteElement.submitInviteForm();
       const currentUserCount = userInviteElement.countNumberOfUsers();
       expect(currentUserCount).toEqual(existingUserCount + 1);
-    });
-
-    it('should add the user as the last entry in the user list', function () {
-      const currentUserCount = userInviteElement.countNumberOfUsers();
-      const user = userInviteElement.getUserByIndex(currentUserCount - 1);
+      user = userInviteElement.getUserByIndex(currentUserCount - 1);
       expect(user.getText()).toMatch(/fake-persona@gsa.gov/);
     });
 

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -426,6 +426,46 @@ describe('userActions', function() {
 
       assertAction(spy, userActionTypes.USER_ROLES_ADD, expectedParams);
     });
+
+    describe('for org user', function() {
+      let roles;
+      let userGuid;
+      let orgGuid;
+
+      beforeEach(function(done) {
+        sandbox.stub(cfApi, 'putOrgUserPermissions').returns(Promise.resolve());
+        sandbox.stub(userActions, 'addedUserRoles').returns(Promise.resolve());
+        roles = ['org_manager'];
+        userGuid = 'user-123';
+        orgGuid = 'org-123';
+
+        userActions.addUserRoles(
+          roles,
+          userGuid,
+          orgGuid,
+          'org'
+        ).then(done, done.fail);
+      });
+
+      it('should call api for org put user permision with guids and roles', () => {
+        expect(cfApi.putOrgUserPermissions).toHaveBeenCalledOnce();
+        expect(cfApi.putOrgUserPermissions).toHaveBeenCalledWith(sinon.match(
+          userGuid,
+          orgGuid,
+          roles
+        ));
+      });
+
+      it('should call addedUserRoles action with all information', function() {
+        expect(userActions.addedUserRoles).toHaveBeenCalledOnce();
+        expect(userActions.addedUserRoles).toHaveBeenCalledWith(sinon.match(
+          roles,
+          userGuid,
+          orgGuid,
+          'org'
+        ));
+      });
+    });
   });
 
   describe('addedUserRoles()', function() {

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -412,7 +412,7 @@ describe('userActions', function() {
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
-        resourceGuid: expectedGuid,
+        entityGuid: expectedGuid,
         resourceType: expectedType
       };
 
@@ -439,7 +439,7 @@ describe('userActions', function() {
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
-        resourceGuid: expectedGuid,
+        entityGuid: expectedGuid,
         resourceType: expectedType
       };
 
@@ -466,7 +466,7 @@ describe('userActions', function() {
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
-        resourceGuid: expectedGuid,
+        entityGuid: expectedGuid,
         resourceType: expectedType
       };
 

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -627,11 +627,13 @@ describe('userActions', function() {
         resource type`, function() {
       var expectedRole = 'org_manager',
           expectedUserGuid = 'azxcvoiuzxcvzxcvzxvzx',
+          expectedGuid = 'org-asdf',
           expectedType = 'organization';
 
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
+        entityGuid: expectedGuid,
         entityType: expectedType
       };
 
@@ -640,6 +642,7 @@ describe('userActions', function() {
       userActions.deletedUserRoles(
         expectedRole,
         expectedUserGuid,
+        expectedGuid,
         expectedType);
 
       assertAction(spy, userActionTypes.USER_ROLES_DELETED, expectedParams);

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -550,6 +550,76 @@ describe('userActions', function() {
 
       assertAction(spy, userActionTypes.USER_ROLES_DELETE, expectedParams);
     });
+
+    describe('for org user', function() {
+      let roles;
+      let userGuid;
+      let orgGuid;
+
+      beforeEach(function(done) {
+        sandbox.stub(cfApi, 'deleteOrgUserPermissions').returns(Promise.resolve());
+        sandbox.stub(userActions, 'deletedUserRoles').returns(Promise.resolve());
+        roles = ['org_manager'];
+        userGuid = 'user-123';
+        orgGuid = 'org-123';
+
+        userActions.deleteUserRoles(
+          roles,
+          userGuid,
+          orgGuid,
+          'org'
+        ).then(done, done.fail);
+      });
+
+      it('should call api for org delete user permision with guids and roles', () => {
+        expect(cfApi.deleteOrgUserPermissions).toHaveBeenCalledOnce();
+        expect(cfApi.deleteOrgUserPermissions).toHaveBeenCalledWith(sinon.match(
+          userGuid,
+          orgGuid,
+          roles
+        ));
+      });
+
+      it('should call deletedUserRoles action with all information', function() {
+        expect(userActions.deletedUserRoles).toHaveBeenCalledOnce();
+        expect(userActions.deletedUserRoles).toHaveBeenCalledWith(sinon.match(
+          roles,
+          userGuid,
+          orgGuid,
+          'org'
+        ));
+      });
+    });
+
+    describe('for space user', function() {
+      let roles;
+      let userGuid;
+      let spaceGuid;
+
+      beforeEach(function(done) {
+        sandbox.stub(cfApi, 'deleteSpaceUserPermissions').returns(Promise.resolve());
+        sandbox.stub(userActions, 'deletedUserRoles').returns(Promise.resolve());
+        roles = ['space_manager'];
+        userGuid = 'user-123';
+        spaceGuid = 'space-123';
+
+        userActions.deleteUserRoles(
+          roles,
+          userGuid,
+          spaceGuid,
+          'space'
+        ).then(done, done.fail);
+      });
+
+      it('should call api for space delete user permision with guids and roles', () => {
+        expect(cfApi.deleteSpaceUserPermissions).toHaveBeenCalledOnce();
+        expect(cfApi.deleteSpaceUserPermissions).toHaveBeenCalledWith(sinon.match(
+          userGuid,
+          spaceGuid,
+          roles
+        ));
+      });
+    });
   });
 
   describe('deletedUserRoles()', function() {

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -413,7 +413,7 @@ describe('userActions', function() {
         roles: expectedRole,
         userGuid: expectedUserGuid,
         entityGuid: expectedGuid,
-        resourceType: expectedType
+        entityType: expectedType
       };
 
       let spy = setupViewSpy(sandbox)
@@ -440,7 +440,7 @@ describe('userActions', function() {
         roles: expectedRole,
         userGuid: expectedUserGuid,
         entityGuid: expectedGuid,
-        resourceType: expectedType
+        entityType: expectedType
       };
 
       let spy = setupServerSpy(sandbox)
@@ -467,7 +467,7 @@ describe('userActions', function() {
         roles: expectedRole,
         userGuid: expectedUserGuid,
         entityGuid: expectedGuid,
-        resourceType: expectedType
+        entityType: expectedType
       };
 
       let spy = setupViewSpy(sandbox)
@@ -492,7 +492,7 @@ describe('userActions', function() {
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
-        resourceType: expectedType
+        entityType: expectedType
       };
 
       let spy = setupServerSpy(sandbox)

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -466,6 +466,36 @@ describe('userActions', function() {
         ));
       });
     });
+
+    describe('for space user', function() {
+      let roles;
+      let userGuid;
+      let spaceGuid;
+
+      beforeEach(function(done) {
+        sandbox.stub(cfApi, 'putSpaceUserPermissions').returns(Promise.resolve());
+        sandbox.stub(userActions, 'addedUserRoles').returns(Promise.resolve());
+        roles = ['space_manager'];
+        userGuid = 'user-123';
+        spaceGuid = 'space-123';
+
+        userActions.addUserRoles(
+          roles,
+          userGuid,
+          spaceGuid,
+          'space'
+        ).then(done, done.fail);
+      });
+
+      it('should call api for space put user permision with guids and roles', () => {
+        expect(cfApi.putSpaceUserPermissions).toHaveBeenCalledOnce();
+        expect(cfApi.putSpaceUserPermissions).toHaveBeenCalledWith(sinon.match(
+          userGuid,
+          spaceGuid,
+          roles
+        ));
+      });
+    });
   });
 
   describe('addedUserRoles()', function() {

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -169,31 +169,6 @@ describe('userActions', function() {
     });
   });
 
-  describe('fetchUserOrgs()', function () {
-    let userGuid;
-
-    beforeEach(function (done) {
-      userGuid = 'user123';
-      sandbox.stub(cfApi, 'fetchUserOrgs').returns(Promise.resolve([]));
-      sandbox.stub(AppDispatcher, 'handleViewAction');
-
-      userActions.fetchUserOrgs(userGuid)
-        .then(done, done.fail);
-    });
-
-    it('dispatches USER_ORGS_FETCH', function () {
-      expect(AppDispatcher.handleViewAction).toHaveBeenCalledWith(sinon.match({
-        type: userActionTypes.USER_ORGS_FETCH,
-        userGuid
-      }));
-    });
-
-    it('calls cfApi', function () {
-      expect(cfApi.fetchUserOrgs).toHaveBeenCalledOnce();
-      expect(cfApi.fetchUserOrgs).toHaveBeenCalledWith(userGuid);
-    });
-  });
-
   describe('fetchUserInvite', function () {
     let email;
 
@@ -608,134 +583,6 @@ describe('userActions', function() {
     });
   });
 
-  describe('fetchUserSpaces()', function () {
-    let userGuid;
-
-    beforeEach(function (done) {
-      userGuid = 'user123';
-      sandbox.stub(cfApi, 'fetchUserSpaces').returns(Promise.resolve([]));
-      sandbox.stub(AppDispatcher, 'handleViewAction');
-
-      userActions.fetchUserSpaces(userGuid)
-        .then(done, done.fail);
-    });
-
-    it('dispatches USER_SPACES_FETCH', function () {
-      expect(AppDispatcher.handleViewAction).toHaveBeenCalledWith(sinon.match({
-        type: userActionTypes.USER_SPACES_FETCH,
-        userGuid
-      }));
-    });
-
-    it('calls cfApi', function () {
-      expect(cfApi.fetchUserSpaces).toHaveBeenCalledWith(userGuid);
-    });
-
-    describe('given orgGuid', function () {
-      let orgGuid;
-      beforeEach(function (done) {
-        orgGuid = 'org123';
-
-        userActions.fetchUserSpaces(userGuid, { orgGuid })
-          .then(done, done.fail);
-      });
-
-      it('dispatches USER_SPACES_FETCH with orgGuid', function () {
-        expect(AppDispatcher.handleViewAction).toHaveBeenCalledWith({
-          type: userActionTypes.USER_SPACES_FETCH,
-          userGuid,
-          orgGuid
-        });
-      });
-
-      it('calls api with orgGuid', function () {
-        expect(cfApi.fetchUserSpaces).toHaveBeenCalledWith(userGuid, sinon.match({ orgGuid }));
-      });
-    });
-  });
-
-  describe('receivedUserSpaces()', function () {
-    let userGuid, userSpaces, result;
-
-    beforeEach(function (done) {
-      userGuid = 'user123';
-      userSpaces = [{ guid: 'space123' }, { guid: 'space456' }];
-      sandbox.stub(AppDispatcher, 'handleServerAction');
-
-      userActions.receivedUserSpaces(userGuid, userSpaces)
-        .then(_result => {
-          result = _result;
-        })
-        .then(done, done.fail);
-    });
-
-    it('dispatches USER_SPACES_RECEIVED', function () {
-      expect(AppDispatcher.handleServerAction).toHaveBeenCalledWith(sinon.match({
-        type: userActionTypes.USER_SPACES_RECEIVED,
-        userGuid,
-        userSpaces
-      }));
-    });
-
-    it('resolves the userSpaces', function () {
-      expect(result).toEqual(userSpaces);
-    });
-  });
-
-  describe('fetchUserOrgs()', function () {
-    let userGuid;
-
-    beforeEach(function (done) {
-      userGuid = 'user123';
-      sandbox.stub(cfApi, 'fetchUserOrgs').returns(Promise.resolve([]));
-      sandbox.stub(AppDispatcher, 'handleViewAction');
-
-      userActions.fetchUserOrgs(userGuid)
-        .then(done, done.fail);
-    });
-
-    it('dispatches USER_ORGS_FETCH', function () {
-      expect(AppDispatcher.handleViewAction).toHaveBeenCalledWith(sinon.match({
-        type: userActionTypes.USER_ORGS_FETCH,
-        userGuid
-      }));
-    });
-
-    it('calls cfApi', function () {
-      expect(cfApi.fetchUserOrgs).toHaveBeenCalledOnce();
-      expect(cfApi.fetchUserOrgs).toHaveBeenCalledWith(userGuid);
-    });
-  });
-
-  describe('receivedUserOrgs()', function () {
-    let userGuid, userOrgs, result;
-
-    beforeEach(function (done) {
-      userGuid = 'user123';
-      userOrgs = [{ guid: 'org123' }, { guid: 'org456' }];
-      sandbox.stub(AppDispatcher, 'handleServerAction');
-
-      userActions.receivedUserOrgs(userGuid, userOrgs)
-        .then(_result => {
-          result = _result;
-        })
-        .then(done, done.fail);
-    });
-
-    it('dispatches USER_ORGS_RECEIVED', function () {
-      expect(AppDispatcher.handleServerAction).toHaveBeenCalledWith(sinon.match({
-        type: userActionTypes.USER_ORGS_RECEIVED,
-        userGuid,
-        userOrgs
-      }));
-    });
-
-    it('resolves the userOrgs', function () {
-      expect(result).toEqual(userOrgs);
-    });
-  });
-
-
   describe('fetchCurrentUserUaaInfo()', function () {
     let guid;
 
@@ -777,8 +624,6 @@ describe('userActions', function() {
       sandbox.stub(userActions, 'fetchCurrentUserInfo')
         .returns(Promise.resolve({ user_id: 'user123' }));
       sandbox.stub(userActions, 'fetchUser').returns(Promise.resolve());
-      sandbox.stub(userActions, 'fetchUserOrgs').returns(Promise.resolve());
-      sandbox.stub(userActions, 'fetchUserSpaces').returns(Promise.resolve());
       sandbox.stub(userActions, 'fetchCurrentUserUaaInfo').returns(Promise.resolve());
       sandbox.stub(userActions, 'receivedCurrentUser').returns(Promise.resolve());
       sandbox.stub(AppDispatcher, 'handleViewAction');
@@ -808,10 +653,6 @@ describe('userActions', function() {
 
     it('calls fetchUser', function () {
       expect(userActions.fetchUser).toHaveBeenCalledOnce();
-    });
-
-    it('calls fetchUserSpaces', function () {
-      expect(userActions.fetchUserSpaces).toHaveBeenCalledOnce();
     });
 
     it('calls receivedCurrentUser', function () {

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -52,7 +52,7 @@ describe('userActions', function() {
     });
   });
 
-  describe('fetchSpaceUsers()', function() {
+  describe('fetchSpaceUserRoles()', function() {
     it('should dispatch a view event of type space users fetch', function() {
       var expectedSpaceGuid = 'asdflkjz',
           expectedParams = {
@@ -61,9 +61,9 @@ describe('userActions', function() {
 
       let spy = setupViewSpy(sandbox);
 
-      userActions.fetchSpaceUsers(expectedSpaceGuid);
+      userActions.fetchSpaceUserRoles(expectedSpaceGuid);
 
-      assertAction(spy, userActionTypes.SPACE_USERS_FETCH, expectedParams);
+      assertAction(spy, userActionTypes.SPACE_USER_ROLES_FETCH, expectedParams);
     });
   });
 
@@ -100,7 +100,7 @@ describe('userActions', function() {
     });
   });
 
-  describe('receivedSpaceUsers()', function() {
+  describe('receivedSpaceUserRoles()', function() {
     it(`should dispatch a server event of type space users received with received
         data`, function() {
       var expected = [{ entity: { }, metadata: { guid: 'adf' }}],
@@ -110,9 +110,9 @@ describe('userActions', function() {
 
       let spy = setupServerSpy(sandbox)
 
-      userActions.receivedSpaceUsers(expected);
+      userActions.receivedSpaceUserRoles(expected);
 
-      assertAction(spy, userActionTypes.SPACE_USERS_RECEIVED, expectedParams);
+      assertAction(spy, userActionTypes.SPACE_USER_ROLES_RECEIVED, expectedParams);
     });
   });
 

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -433,11 +433,13 @@ describe('userActions', function() {
         resource type`, function() {
       var expectedRole = 'org_manager',
           expectedUserGuid = 'azxcvoiuzxcvzxcvzxvzx',
+          expectedGuid = 'org-guid-asdf',
           expectedType = 'organization';
 
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
+        resourceGuid: expectedGuid,
         resourceType: expectedType
       };
 
@@ -446,6 +448,7 @@ describe('userActions', function() {
       userActions.addedUserRoles(
         expectedRole,
         expectedUserGuid,
+        expectedGuid,
         expectedType);
 
       assertAction(spy, userActionTypes.USER_ROLES_ADDED, expectedParams);

--- a/static_src/test/unit/components/user_role_list_control.spec.jsx
+++ b/static_src/test/unit/components/user_role_list_control.spec.jsx
@@ -1,0 +1,135 @@
+
+import '../../global_setup.js';
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import UserRoleListControl from '../../../components/user_role_list_control.jsx';
+import UserStore from '../../../stores/user_store';
+
+describe('<UserRoleListControl />', function () {
+  let userRoleListControl, sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('with an org user', function () {
+    const orgGuid = 'org-123';
+
+    beforeEach(function () {
+      const userGuid = 'a-user-guid';
+      const user = {
+        guid: userGuid,
+        roles: []
+      };
+
+      userRoleListControl = shallow(
+        <UserRoleListControl
+          user={ user }
+          userType='org_users'
+          currentUserAccess={ true }
+          entityGuid={ orgGuid }
+        />
+      );
+    });
+
+    describe('that has no roles', function () {
+      it('returns an empty list of roles', function () {
+        const actual = userRoleListControl.instance().roles();
+        expect(actual).toEqual([]);
+      });
+
+      it('returns false for all org roles', function () {
+        const actual = userRoleListControl.instance().checkRole('org_manager');
+        expect(actual).toEqual(false);
+      });
+    });
+
+    describe('that has org_manager role, checkRole', function() {
+      beforeEach(function() {
+        const user = {
+          guid: 'user-123',
+          entityGuid: orgGuid,
+          roles: {
+            [orgGuid]: ['org_manager']
+          }
+        }
+        userRoleListControl.setProps({user: user});
+      });
+
+      it('returns true for org manager', function () {
+        const actual = userRoleListControl.instance().checkRole('org_manager');
+        expect(actual).toEqual(true);
+      });
+
+      it('returns false for org auditor, space manager', function () {
+        const actual = userRoleListControl.instance().checkRole('org_auditor');
+        expect(actual).toEqual(false);
+        expect(userRoleListControl.instance().checkRole('space_manager'))
+          .toEqual(false);
+      });
+    });
+  });
+
+  describe('with a space user', function () {
+    const spaceGuid = 'space-123';
+
+    beforeEach(function () {
+      const userGuid = 'a-user-guid';
+      const user = {
+        guid: userGuid,
+        roles: []
+      };
+
+      userRoleListControl = shallow(
+        <UserRoleListControl
+          user={ user }
+          userType='space_users'
+          currentUserAccess={ true }
+          entityGuid={ spaceGuid }
+        />
+      );
+    });
+
+    describe('that has no roles', function () {
+      it('returns an empty list of roles', function () {
+        const actual = userRoleListControl.instance().roles();
+        expect(actual).toEqual([]);
+      });
+
+      it('returns false for all space roles', function () {
+        const actual = userRoleListControl.instance().checkRole('space_manager');
+        expect(actual).toEqual(false);
+      });
+    });
+
+    describe('that has space_manager role, checkRole', function() {
+      beforeEach(function() {
+        const user = {
+          guid: 'user-123',
+          entityGuid: spaceGuid,
+          roles: {
+            [spaceGuid]: ['space_manager']
+          }
+        }
+        userRoleListControl.setProps({user: user});
+      });
+
+      it('returns true for space manager', function () {
+        const actual = userRoleListControl.instance().checkRole('space_manager');
+        expect(actual).toEqual(true);
+      });
+
+      it('returns false for space auditor, org manager', function () {
+        const actual = userRoleListControl.instance().checkRole('space_auditor');
+        expect(actual).toEqual(false);
+        expect(userRoleListControl.instance().checkRole('org_manager'))
+          .toEqual(false);
+      });
+    });
+  });
+});

--- a/static_src/test/unit/components/user_role_list_control.spec.jsx
+++ b/static_src/test/unit/components/user_role_list_control.spec.jsx
@@ -4,7 +4,6 @@ import '../../global_setup.js';
 import React from 'react';
 import { shallow } from 'enzyme';
 import UserRoleListControl from '../../../components/user_role_list_control.jsx';
-import UserStore from '../../../stores/user_store';
 
 describe('<UserRoleListControl />', function () {
   let userRoleListControl, sandbox;
@@ -30,8 +29,8 @@ describe('<UserRoleListControl />', function () {
       userRoleListControl = shallow(
         <UserRoleListControl
           user={ user }
-          userType='org_users'
-          currentUserAccess={ true }
+          userType="org_users"
+          currentUserAccess
           entityGuid={ orgGuid }
         />
       );
@@ -49,16 +48,16 @@ describe('<UserRoleListControl />', function () {
       });
     });
 
-    describe('that has org_manager role, checkRole', function() {
-      beforeEach(function() {
+    describe('that has org_manager role, checkRole', function () {
+      beforeEach(function () {
         const user = {
           guid: 'user-123',
           entityGuid: orgGuid,
           roles: {
             [orgGuid]: ['org_manager']
           }
-        }
-        userRoleListControl.setProps({user: user});
+        };
+        userRoleListControl.setProps({ user });
       });
 
       it('returns true for org manager', function () {
@@ -88,8 +87,8 @@ describe('<UserRoleListControl />', function () {
       userRoleListControl = shallow(
         <UserRoleListControl
           user={ user }
-          userType='space_users'
-          currentUserAccess={ true }
+          userType="space_users"
+          currentUserAccess
           entityGuid={ spaceGuid }
         />
       );
@@ -107,16 +106,16 @@ describe('<UserRoleListControl />', function () {
       });
     });
 
-    describe('that has space_manager role, checkRole', function() {
-      beforeEach(function() {
+    describe('that has space_manager role, checkRole', function () {
+      beforeEach(function () {
         const user = {
           guid: 'user-123',
           entityGuid: spaceGuid,
           roles: {
             [spaceGuid]: ['space_manager']
           }
-        }
-        userRoleListControl.setProps({user: user});
+        };
+        userRoleListControl.setProps({ user });
       });
 
       it('returns true for space manager', function () {

--- a/static_src/test/unit/components/users.spec.jsx
+++ b/static_src/test/unit/components/users.spec.jsx
@@ -33,7 +33,7 @@ describe('<Users />', function () {
         users.setState({ currentType: 'org_users' });
       });
       it('doesnt have permissions to edit users', function () {
-        const actual = users.instance().resourceType;
+        const actual = users.instance().entityType;
         expect(actual).toEqual('org');
       });
     });
@@ -43,7 +43,7 @@ describe('<Users />', function () {
         users.setState({ currentType: 'space_users' });
       });
       it('doesnt have permissions to edit users', function () {
-        const actual = users.instance().resourceType;
+        const actual = users.instance().entityType;
         expect(actual).toEqual('space');
       });
     });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -144,32 +144,52 @@ describe('UserStore', function () {
 
   describe('on org user roles received', function() {
     it('should emit a change event if data changed', function() {
-      var spy = sandbox.spy(UserStore, 'emitChange');
+      const spy = sandbox.spy(UserStore, 'emitChange');
 
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
-        orgUserRoles: [{ guid: 'adsfa' }]
-      });
+      userActions.receivedOrgUserRoles([{ guid: 'adsfa', organization_roles: [] }],
+        'asdf');
 
       expect(spy).toHaveBeenCalledOnce();
     });
 
     it('should merge and update new users with existing users in data',
         function() {
-      const sharedGuid = 'wpqoifesadkzcvn';
-      const existingUser = { guid: sharedGuid, name: 'Michael' };
-      const newUser = { guid: sharedGuid, organization_roles: ['role'] };
+      const userGuid = 'user-75384';
+      const orgGuid = 'org-534789';
+      const currentUsers = [
+        { guid: userGuid },
+        { guid: 'asdf', roles: { 'adjf': [ 'org_manager' ] } }
+      ];
+      const roles = [
+        {
+          guid: userGuid,
+          organization_roles: [ 'org_manager', 'org_auditor' ]
+        },
+        {
+          guid: 'asdf',
+          organization_roles: ['org_manager']
+        }
+      ];
+      const expectedUsers = [
+        {
+          guid: userGuid,
+          roles: {
+            [orgGuid]: ['org_manager', 'org_auditor']
+          }
+        },
+        {
+          guid: 'asdf',
+          roles: {
+            'adjf': ['org_manager']
+          }
+        }
+      ];
 
-      UserStore.push(existingUser);
-      expect(UserStore.get(sharedGuid)).toEqual(existingUser);
+      UserStore.push(expectedUsers[0]);
+      UserStore.push(expectedUsers[1]);
+      userActions.receivedOrgUserRoles(roles, orgGuid);
 
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
-        orgUserRoles: [newUser]
-      });
-      let actual = UserStore.get(sharedGuid);
-      let expected = Object.assign({}, existingUser, newUser);
-      expect(actual).toEqual(expected);
+      expect(UserStore.getAll(userGuid)).toEqual(expectedUsers);
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -280,37 +280,38 @@ describe('UserStore', function () {
   });
 
   describe('on user roles deleted', function() {
-    it('should update the resource type roles array if it exists with new roles',
-        function() {
-      var testGuid = 'zxcvzxc',
-          expectedRole = 'org_dark_lord';
+    const testGuid = 'zxcvzxc';
+    const expectedRole = 'org_dark_lord';
+    const otherRole = 'wizard';
+    const orgGuid = 'org-123';
+    const otherOrgGuid = 'org-987';
 
-      var existingUser = {
+    beforeEach(function() {
+      const existingUser = {
         guid: testGuid,
-        organization_roles: ['org_manager', expectedRole]
+        roles: {
+          [orgGuid]: [expectedRole, otherRole],
+          [otherOrgGuid]: ['org_manager']
+        }
       };
 
       UserStore._data = Immutable.fromJS([existingUser]);
+      sandbox.spy(UserStore, 'emitChange'),
 
-      userActions.deletedUserRoles(expectedRole, testGuid, 'org');
+      userActions.deletedUserRoles(expectedRole, testGuid, orgGuid, 'org');
+    });
 
+    it('should update the resource type roles array if it exists with new roles',
+        function() {
       let actual = UserStore.get(testGuid);
       expect(actual).toBeTruthy();
-      expect(actual.organization_roles).not.toContain(expectedRole);
+      expect(actual.roles[orgGuid]).not.toContain(expectedRole);
+      expect(actual.roles[orgGuid]).toContain(otherRole);
+      expect(actual.roles[otherOrgGuid]).toContain('org_manager');
     });
 
     it('should emit a change event if it finds the user and no role', function() {
-      var spy = sandbox.spy(UserStore, 'emitChange'),
-          expectedRole = 'org_dark_lord',
-          testUserGuid = '234xcvbqwn';
-
-      UserStore._data = Immutable.fromJS([{
-        guid: testUserGuid,
-        organization_roles: [expectedRole]
-      }]);
-      userActions.deletedUserRoles(expectedRole, testUserGuid, 'org');
-
-      expect(spy).toHaveBeenCalledOnce();
+      expect(UserStore.emitChange).toHaveBeenCalledOnce();
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -604,52 +604,6 @@ describe('UserStore', function () {
     });
   });
 
-  describe('USER_SPACES_RECEIVED|USER_ORGS_RECEIVED', function () {
-    let userGuid, userSpaces, userOrgs, user;
-    beforeEach(function () {
-      userGuid = 'user123';
-      userSpaces = [{ guid: 'space123' }, { guid: 'space456' }];
-      userOrgs = [{ guid: 'org123' }];
-
-      // User with no roles
-      UserStore.push({ guid: userGuid });
-
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.USER_SPACES_RECEIVED,
-        userGuid,
-        userSpaces
-      });
-
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.USER_ORGS_RECEIVED,
-        userGuid,
-        userOrgs
-      });
-
-      user = UserStore.get(userGuid);
-    });
-
-    it('creates a roles property on user', function () {
-      expect(user.roles).toBeTruthy();
-    });
-
-    it('assigns space_developer role for each space', function () {
-      expect(user.roles).toEqual({
-        space123: ['space_manager'],
-        space456: ['space_manager'],
-        org123: ['org_manager']
-      });
-    });
-
-    it('assigns org_manager role for each org', function () {
-      expect(user.roles).toEqual({
-        space123: ['space_manager'],
-        space456: ['space_manager'],
-        org123: ['org_manager']
-      });
-    });
-  });
-
   describe('CURRENT_USER_FETCH', function () {
     beforeEach(function () {
       sandbox.spy(UserStore, 'emitChange');

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -158,7 +158,12 @@ describe('UserStore', function () {
       const orgGuid = 'org-534789';
       const currentUsers = [
         { guid: userGuid },
-        { guid: 'asdf', roles: { 'adjf': [ 'org_manager' ] } }
+        { guid: 'asdf',
+          roles: {
+            [ orgGuid ]: [ 'org_manager' ] ,
+            'adjf': [ 'org_manager' ]
+          }
+        }
       ];
       const roles = [
         {
@@ -173,15 +178,12 @@ describe('UserStore', function () {
       const expectedUsers = [
         {
           guid: userGuid,
-          roles: {
-            [orgGuid]: ['org_manager', 'org_auditor']
-          }
+          roles: { [orgGuid]: ['org_manager', 'org_auditor'] }
         },
         {
           guid: 'asdf',
-          roles: {
-            'adjf': ['org_manager']
-          }
+          roles: { 'adjf': ['org_manager'],
+                   [orgGuid]: ['org_manager', 'org_auditor'] }
         }
       ];
 
@@ -189,7 +191,7 @@ describe('UserStore', function () {
       UserStore.push(expectedUsers[1]);
       userActions.receivedOrgUserRoles(roles, orgGuid);
 
-      expect(UserStore.getAll(userGuid)).toEqual(expectedUsers);
+      expect(UserStore.getAll()).toEqual(expectedUsers);
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -279,38 +279,6 @@ describe('UserStore', function () {
     });
   });
 
-  describe('on user roles added', function() {
-    it('should update the resource type roles array if it exists with new roles',
-        function() {
-      var testGuid = 'zxcvzxc',
-          expectedRole = 'org_dark_lord';
-
-      var existingUser = {
-        guid: testGuid,
-        organization_roles: ['org_manager']
-      };
-
-      UserStore.push(existingUser);
-
-      userActions.addedUserRoles(expectedRole, testGuid, 'org');
-
-      let actual = UserStore.get(testGuid);
-      expect(actual).toBeTruthy();
-      expect(actual.organization_roles).toContain(expectedRole);
-    });
-
-    it('should emit a change event if it finds the user', function() {
-      const spy = sandbox.spy(UserStore, 'emitChange');
-      const testUserGuid = '234xcvbqwn';
-      const initialData = [{guid: testUserGuid, organization_roles: []}]
-
-      UserStore._data = Immutable.fromJS(initialData);
-      userActions.addedUserRoles('testrole', testUserGuid, 'org');
-
-      expect(spy).toHaveBeenCalledOnce();
-    });
-  });
-
   describe('on user roles delete', function() {
     it('should call the api to delete the role', function() {
       var spy = sandbox.stub(cfApi, 'deleteOrgUserPermissions'),

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -167,6 +167,10 @@ describe('UserStore', function () {
   });
 
   describe('on org user roles received', function() {
+    beforeEach(function() {
+      UserStore._data = Immutable.List();
+    });
+
     it('should emit a change event if data changed', function() {
       const spy = sandbox.spy(UserStore, 'emitChange');
 
@@ -207,7 +211,7 @@ describe('UserStore', function () {
         {
           guid: 'asdf',
           roles: { 'adjf': ['org_manager'],
-                   [orgGuid]: ['org_manager', 'org_auditor'] }
+                   [orgGuid]: ['org_manager'] }
         }
       ];
 
@@ -215,7 +219,8 @@ describe('UserStore', function () {
       UserStore.push(expectedUsers[1]);
       userActions.receivedOrgUserRoles(roles, orgGuid);
 
-      expect(UserStore.getAll()).toEqual(expectedUsers);
+      expect(UserStore.get(userGuid)).toEqual(expectedUsers[0]);
+      expect(UserStore.get('asdf')).toEqual(expectedUsers[1]);
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -279,31 +279,6 @@ describe('UserStore', function () {
     });
   });
 
-  describe('on user roles delete', function() {
-    it('should call the api to delete the role', function() {
-      var spy = sandbox.stub(cfApi, 'deleteOrgUserPermissions'),
-          expectedRoles = 'org_manager',
-          expectedUserGuid = 'zjkxcvz234asdf',
-          expectedOrgGuid = 'zxcvzcxvzxroiter';
-
-      let testPromise = Promise.resolve()
-      spy.returns(testPromise);
-
-      userActions.deleteUserRoles(
-        expectedRoles,
-        expectedUserGuid,
-        expectedOrgGuid,
-        'org'
-      );
-
-      expect(spy).toHaveBeenCalledOnce();
-      let args = spy.getCall(0).args;
-      expect(args[0]).toEqual(expectedUserGuid);
-      expect(args[1]).toEqual(expectedOrgGuid);
-      expect(args[2]).toEqual(expectedRoles);
-    });
-  });
-
   describe('on user roles deleted', function() {
     it('should update the resource type roles array if it exists with new roles',
         function() {

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -578,7 +578,7 @@ describe('UserStore', function () {
     // TODO possibly move this functionality to shared place.
     it('should find all user that have the space guid passed in', function() {
       var spaceGuid = 'asdfa';
-      var testUser = { guid: 'adfzxcv', spaceGuid: spaceGuid };
+      var testUser = { guid: 'adfzxcv', roles: { [spaceGuid]: [ 'space_user'] } };
 
       UserStore.push(testUser);
 
@@ -591,7 +591,7 @@ describe('UserStore', function () {
   describe('getAllInOrg()', function() {
     it('should find all users that have the org guid passed in', function() {
       var orgGuid = 'asdfa';
-      var testUser = { guid: 'adfzxcv', orgGuid: orgGuid };
+      var testUser = { guid: 'adfzxcv', roles: { [orgGuid]: ['org_user'] } };
 
       UserStore.push(testUser);
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -36,11 +36,11 @@ describe('UserStore', function () {
 
   describe('on space users fetch', function() {
     it('should fetch space users through api', function() {
-      var spy = sandbox.spy(cfApi, 'fetchSpaceUsers'),
+      var spy = sandbox.spy(cfApi, 'fetchSpaceUserRoles'),
           expectedGuid = 'axckzvjxcov';
 
       AppDispatcher.handleViewAction({
-        type: userActionTypes.SPACE_USERS_FETCH,
+        type: userActionTypes.SPACE_USER_ROLES_FETCH,
         spaceGuid: expectedGuid
       });
 
@@ -53,7 +53,7 @@ describe('UserStore', function () {
       const expectedGuid = 'axckzvjxcov';
 
       AppDispatcher.handleViewAction({
-        type: userActionTypes.SPACE_USERS_FETCH,
+        type: userActionTypes.SPACE_USER_ROLES_FETCH,
         spaceGuid: expectedGuid
       });
 
@@ -102,43 +102,9 @@ describe('UserStore', function () {
     });
   });
 
-  describe('on space or org users received', function() {
+  describe('on org users received', function() {
     it('should merge and update new users with existing users in data',
         function() {
-      var sharedGuid = 'wpqoifesadkzcvn';
-
-      let existingUser = { guid: sharedGuid, name: 'Michael' };
-      let newUser = { guid: sharedGuid, email: 'michael@gsa.gov' };
-
-      UserStore.push(existingUser);
-      expect(UserStore.get(sharedGuid)).toEqual(existingUser);
-
-      AppDispatcher.handleServerAction({
-        type: userActionTypes.SPACE_USERS_RECEIVED,
-        users: [newUser]
-      });
-
-      let actual = UserStore.get(sharedGuid);
-      expect(actual).toEqual({
-        guid: sharedGuid,
-        name: 'Michael',
-        email: 'michael@gsa.gov'
-      });
-    });
-
-    it('should add org and/or space guid to user', function() {
-      var user = { guid: 'adzxcv', name: 'Seymor' },
-          expectedGuid = 'a09dsfuva';
-
-      AppDispatcher.handleServerAction({
-        type: userActionTypes.SPACE_USERS_RECEIVED,
-        users: [user],
-        orgGuid: expectedGuid
-      });
-
-      let actual = UserStore.get(user.guid);
-
-      expect(actual.orgGuid).toEqual(expectedGuid);
     });
   });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -108,6 +108,64 @@ describe('UserStore', function () {
     });
   });
 
+  describe('on space user roles received', function() {
+    let expectedUsers;
+    const userGuidA = 'user-a';
+    const userGuidB = 'user-b';
+    const spaceGuid = 'space-123';
+
+    beforeEach(function() {
+      const spaceUserRoles = [
+        {
+          guid: userGuidA,
+          space_roles: [ 'space_developer' ]
+        },
+        {
+          guid: userGuidB,
+          space_roles: [ 'space_developer', 'space_manager' ]
+        }
+      ]
+      const currentUsers = [
+        {
+          guid: userGuidB,
+          roles: { [spaceGuid]: ['space_developer'] }
+        }
+      ];
+      expectedUsers = [
+        {
+          guid: userGuidA,
+          roles: { [spaceGuid]: ['space_developer'] }
+        },
+        {
+          guid: userGuidB,
+          roles: { [spaceGuid]: ['space_developer', 'space_manager'] }
+        }
+      ]
+
+      UserStore.push(currentUsers[0]);
+      sandbox.spy(UserStore, 'emitChange');
+
+      userActions.receivedSpaceUserRoles(spaceUserRoles, spaceGuid);
+    });
+
+    afterEach(function() {
+      UserStore._data = [];
+    });
+
+    it('should emit a change event', function() {
+      expect(UserStore.emitChange).toHaveBeenCalledOnce();
+    });
+
+    it('should add any new users', function() {
+      expect(UserStore.get(userGuidA)).toEqual(expectedUsers[0]);
+    });
+
+    it('should create a roles hash with space guid and all space roles', () => {
+      expect(UserStore.get(userGuidA)).toEqual(expectedUsers[0]);
+      expect(UserStore.get(userGuidB)).toEqual(expectedUsers[1]);
+    });
+  });
+
   describe('on org user roles received', function() {
     it('should emit a change event if data changed', function() {
       const spy = sandbox.spy(UserStore, 'emitChange');

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -279,6 +279,66 @@ describe('UserStore', function () {
     });
   });
 
+  describe('on user roles added', function() {
+    let user;
+    const userGuid = 'user-123';
+    const spaceGuid = 'space-123';
+    const addedRole = 'space_lord';
+    const existingRole = 'space_manager';
+    const otherOrgGuid = 'org-123';
+
+    describe('for new role', function() {
+      beforeEach(function() {
+        const existingUser = {
+          guid: userGuid,
+          roles: {
+            [spaceGuid]: [existingRole],
+            [otherOrgGuid]: ['org_manager']
+          }
+        };
+
+        UserStore._data = Immutable.fromJS([existingUser]);
+        sandbox.spy(UserStore, 'emitChange'),
+
+        userActions.addedUserRoles(addedRole, userGuid, spaceGuid, 'space');
+        user = UserStore.get(userGuid);
+      });
+
+      it('should emit a change event', function() {
+        expect(UserStore.emitChange).toHaveBeenCalledOnce();
+      });
+
+      it('should add the role for that org', function() {
+        expect(user.roles[spaceGuid]).toContain(addedRole);
+      });
+
+      it('should not change any other roles', function() {
+        expect(user.roles[spaceGuid]).toContain(existingRole);
+        expect(user.roles[otherOrgGuid]).toContain('org_manager');
+      });
+    });
+
+    describe('for a user with no existing space roles, somehow', function() {
+      beforeEach(function() {
+        const existingUser = {
+          guid: userGuid
+        }
+        UserStore._data = Immutable.fromJS([existingUser]);
+        sandbox.spy(UserStore, 'emitChange'),
+        userActions.addedUserRoles(addedRole, userGuid, spaceGuid, 'space');
+        user = UserStore.get(userGuid);
+      });
+
+      it('should emit a change event', function() {
+        expect(UserStore.emitChange).toHaveBeenCalledOnce();
+      });
+
+      it('should add the role for that org', function() {
+        expect(user.roles[spaceGuid]).toContain(addedRole);
+      });
+    });
+  });
+
   describe('on user roles deleted', function() {
     const testGuid = 'zxcvzxc';
     const expectedRole = 'org_dark_lord';

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -891,7 +891,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp('spaces'));
       expect(actual).toMatch(new RegExp('user_roles'));
       actual = spy.getCall(0).args[1];
-      expect(actual).toEqual(userActions.receivedSpaceUsers);
+      expect(actual).toEqual(userActions.receivedSpaceUserRoles);
       actual = spy.getCall(0).args[2];
       expect(actual).toEqual(expected);
     });

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -877,13 +877,13 @@ describe('cfApi', function() {
     });
   })
 
-  describe('fetchSpaceUsers()', function() {
+  describe('fetchSpaceUserRoles()', function() {
     it('should call fetch with spaces user roles url with space guid and the' +
        ' received space users action', function() {
       var expected = 'yyyybba1',
           spy = sandbox.stub(cfApi, 'fetchMany');
 
-      cfApi.fetchSpaceUsers(expected);
+      cfApi.fetchSpaceUserRoles(expected);
 
       expect(spy).toHaveBeenCalledOnce();
       let actual = spy.getCall(0).args[0];

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -357,7 +357,7 @@ export default {
    */
   fetchSpaceUserRoles(spaceGuid) {
     return this.fetchMany(`/spaces/${spaceGuid}/user_roles`,
-                          userActions.receivedSpaceUsers,
+                          userActions.receivedSpaceUserRoles,
                           spaceGuid);
   },
 

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -355,7 +355,7 @@ export default {
    *
    * @param {Number} spaceGuid - The guid of the space that the users belong to.
    */
-  fetchSpaceUsers(spaceGuid) {
+  fetchSpaceUserRoles(spaceGuid) {
     return this.fetchMany(`/spaces/${spaceGuid}/user_roles`,
                           userActions.receivedSpaceUsers,
                           spaceGuid);


### PR DESCRIPTION


Before:
The user objects in `UserStore` had two different data structures related to permissions:

1. The `organization_roles` / `space_roles` array with each role in the array
1. The `roles` object with an array of roles by org / space guid.

This is an example user object:

```js
{
  guid: 'asdflkja',
  organization_roles: ['org_manager'],
  roles: {
    'asdfkjlsdf': ['org_manager']
  }
}
```

The organization/space_roles property was used for displaying what roles a user had checked off on the org and space page. This array of roles was completely replaced each time a new org or space page was loaded, which lead to some potential bugs. The `roles` property with org/space guid was used to check the current user's role. This was incorrectly set based on prior assumptions about how CF api returned things.

This PR changes all role logic to use the 2nd, `roles` with org/space guid data structure. Additionally, it now uses this roles property to get all the users that belong to an org or space. Benefits of this:

- Keeps all role logic in one data structure rather then duplicate logic in different places which can easily get confusing.
- Fixes some bugs related to all users having org manager roles on all orgs. Fixes potential problems with user roles being set strangely based on space and org routes loading for users.