### PR TITLE
Fix tests with timing problems

### DIFF
--- a/static_src/test/functional/global_error.spec.js
+++ b/static_src/test/functional/global_error.spec.js
@@ -70,6 +70,7 @@ describe('Global error', function () {
         browser.refresh();
         globalErrorsElement = getErrorsComponent();
 
+        browser.waitForExist(BreadcrumbsElement.primarySelector);
         const breadcrumbsElement = new BreadcrumbsElement(
           browser,
           browser.element(BreadcrumbsElement.primarySelector)

--- a/static_src/test/functional/pageobjects/base.element.js
+++ b/static_src/test/functional/pageobjects/base.element.js
@@ -18,6 +18,7 @@ export default class BaseElement {
 
     let webElement = webElementOrSelector;
     if (typeof webElementOrSelector === 'string') {
+      browser.waitForExist(webElementOrSelector);
       webElement = browser.element(webElementOrSelector);
     }
 

--- a/static_src/test/functional/user_invite.spec.js
+++ b/static_src/test/functional/user_invite.spec.js
@@ -18,8 +18,6 @@ describe('User roles', function () {
       browser.waitForExist('.test-users');
       userRoleElement = new UserRoleElement(browser, browser.element('.test-users'));
       userRoleElement.setUserRole(cookieManagerOrgX);
-
-      expect(browser.isExisting('.test-users')).toBe(true);
     });
 
     it('should have the user invite panel', function () {

--- a/static_src/test/functional/user_role.spec.js
+++ b/static_src/test/functional/user_role.spec.js
@@ -84,6 +84,7 @@ describe('User roles', function () {
         });
 
         it('verify org Y manager cannot modify org X page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(false);
         });
       });
@@ -99,6 +100,7 @@ describe('User roles', function () {
         });
 
         it('verify org Y manager can modify org Y page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
         });
       });
@@ -120,6 +122,7 @@ describe('User roles', function () {
         });
 
         it('verify org X manager cannot modify org Y page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(false);
         });
       });
@@ -135,6 +138,7 @@ describe('User roles', function () {
         });
 
         it('verify org X manager can modify org X page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
         });
       });
@@ -210,6 +214,7 @@ describe('User roles', function () {
         });
 
         it('verify space manager org X space XX cannot modify space YY org X page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(false);
         });
       });
@@ -225,6 +230,7 @@ describe('User roles', function () {
         });
 
         it('verify space manager org X space XX can modify space XX org X page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
         });
       });
@@ -246,6 +252,7 @@ describe('User roles', function () {
         });
 
         it('verify org X manager cannot modify org Y page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(false);
         });
       });
@@ -262,6 +269,7 @@ describe('User roles', function () {
         });
 
         it('verify space manager org X space YY can modify space YY org X page', function () {
+          browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
         });
       });


### PR DESCRIPTION
At least locally. This is a quick fix, a better solution would
be to add more of these waits to shared funcitonality, such as
in the base element or in beforeEach places for each set of tests.