### PR TITLE
Fix user management

### DIFF
--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -62,9 +62,8 @@ export default class UserRoleListControl extends React.Component {
   _onChange(roleKey, checked) {
     const handler = (!checked) ? this.props.onRemovePermissions :
       this.props.onAddPermissions;
-    const resource = roleToResource[roleKey];
 
-    handler(resource, this.props.user.guid);
+    handler(roleKey, this.props.user.guid);
   }
 
   roles() {

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -22,15 +22,6 @@ const roleMapping = {
 
 };
 
-const roleToResource = {
-  org_manager: 'managers',
-  billing_manager: 'billing_managers',
-  org_auditor: 'auditors',
-  space_developer: 'developers',
-  space_manager: 'managers',
-  space_auditor: 'auditors'
-};
-
 const propTypes = {
   user: React.PropTypes.object.isRequired,
   userType: React.PropTypes.string,

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -110,9 +110,8 @@ export class UserStore extends BaseStore {
           updatedRoles.add(addedRole);
           user.roles[action.entityGuid] = Array.from(updatedRoles);
 
-          this.merge('guid', user, (changed) => {
-            if (changed) this.emitChange();
-          });
+          this.merge('guid', user, (changed) => {});
+          this.emitChange();
         }
 
         break;
@@ -138,9 +137,8 @@ export class UserStore extends BaseStore {
               roles.splice(idx, 1);
             }
           }
-          this.merge('guid', user, (changed) => {
-            if (changed) this.emitChange();
-          });
+          this.merge('guid', user, (changed) => {});
+          this.emitChange();
         }
         break;
       }

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -110,7 +110,7 @@ export class UserStore extends BaseStore {
           updatedRoles.add(addedRole);
           user.roles[action.entityGuid] = Array.from(updatedRoles);
 
-          this.merge('guid', user, (changed) => {});
+          this.merge('guid', user, () => {});
           this.emitChange();
         }
 
@@ -137,7 +137,7 @@ export class UserStore extends BaseStore {
               roles.splice(idx, 1);
             }
           }
-          this.merge('guid', user, (changed) => {});
+          this.merge('guid', user, () => {});
           this.emitChange();
         }
         break;

--- a/static_src/test/functional/pageobjects/user_role.element.js
+++ b/static_src/test/functional/pageobjects/user_role.element.js
@@ -52,4 +52,43 @@ export default class UserRoleElement extends BaseElement {
   isUserSpaceAuditor(guid) {
     return !!this.browser.getAttribute(`#space_auditor${guid}`, 'checked');
   }
+
+  toggleAccess(selector, state) {
+    this.browser.click(selector);
+    // waitForSelected's state parameter operates in reverse.
+    // if passed true, it will wait for it to be unchecked.
+    // if passed false, it will operate as normal and wait for it to be checked.
+    // http://webdriver.io/api/utility/waitForSelected.html
+    // just flip the state to what the user expected to get the behavior of
+    // which state waitForSelected looks for.
+    // returns true in success of finding whichever desired state.
+    // will never return false. instead, will throw an error.
+    // Sample of how it works:
+    // https://github.com/webdriverio/webdriverio/blob/v4.6.1/test/spec/waitFor.js#L58-L66
+    return this.browser.waitForSelected(selector, 2000, !state);
+  }
+
+  toggleOrgManagerAccess(guid, state) {
+    return this.toggleAccess(`#org_manager${guid}`, state);
+  }
+
+  toggleBillingManagerAccess(guid, state) {
+    return this.toggleAccess(`#billing_manager${guid}`, state);
+  }
+
+  toggleOrgAuditorAccess(guid, state) {
+    return this.toggleAccess(`#org_auditor${guid}`, state);
+  }
+
+  toggleSpaceManagerAccess(guid, state) {
+    return this.toggleAccess(`#space_manager${guid}`, state);
+  }
+
+  toggleSpaceDeveloperAccess(guid, state) {
+    return this.toggleAccess(`#space_developer${guid}`, state);
+  }
+
+  toggleSpaceAuditorAccess(guid, state) {
+    return this.toggleAccess(`#space_auditor${guid}`, state);
+  }
 }

--- a/static_src/test/functional/user_role.spec.js
+++ b/static_src/test/functional/user_role.spec.js
@@ -103,6 +103,18 @@ describe('User roles', function () {
           browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
         });
+
+        it('should give manager X all the permissions', function () {
+          expect(userRoleElement.toggleOrgManagerAccess(guidManagerOrgX, true)).toBe(true);
+          expect(userRoleElement.toggleBillingManagerAccess(guidManagerOrgX, true)).toBe(true);
+          expect(userRoleElement.toggleOrgAuditorAccess(guidManagerOrgX, true)).toBe(true);
+        });
+
+        it('should take all permissions from manager X', function () {
+          expect(userRoleElement.toggleOrgManagerAccess(guidManagerOrgX, false)).toBe(true);
+          expect(userRoleElement.toggleBillingManagerAccess(guidManagerOrgX, false)).toBe(true);
+          expect(userRoleElement.toggleOrgAuditorAccess(guidManagerOrgX, false)).toBe(true);
+        });
       });
     });
 
@@ -140,6 +152,18 @@ describe('User roles', function () {
         it('verify org X manager can modify org X page', function () {
           browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
+        });
+
+        it('should give manager Y all the permissions', function () {
+          expect(userRoleElement.toggleOrgManagerAccess(guidManagerOrgY, true)).toBe(true);
+          expect(userRoleElement.toggleBillingManagerAccess(guidManagerOrgY, true)).toBe(true);
+          expect(userRoleElement.toggleOrgAuditorAccess(guidManagerOrgY, true)).toBe(true);
+        });
+
+        it('should take all permissions from manager Y', function () {
+          expect(userRoleElement.toggleOrgManagerAccess(guidManagerOrgY, false)).toBe(true);
+          expect(userRoleElement.toggleBillingManagerAccess(guidManagerOrgY, false)).toBe(true);
+          expect(userRoleElement.toggleOrgAuditorAccess(guidManagerOrgY, false)).toBe(true);
         });
       });
     });
@@ -233,6 +257,26 @@ describe('User roles', function () {
           browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
         });
+
+        it('should give all the space permissions for org X space XX to the user ' +
+        'of the other space (org X space YY)', function () {
+          expect(userRoleElement.toggleSpaceManagerAccess(guidManagerOrgXSpaceYY, true))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceDeveloperAccess(guidManagerOrgXSpaceYY, true))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceAuditorAccess(guidManagerOrgXSpaceYY, true))
+            .toBe(true);
+        });
+
+        it('should take all space permissions from the the user of the other space ' +
+        '(org X space YY)', function () {
+          expect(userRoleElement.toggleSpaceManagerAccess(guidManagerOrgXSpaceYY, false))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceDeveloperAccess(guidManagerOrgXSpaceYY, false))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceAuditorAccess(guidManagerOrgXSpaceYY, false))
+            .toBe(true);
+        });
       });
     });
 
@@ -271,6 +315,26 @@ describe('User roles', function () {
         it('verify space manager org X space YY can modify space YY org X page', function () {
           browser.waitForExist('.test-user-role-control');
           expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
+        });
+
+        it('should give all the space permissions for org X space YY to the user ' +
+        'of the other space (org X space XX)', function () {
+          expect(userRoleElement.toggleSpaceManagerAccess(guidManagerOrgXSpaceXX, true))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceDeveloperAccess(guidManagerOrgXSpaceXX, true))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceAuditorAccess(guidManagerOrgXSpaceXX, true))
+            .toBe(true);
+        });
+
+        it('should take all space permissions from the the user of the other space ' +
+        '(org X space XX)', function () {
+          expect(userRoleElement.toggleSpaceManagerAccess(guidManagerOrgXSpaceXX, false))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceDeveloperAccess(guidManagerOrgXSpaceXX, false))
+            .toBe(true);
+          expect(userRoleElement.toggleSpaceAuditorAccess(guidManagerOrgXSpaceXX, false))
+            .toBe(true);
         });
       });
     });


### PR DESCRIPTION
The mapping in role control is no longer needed based on how actions work, so removed. This fixes issue where modifying a role doesn't work.

Speaking of which, there's many functional tests for modifying roles, why didn't any of them fail when the previous change broken them?