### PR TITLE
Do not allow role checkboxes to update in error cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "jasmine-sinon": "^0.4.0",
     "karma-jasmine-sinon": "^1.0.4",
     "lighthouse": "^1.6.3",
+    "moxios": "^0.4.0",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "selenium-standalone": "^5.11.0",

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -132,13 +132,7 @@ const userActions = {
       userGuid,
       entityGuid,
       roles
-    ).then(() => {
-      userActions.deletedUserRoles(
-        roles,
-        userGuid,
-        entityGuid,
-        entityType);
-    }).catch((err) => {
+    ).catch((err) => {
       window.console.error(err);
     });
   },

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -439,6 +439,26 @@ module.exports = function api(smocks) {
   });
 
   smocks.route({
+    id: 'user-roles-space-add-new-role',
+    label: 'User roles Space Add New role',
+    method: 'PUT',
+    path: `${BASE_URL}/spaces/{spaceGuid}/{role}/{userGuid}`,
+    handler: function (req, reply) {
+      reply(SingleResponse({}));
+    }
+  });
+
+  smocks.route({
+    id: 'user-roles-space-delete-role',
+    label: 'User roles Space Delete role',
+    method: 'DELETE',
+    path: `${BASE_URL}/spaces/{spaceGuid}/{role}/{userGuid}`,
+    handler: function (req, reply) {
+      reply(SingleResponse({}));
+    }
+  });
+
+  smocks.route({
     id: 'service-bindings',
     label: 'Service bindings',
     path: `${BASE_URL}/service_bindings`,

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -399,10 +399,10 @@ export default {
 
   deleteOrgUserPermissions(userGuid, orgGuid, permissions) {
     return http.delete(`${APIV}/organizations/${orgGuid}/${permissions}/${userGuid}`)
-      .then((res) =>
-        res.response
-      , (err) => {
-        userActions.errorRemoveUser(userGuid, err.data);
+      .then(() => {
+        userActions.deletedUserRoles(permissions, userGuid, orgGuid, 'organizations');
+      }, (err) => {
+        userActions.errorRemoveUser(userGuid, err.response.data);
       });
   },
 
@@ -414,9 +414,8 @@ export default {
 
   putSpaceUserPermissions(userGuid, spaceGuid, role) {
     return http.put(`${APIV}/spaces/${spaceGuid}/${role}/${userGuid}`)
-      .then((res) => res.response, () => {
-        // TODO figure out error action
-      });
+      .then((res) => res.response
+    );
   },
 
   postCreateNewUserWithGuid(userGuid) {
@@ -443,9 +442,11 @@ export default {
   // TODO refactor with org user permissions
   deleteSpaceUserPermissions(userGuid, spaceGuid, role) {
     return http.delete(`${APIV}/spaces/${spaceGuid}/${role}/${userGuid}`)
-      .then((res) => res.response, (err) => {
-        userActions.errorRemoveUser(userGuid, err.data);
-      });
+    .then(() => {
+      userActions.deletedUserRoles(role, userGuid, spaceGuid, 'spaces');
+    }, (err) => {
+      userActions.errorRemoveUser(userGuid, err.response.data);
+    });
   },
 
   fetchServicePlan(servicePlanGuid) {


### PR DESCRIPTION
Solves: https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-5842

The problem was that even though there was an error from trying to
associate/dissociate spaces roles or just dissociate org roles, the
checkboxes would still reflect because addedUserRoles / deletedUserRoles
actions would be called.

This PR moves addedUserRoles and deletedUserRoles to in another place in
the promise chain.
Now, after succeeding with deleteSpaceUserPermissions and
deleteOrgUserPermissions, the deletedUserRoles action is called in error
either, it will call errorRemoveUser (which will be used for raising
errors to UI)

The problem with the association of space roles was that it was not
passing the error back up like the org space association. This PR
mirrors that same behavior. (There is no errorAddUser action right now
so no need to call that.)

There are tests in this PR to test that in success cases addedUserRoles
and deletedUserRoles actions are called. Also the tests test to make
sure those actions are NOT called in the case of an error.

Also added moxios so that we can easily test the axios library. (it's by the same author)

Also, this fixes typos.