### PR TITLE
Fix org and space role association

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -73,7 +73,7 @@ const userActions = {
     });
   },
 
-  addUserRoles(roles, userGuid, entityGuid, entityType) {
+  addUserRoles(roles, apiKey, userGuid, entityGuid, entityType) {
     const apiMethodMap = {
       org: cfApi.putOrgUserPermissions,
       space: cfApi.putSpaceUserPermissions
@@ -91,7 +91,7 @@ const userActions = {
     return api(
       userGuid,
       entityGuid,
-      roles
+      apiKey
     ).then(() => {
       userActions.addedUserRoles(
         roles,
@@ -113,7 +113,7 @@ const userActions = {
     });
   },
 
-  deleteUserRoles(roles, userGuid, entityGuid, entityType) {
+  deleteUserRoles(roles, apiKey, userGuid, entityGuid, entityType) {
     const apiMethodMap = {
       org: cfApi.deleteOrgUserPermissions,
       space: cfApi.deleteSpaceUserPermissions
@@ -131,7 +131,8 @@ const userActions = {
     return api(
       userGuid,
       entityGuid,
-      roles
+      roles,
+      apiKey
     ).catch((err) => {
       window.console.error(err);
     });

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -83,15 +83,17 @@ export default class Users extends React.Component {
     userActions.deleteUser(userGuid, this.state.currentOrgGuid);
   }
 
-  handleAddPermissions(roleKey, userGuid) {
+  handleAddPermissions(roleKey, apiKey, userGuid) {
     userActions.addUserRoles(roleKey,
+                                apiKey,
                                 userGuid,
                                 this.entityGuid,
                                 this.entityType);
   }
 
-  handleRemovePermissions(roleKey, userGuid) {
+  handleRemovePermissions(roleKey, apiKey, userGuid) {
     userActions.deleteUserRoles(roleKey,
+                                apiKey,
                                 userGuid,
                                 this.entityGuid,
                                 this.entityType);

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -10,20 +10,6 @@ import BaseStore from './base_store.js';
 import cfApi from '../util/cf_api.js';
 import { userActionTypes } from '../constants.js';
 
-// TODO why is this role mapping needed?
-const resourceToRole = {
-  space: {
-    managers: 'space_manager',
-    developers: 'space_developer',
-    auditors: 'space_auditor'
-  },
-  org: {
-    managers: 'org_manager',
-    billing_managers: 'billing_manager',
-    auditors: 'org_auditor'
-  }
-};
-
 export class UserStore extends BaseStore {
   constructor() {
     super();
@@ -164,6 +150,7 @@ export class UserStore extends BaseStore {
         const orgPermissionsReq = cfApi.deleteOrgUserPermissions(
           action.userGuid,
           action.orgGuid,
+          'users',
           'users');
 
         orgPermissionsReq.then(() => {
@@ -287,14 +274,6 @@ export class UserStore extends BaseStore {
 
   getError() {
     return this._error;
-  }
-
-  getResourceToRole(resource, entityType) {
-    if (entityType !== 'space' && entityType !== 'org') {
-      throw new Error(`unknown resource type ${entityType}`);
-    }
-    const role = resourceToRole[entityType][resource] || resource;
-    return role;
   }
 
   get currentlyViewedType() {

--- a/static_src/test/server/api.js
+++ b/static_src/test/server/api.js
@@ -331,9 +331,18 @@ module.exports = function api(smocks) {
     path: `${BASE_URL}/organizations/{orgGuid}/{role}/{userGuid}`,
     handler: function (req, reply) {
       const orgGuid = req.params.orgGuid;
+      const role = req.params.role;
       const user = userRoleOrgAddNewRole(orgGuid);
-
-      reply(SingleResponse(user));
+      switch (role) {
+        case 'managers':
+        case 'auditors':
+        case 'billing_managers':
+        case 'users':
+          reply(SingleResponse(user));
+          break;
+        default:
+          reply().code(500);
+      }
     }
   });
 
@@ -343,7 +352,17 @@ module.exports = function api(smocks) {
     method: 'DELETE',
     path: `${BASE_URL}/organizations/{orgGuid}/{role}/{userGuid}`,
     handler: function (req, reply) {
-      reply(SingleResponse({}));
+      const role = req.params.role;
+      switch (role) {
+        case 'managers':
+        case 'auditors':
+        case 'billing_managers':
+        case 'users':
+          reply(SingleResponse({}));
+          break;
+        default:
+          reply().code(500);
+      }
     }
   });
 
@@ -444,7 +463,17 @@ module.exports = function api(smocks) {
     method: 'PUT',
     path: `${BASE_URL}/spaces/{spaceGuid}/{role}/{userGuid}`,
     handler: function (req, reply) {
-      reply(SingleResponse({}));
+      const role = req.params.role;
+      switch (role) {
+        case 'managers':
+        case 'auditors':
+        case 'developers':
+        case 'users':
+          reply(SingleResponse({}));
+          break;
+        default:
+          reply().code(500);
+      }
     }
   });
 
@@ -454,7 +483,17 @@ module.exports = function api(smocks) {
     method: 'DELETE',
     path: `${BASE_URL}/spaces/{spaceGuid}/{role}/{userGuid}`,
     handler: function (req, reply) {
-      reply(SingleResponse({}));
+      const role = req.params.role;
+      switch (role) {
+        case 'managers':
+        case 'auditors':
+        case 'developers':
+        case 'users':
+          reply(SingleResponse({}));
+          break;
+        default:
+          reply().code(500);
+      }
     }
   });
 

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -228,10 +228,13 @@ describe('userActions', function() {
     it(`should call a view action to add user roles with current roles
         user guid and guid and type`, function() {
       var expectedRole = 'org_manager',
+          expectedApiKey = 'managers',
           expectedUserGuid = 'akdfjadzxcvzxcvzxvzx',
           expectedGuid = '2eve2v2vadsfa',
           expectedType = 'org';
 
+      // expectedParams for the params dispatched with userActionTypes.USER_ROLES_ADD.
+      // the apiKey is not sent with it.
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
@@ -243,6 +246,7 @@ describe('userActions', function() {
 
       userActions.addUserRoles(
         expectedRole,
+        expectedApiKey,
         expectedUserGuid,
         expectedGuid,
         expectedType);
@@ -252,6 +256,7 @@ describe('userActions', function() {
 
     describe('for org user that successfully adds a user permission', function() {
       let roles;
+      let apiKey;
       let userGuid;
       let orgGuid;
 
@@ -259,6 +264,7 @@ describe('userActions', function() {
         sandbox.spy(cfApi, 'putOrgUserPermissions');
         sandbox.stub(userActions, 'addedUserRoles').returns(Promise.resolve());
         roles = ['org_manager'];
+        apiKey = 'managers';
         userGuid = 'user-123';
         orgGuid = 'org-123';
         moxios.wait(function() {
@@ -272,6 +278,7 @@ describe('userActions', function() {
 
         userActions.addUserRoles(
           roles,
+          apiKey,
           userGuid,
           orgGuid,
           'org'
@@ -283,7 +290,7 @@ describe('userActions', function() {
         expect(cfApi.putOrgUserPermissions).toHaveBeenCalledWith(sinon.match(
           userGuid,
           orgGuid,
-          roles
+          apiKey
         ));
       });
 
@@ -300,6 +307,7 @@ describe('userActions', function() {
 
     describe('for org user that unsuccessfully adds a user permission', function() {
       let roles;
+      let apiKey;
       let userGuid;
       let orgGuid;
 
@@ -307,6 +315,7 @@ describe('userActions', function() {
         sandbox.spy(cfApi, 'putOrgUserPermissions');
         sandbox.spy(userActions, 'addedUserRoles');
         roles = ['org_manager'];
+        apiKey = 'managers';
         userGuid = 'user-123';
         orgGuid = 'org-123';
         moxios.wait(function() {
@@ -321,6 +330,7 @@ describe('userActions', function() {
 
         userActions.addUserRoles(
           roles,
+          apiKey,
           userGuid,
           orgGuid,
           'org'
@@ -332,7 +342,7 @@ describe('userActions', function() {
         expect(cfApi.putOrgUserPermissions).toHaveBeenCalledWith(sinon.match(
           userGuid,
           orgGuid,
-          roles
+          apiKey
         ));
       });
 
@@ -343,6 +353,7 @@ describe('userActions', function() {
 
     describe('for space user that successfully adds a user permission', function() {
       let roles;
+      let apiKey;
       let userGuid;
       let spaceGuid;
 
@@ -350,6 +361,7 @@ describe('userActions', function() {
         sandbox.spy(cfApi, 'putSpaceUserPermissions');
         sandbox.stub(userActions, 'addedUserRoles').returns(Promise.resolve());
         roles = ['space_manager'];
+        apiKey = 'managers';
         userGuid = 'user-123';
         spaceGuid = 'space-123';
         moxios.wait(function() {
@@ -363,6 +375,7 @@ describe('userActions', function() {
 
         userActions.addUserRoles(
           roles,
+          apiKey,
           userGuid,
           spaceGuid,
           'space'
@@ -374,7 +387,7 @@ describe('userActions', function() {
         expect(cfApi.putSpaceUserPermissions).toHaveBeenCalledWith(sinon.match(
           userGuid,
           spaceGuid,
-          roles
+          apiKey
         ));
       });
     });
@@ -382,6 +395,7 @@ describe('userActions', function() {
 
   describe('for space user that unsuccessfully adds a user permission', function() {
     let roles;
+    let apiKey;
     let userGuid;
     let spaceGuid;
 
@@ -389,6 +403,7 @@ describe('userActions', function() {
       sandbox.spy(cfApi, 'putSpaceUserPermissions');
       sandbox.spy(userActions, 'addedUserRoles');
       roles = ['space_manager'];
+      apiKey = 'managers';
       userGuid = 'user-123';
       spaceGuid = 'space-123';
       moxios.wait(function() {
@@ -403,6 +418,7 @@ describe('userActions', function() {
 
       userActions.addUserRoles(
         roles,
+        apiKey,
         userGuid,
         spaceGuid,
         'space'
@@ -445,10 +461,13 @@ describe('userActions', function() {
     it(`should call a view action to remove user roles with current roles
         user guid and org guid and type`, function() {
       var expectedRole = 'org_manager',
+          expecctedApiKey = 'managers',
           expectedUserGuid = 'akdfjasdfjasdfadzxcvzxcvzxvzx',
           expectedGuid = '2eve2dsfa',
           expectedType = 'space';
 
+      // expectedParams for the params dispatched with userActionTypes.USER_ROLES_DELETE.
+      // the apiKey is not sent with it.
       let expectedParams = {
         roles: expectedRole,
         userGuid: expectedUserGuid,
@@ -460,6 +479,7 @@ describe('userActions', function() {
 
       userActions.deleteUserRoles(
         expectedRole,
+        expecctedApiKey,
         expectedUserGuid,
         expectedGuid,
         expectedType);
@@ -469,6 +489,7 @@ describe('userActions', function() {
 
     describe('for org user that successfully deletes a user permission', function() {
       let roles;
+      let apiKey;
       let userGuid;
       let orgGuid;
 
@@ -477,6 +498,7 @@ describe('userActions', function() {
         sandbox.spy(userActions, 'errorRemoveUser');
         sandbox.stub(userActions, 'deletedUserRoles').returns(Promise.resolve());
         roles = ['org_manager'];
+        apiKey = 'managers';
         userGuid = 'user-123';
         orgGuid = 'org-123';
         moxios.wait(function() {
@@ -490,6 +512,7 @@ describe('userActions', function() {
 
         userActions.deleteUserRoles(
           roles,
+          apiKey,
           userGuid,
           orgGuid,
           'org'
@@ -501,7 +524,8 @@ describe('userActions', function() {
         expect(cfApi.deleteOrgUserPermissions).toHaveBeenCalledWith(sinon.match(
           userGuid,
           orgGuid,
-          roles
+          roles,
+          apiKey
         ));
       });
 
@@ -522,6 +546,7 @@ describe('userActions', function() {
 
     describe('for org user that unsuccessfully deletes a user permission', function() {
       let roles;
+      let apiKey;
       let userGuid;
       let orgGuid;
 
@@ -530,6 +555,7 @@ describe('userActions', function() {
         sandbox.spy(userActions, 'deletedUserRoles');
         sandbox.stub(userActions, 'errorRemoveUser').returns(Promise.resolve());
         roles = ['org_manager'];
+        apiKey = 'managers';
         userGuid = 'user-123';
         orgGuid = 'org-123';
         moxios.wait(function() {
@@ -544,6 +570,7 @@ describe('userActions', function() {
 
         userActions.deleteUserRoles(
           roles,
+          apiKey,
           userGuid,
           orgGuid,
           'org'
@@ -555,7 +582,8 @@ describe('userActions', function() {
         expect(cfApi.deleteOrgUserPermissions).toHaveBeenCalledWith(sinon.match(
           userGuid,
           orgGuid,
-          roles
+          roles,
+          apiKey
         ));
       });
 
@@ -574,6 +602,7 @@ describe('userActions', function() {
 
     describe('for space user that successfully deletes a user permission', function() {
       let roles;
+      let apiKey;
       let userGuid;
       let spaceGuid;
 
@@ -582,6 +611,7 @@ describe('userActions', function() {
         sandbox.spy(userActions, 'errorRemoveUser');
         sandbox.stub(userActions, 'deletedUserRoles').returns(Promise.resolve());
         roles = ['space_manager'];
+        apiKey = 'managers';
         userGuid = 'user-123';
         spaceGuid = 'space-123';
         moxios.wait(function() {
@@ -595,6 +625,7 @@ describe('userActions', function() {
 
         userActions.deleteUserRoles(
           roles,
+          apiKey,
           userGuid,
           spaceGuid,
           'space'
@@ -606,7 +637,8 @@ describe('userActions', function() {
         expect(cfApi.deleteSpaceUserPermissions).toHaveBeenCalledWith(sinon.match(
           userGuid,
           spaceGuid,
-          roles
+          roles,
+          apiKey
         ));
       });
 
@@ -628,6 +660,7 @@ describe('userActions', function() {
 
   describe('for space user that unsuccessfully deletes a user permission', function() {
     let roles;
+    let apiKey;
     let userGuid;
     let spaceGuid;
 
@@ -636,6 +669,7 @@ describe('userActions', function() {
       sandbox.spy(userActions, 'deletedUserRoles');
       sandbox.stub(userActions, 'errorRemoveUser').returns(Promise.resolve());
       roles = ['space_manager'];
+      apiKey = 'managers';
       userGuid = 'user-123';
       spaceGuid = 'space-123';
       moxios.wait(function() {
@@ -650,6 +684,7 @@ describe('userActions', function() {
 
       userActions.deleteUserRoles(
         roles,
+        apiKey,
         userGuid,
         spaceGuid,
         'space'
@@ -661,7 +696,8 @@ describe('userActions', function() {
       expect(cfApi.deleteSpaceUserPermissions).toHaveBeenCalledWith(sinon.match(
         userGuid,
         spaceGuid,
-        roles
+        roles,
+        apiKey
       ));
     });
 

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -289,6 +289,7 @@ describe('UserStore', function () {
         function() {
       var spy = sandbox.stub(cfApi, 'putOrgUserPermissions'),
           expectedRoles = 'org_manager',
+          expectedApiKey = 'managers',
           expectedUserGuid = 'zjkxcvadfzxcvz',
           expectedOrgGuid = 'zxcvzcxvzxroiter';
 
@@ -297,6 +298,7 @@ describe('UserStore', function () {
 
       userActions.addUserRoles(
         expectedRoles,
+        expectedApiKey,
         expectedUserGuid,
         expectedOrgGuid,
         'org'
@@ -306,7 +308,7 @@ describe('UserStore', function () {
       let args = spy.getCall(0).args;
       expect(args[0]).toEqual(expectedUserGuid);
       expect(args[1]).toEqual(expectedOrgGuid);
-      expect(args[2]).toEqual(expectedRoles);
+      expect(args[2]).toEqual(expectedApiKey);
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -1001,17 +1001,19 @@ describe('cfApi', function() {
       var spy = sandbox.stub(http, 'delete').returns(Promise.resolve({})),
           expectedUserGuid = 'zvmxncznv-9u8qwphu',
           expectedOrgGuid = '0291kdvakjbdfvhp',
-          expectedPermission = 'manager';
+          expectedPermission = 'manager',
+          expectedApiKey = 'managers';
 
       cfApi.deleteOrgUserPermissions(
         expectedUserGuid,
         expectedOrgGuid,
-        expectedPermission).then(() => {
+        expectedPermission,
+        expectedApiKey).then(() => {
           expect(spy).toHaveBeenCalledOnce();
           let actual = spy.getCall(0).args[0];
           expect(actual).toMatch(new RegExp(expectedUserGuid));
           expect(actual).toMatch(new RegExp(expectedOrgGuid));
-          expect(actual).toMatch(new RegExp(expectedPermission));
+          expect(actual).toMatch(new RegExp(expectedApiKey));
           done();
         }).catch(done.fail);
     });
@@ -1020,22 +1022,22 @@ describe('cfApi', function() {
         message about the error from cf`, function(done) {
       var spy = sandbox.spy(userActions, 'errorRemoveUser'),
           expectedUserGuid = 'zcvmzxncbvpafd',
-          expectedRespone = {
+          expectedResponse = {
             code: 10006,
             description: 'Please delete the user associations for your spaces',
             error_code: 'CF-AssociationNotEmpty'
           };
-      moxios.stubOnce('DELETE', `/v2/organizations/asdf/role/${expectedUserGuid}`, {
+      moxios.stubOnce('DELETE', `/v2/organizations/asdf/apiKey/${expectedUserGuid}`, {
         status: 400,
-        response: expectedRespone
+        response: expectedResponse
       });
 
-      cfApi.deleteOrgUserPermissions(expectedUserGuid, 'asdf', 'role').then(
+      cfApi.deleteOrgUserPermissions(expectedUserGuid, 'asdf', 'role', 'apiKey').then(
         () => {
         expect(spy).toHaveBeenCalledOnce();
         let args = spy.getCall(0).args;
         expect(args[0]).toEqual(expectedUserGuid);
-        expect(args[1]).toEqual(expectedRespone);
+        expect(args[1]).toEqual(expectedResponse);
         done();
       }).catch(done.fail);
     });

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -397,8 +397,8 @@ export default {
       /${userGuid}`);
   },
 
-  deleteOrgUserPermissions(userGuid, orgGuid, permissions) {
-    return http.delete(`${APIV}/organizations/${orgGuid}/${permissions}/${userGuid}`)
+  deleteOrgUserPermissions(userGuid, orgGuid, permissions, apiKey) {
+    return http.delete(`${APIV}/organizations/${orgGuid}/${apiKey}/${userGuid}`)
       .then(() => {
         userActions.deletedUserRoles(permissions, userGuid, orgGuid, 'organizations');
       }, (err) => {
@@ -440,8 +440,8 @@ export default {
   },
 
   // TODO refactor with org user permissions
-  deleteSpaceUserPermissions(userGuid, spaceGuid, role) {
-    return http.delete(`${APIV}/spaces/${spaceGuid}/${role}/${userGuid}`)
+  deleteSpaceUserPermissions(userGuid, spaceGuid, role, apiKey) {
+    return http.delete(`${APIV}/spaces/${spaceGuid}/${apiKey}/${userGuid}`)
     .then(() => {
       userActions.deletedUserRoles(role, userGuid, spaceGuid, 'spaces');
     }, (err) => {


### PR DESCRIPTION
### First commit: Fix functional test server to check for correct roles
This modification makes sure that all requests to do
association/dissociation of roles use the right api key for the role.

This will break tests because currently the code doesn't use the right
api key for role modification but will be fixed in following commits.

### Other commits: fixing the api calls and tests