### PR TITLE
Update README and env.sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Learn more about [cloud.gov](https://cloud.gov).
 The Go backend isn't strictly required for all development. Consider [running locally with node](#run-locally-without-needing-go) if you will not be doing primary feature work where you need access to the actual Cloud Foundry API.
 
 #### Cloning the repository
-If you are unfamiliar with [`Go` project directory structure](https://golang.org/doc/code.html#Workspaces), you want the code in this repository to be in something like `<your-code-directory>/cg-dashboard-ws/src/github.com/18f/cg-dashboard`. You can use that exact pattern by cloning the repository with:
+If you are unfamiliar with [`Go` project directory structure](https://golang.org/doc/code.html#Workspaces), you want the code in this repository to be in something like `<your-code-directory>/src/github.com/18f/cg-dashboard`. You can use that exact pattern by cloning the repository with:
 
 ```
-git clone git@github.com:18F/cg-dashboard.git cg-dashboard-ws/src/github.com/18F/cg-dashboard
+git clone git@github.com:18F/cg-dashboard.git src/github.com/18F/cg-dashboard
 ```
 
 #### Set the environment variables
@@ -43,7 +43,7 @@ If you are testing locally, export these variables. There is a sample file of en
 
 Then edit the file `~/.env/cg-dashboard` and provide the proper values. When you want to set all the environment variables, just run `source ~/.env/cg-dashboard`. You'll have to do this every time you open a new shell. If you work at 18F, ask a team member to send you the secret credentials.
 
-- `GOPATH`: The absolute path to your project root. If you followed the cloning instructions above, this path should end with `cg-dashboard-ws`
+- `GOPATH`: The absolute path to your code directory, one level up from the root of this project. If you followed the cloning instructions above, this path should correspond to the value you used for `<your-code-directory>`.
 - `CONSOLE_CLIENT_ID`: Registered client id with UAA.
 - `CONSOLE_CLIENT_SECRET`: The client secret.
 - `CONSOLE_HOSTNAME`: The URL of the service itself.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![CircleCI](https://circleci.com/gh/18F/cg-dashboard.svg?style=svg)](https://circleci.com/gh/18F/cg-dashboard)
 [![Code Climate](https://codeclimate.com/github/18F/cg-dashboard/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-dashboard)
 
-Environments: [Production](https://dashboard.cloud.gov)
-[Staging](https://dashboard-staging.apps.cloud.gov)
-[Demo](https://dashboard-demo.apps.cloud.gov)
+Environments: [Production](https://dashboard.fr.cloud.gov)
+[Staging](https://dashboard-staging.fr.app.cloud.gov)
+[Demo](https://dashboard-demo.fr.app.cloud.gov)
 
 
 ## Introduction

--- a/env.sample
+++ b/env.sample
@@ -50,3 +50,12 @@ export SMTP_USER=
 
 # The SMTP PASS
 export SMTP_PASS=
+
+# The FROM Address for email
+export SMTP_FROM='no-reply@cloud.gov'
+
+# The New Relic ID
+export NEW_RELIC_ID=12345
+
+# The New Relic Browser License ID
+export NEW_RELIC_BROWSER_LICENSE_KEY=abcdef

--- a/env.sample
+++ b/env.sample
@@ -12,16 +12,16 @@ export CONSOLE_CLIENT_SECRET=
 export CONSOLE_HOSTNAME=http://localhost:9999
 
 # The base URL of the auth service.
-export CONSOLE_LOGIN_URL=https://login.cloud.gov
+export CONSOLE_LOGIN_URL=https://login.fr.cloud.gov
 
 # The URL of the UAA service.
-export CONSOLE_UAA_URL=https://uaa.cloud.gov
+export CONSOLE_UAA_URL=https://uaa.fr.cloud.gov
 
 # The URL of the API service.
-export CONSOLE_API_URL=https://api.cloud.gov
+export CONSOLE_API_URL=https://api.fr.cloud.gov
 
 # The URL of the loggregator service.
-export CONSOLE_LOG_URL=https://loggregator.cloud.gov
+export CONSOLE_LOG_URL=https://loggregator.fr.cloud.gov
 
 # The key used to protect session data
 export SESSION_KEY=GONMwryeLTC7a3sRjjDi


### PR DESCRIPTION
This PR:
* Updates the example values in `env.sample` from `[*].cloud.gov` to `[*].fr.cloud.gov`,
* Updates the recommended GOPATH value and repository locations, as the current instructions are derived from an older version of Go, and
* Updates the README's listed environments to their new GovCloud locations.