### PR TITLE
Break a >100-character line into two <=100-character lines

### DIFF
--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -63,7 +63,8 @@ export default class UsersInvite extends React.Component {
       content = (
         <div>
           <PanelDocumentation description>
-            <p>Invite new user to cloud.gov and this organization, or add an existing user to this organization.</p>
+            <p>Invite new user to cloud.gov and this organization, or add an existing user to this
+            organization.</p>
           </PanelDocumentation>
           <Form
             guid={ USERS_INVITE_FORM_GUID }


### PR DESCRIPTION
Fixes an error thrown by `npm run lint`. Evidently the linter dislikes lines that contain more than 100 characters.

