### PR TITLE
Display UI error when user attempts to add/remove a roles without proper permissions

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -101,9 +101,7 @@ const userActions = {
         userGuid,
         entityGuid,
         entityType);
-    }).catch((err) => {
-      window.console.error(err);
-    });
+    }).catch(error => this.errorChangeUserRole(error));
   },
 
   addedUserRoles(roles, userGuid, entityGuid, entityType) {
@@ -136,9 +134,7 @@ const userActions = {
       entityGuid,
       roles,
       apiKey
-    ).catch((err) => {
-      window.console.error(err);
-    });
+    ).catch(err => this.errorChangeUserRole(error));
   },
 
   deletedUserRoles(roles, userGuid, entityGuid, entityType) {
@@ -148,6 +144,16 @@ const userActions = {
       userGuid,
       entityGuid,
       entityType
+    });
+  },
+
+  errorChangeUserRole(error) {
+    const message = `You don't have permission to perform that action`
+
+    AppDispatcher.handleViewAction({
+      type: userActionTypes.USER_ROLE_CHANGE_ERROR,
+      error,
+      message
     });
   },
 

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -134,7 +134,7 @@ const userActions = {
       entityGuid,
       roles,
       apiKey
-    ).catch(err => this.errorChangeUserRole(error));
+    ).catch(error => this.errorChangeUserRole(error));
   },
 
   deletedUserRoles(roles, userGuid, entityGuid, entityType) {
@@ -148,7 +148,7 @@ const userActions = {
   },
 
   errorChangeUserRole(error) {
-    const message = `You don't have permission to perform that action`
+    const message = 'You don\'t have permission to perform that action';
 
     AppDispatcher.handleViewAction({
       type: userActionTypes.USER_ROLE_CHANGE_ERROR,

--- a/static_src/components/error_message.jsx
+++ b/static_src/components/error_message.jsx
@@ -22,18 +22,14 @@ const defaultProps = {
 export default class ErrorMessage extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
     this.styler = createStyler(style);
   }
 
   get errorMessage() {
-    const err = this.props.error;
-    return err && err.message || err.description;
-  }
+    const { error } = this.props;
+    const message = error && error.message || error.description;
 
-  get hasErrorMessage() {
-    const message = this.errorMessage;
-    return message && message.length;
+    return message ? this.knownMessage(message) : this.shortDefaultMessage;
   }
 
   get statusCode() {
@@ -49,23 +45,23 @@ export default class ErrorMessage extends React.Component {
     );
   }
 
-  get knownMessage() {
-    return (<span>The system returned an error, { this.errorMessage }. Please
-      try again.</span>);
+  knownMessage(message) {
+    return `The system returned an error, ${message}. Please
+      try again`;
   }
 
   render() {
-    const typeClass = `error-${this.props.displayType}`;
-    let content = <span>{ this.shortDefaultMessage }</span>;
+    const { displayType, error } = this.props;
+    const typeClass = `error-${displayType}`;
 
-    if (this.hasErrorMessage) {
-      content = <span>{ this.knownMessage }</span>;
+    if (!error) {
+      return null;
     }
 
     return (
-    <div className={ this.styler('error_message', typeClass) }>
-      { content }
-    </div>
+      <div className={ this.styler('error_message', typeClass) } role="alert">
+        { this.errorMessage }
+      </div>
     );
   }
 }

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -4,6 +4,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import overrideStyle from '../css/overrides.css';
 
 import createStyler from '../util/create_styler';
+import userProvider from './user_provider.jsx';
 
 import Disclaimer from './disclaimer.jsx';
 import Footer from './footer.jsx';
@@ -23,7 +24,7 @@ function stateSetter() {
   };
 }
 
-export default class App extends React.Component {
+class App extends React.Component {
   constructor(props) {
     super(props);
     this.styler = createStyler(style, overrideStyle);
@@ -69,7 +70,8 @@ export default class App extends React.Component {
       </div>
     );
   }
-}
+};
+
 App.propTypes = {
   children: React.PropTypes.any
 };
@@ -77,3 +79,5 @@ App.propTypes = {
 App.defaultProps = {
   children: []
 };
+
+export default userProvider(App);

--- a/static_src/components/user_provider.jsx
+++ b/static_src/components/user_provider.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import UserStore from '../stores/user_store.js';
+
+const userProvider = Component => {
+  class UserProvider extends React.Component {
+    getChildContext() {
+      return { currentUser: this.state.currentUser };
+    }
+
+    constructor(props) {
+      super(props);
+
+      this.state = { currentUser: null };
+      this.onChange = this.onChange.bind(this);
+    }
+
+    componentDidMount() {
+      UserStore.addChangeListener(this.onChange);
+    }
+
+    componentWillUnmount() {
+      UserStore.removeChangeListener(this.onChange)
+    }
+
+    onChange() {
+      this.setState({
+        currentUser: UserStore.currentUser
+      })
+    }
+
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+
+  UserProvider.childContextTypes = {
+    currentUser: React.PropTypes.object
+  };
+
+  return UserProvider;
+};
+
+export default userProvider;

--- a/static_src/components/user_provider.jsx
+++ b/static_src/components/user_provider.jsx
@@ -3,10 +3,6 @@ import UserStore from '../stores/user_store.js';
 
 const userProvider = Component => {
   class UserProvider extends React.Component {
-    getChildContext() {
-      return { currentUser: this.state.currentUser };
-    }
-
     constructor(props) {
       super(props);
 
@@ -14,22 +10,26 @@ const userProvider = Component => {
       this.onChange = this.onChange.bind(this);
     }
 
+    getChildContext() {
+      return { currentUser: this.state.currentUser };
+    }
+
     componentDidMount() {
       UserStore.addChangeListener(this.onChange);
     }
 
     componentWillUnmount() {
-      UserStore.removeChangeListener(this.onChange)
+      UserStore.removeChangeListener(this.onChange);
     }
 
     onChange() {
       this.setState({
         currentUser: UserStore.currentUser
-      })
+      });
     }
 
     render() {
-      return <Component {...this.props} />
+      return <Component {...this.props} />;
     }
   }
 

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -10,7 +10,7 @@ const propTypes = {
   onChange: React.PropTypes.func
 };
 
-const warningMessage = `Performing this action will remove your ability to adjust user's roles! Are you sure you want to continue?`;
+const warningMessage = 'Performing this action will remove your ability to adjust user\'s roles! Are you sure you want to continue?';
 
 export default class UserRoleControl extends React.Component {
   constructor(props, context) {

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -23,17 +23,17 @@ export default class UserRoleControl extends React.Component {
 
   userSelfRemovingOrgManager(role, removing) {
     const { userId } = this.props;
-    const { currentUser: { user_id: { currentUserId } } } = this.context;
+    const currentUserId = this.context.currentUser.user_id;
 
     return userId === currentUserId && role === dangerousRole && removing;
   }
 
   _handleChange(ev) {
     const { roleKey, onChange } = this.props;
-    const { checked, name: { role } } = ev.target;
+    const { checked, name } = ev.target;
     let shouldContinue = true;
 
-    if (this.userSelfRemovingOrgManager(role, checked)) {
+    if (this.userSelfRemovingOrgManager(name, !checked)) {
       shouldContinue = window.confirm(warningMessage);
     }
 
@@ -68,6 +68,7 @@ export default class UserRoleControl extends React.Component {
 UserRoleControl.contextTypes = {
   currentUser: React.PropTypes.object
 };
+
 UserRoleControl.propTypes = propTypes;
 UserRoleControl.defaultProps = {
   initialValue: false,

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -1,22 +1,20 @@
 
 import React from 'react';
 
+const propTypes = {
+  userId: React.PropTypes.string.isRequired,
+  roleName: React.PropTypes.string.isRequired,
+  roleKey: React.PropTypes.string.isRequired,
+  initialValue: React.PropTypes.bool,
+  initialEnableControl: React.PropTypes.bool,
+  onChange: React.PropTypes.func
+};
+
 export default class UserRoleControl extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
-    this.state = {
-      checked: props.initialValue,
-      enableControl: props.initialEnableControl
-    };
-    this._handleChange = this._handleChange.bind(this);
-  }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      checked: nextProps.initialValue,
-      enableControl: nextProps.initialEnableControl
-    });
+    this._handleChange = this._handleChange.bind(this);
   }
 
   _handleChange(ev) {
@@ -24,31 +22,31 @@ export default class UserRoleControl extends React.Component {
   }
 
   render() {
+    const {
+      roleKey, roleName, userId, initialValue, initialEnableControl
+    } = this.props;
+    const inputId = roleKey + userId;
+
     return (
       <span className="test-user-role-control">
-        <label htmlFor={ this.props.roleKey + this.props.userId }>
+        <label htmlFor={ inputId }>
           <input type="checkbox"
             onChange={ this._handleChange }
-            name={ this.props.roleKey }
-            checked={ this.state.checked }
-            disabled={ !this.state.enableControl }
-            id={ this.props.roleKey + this.props.userId }
+            name={ roleKey }
+            checked={ initialValue }
+            disabled={ !initialEnableControl }
+            id={ inputId }
           />
-          { this.props.roleName }
+          { roleName }
         </label>
       </span>
     );
   }
-}
-UserRoleControl.propTypes = {
-  roleName: React.PropTypes.string.isRequired,
-  roleKey: React.PropTypes.string.isRequired,
-  initialValue: React.PropTypes.bool,
-  initialEnableControl: React.PropTypes.bool,
-  onChange: React.PropTypes.func
 };
+
+UserRoleControl.propTypes = propTypes;
 UserRoleControl.defaultProps = {
   initialValue: false,
   initialEnableControl: false,
   onChange: function() { }
-}
+};

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -10,16 +10,26 @@ const propTypes = {
   onChange: React.PropTypes.func
 };
 
+const warningMessage = `Performing this action will remove your ability to adjust user's roles! Are you sure you want to continue?`;
+
 export default class UserRoleControl extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor(props, context) {
+    super(props, context);
 
     this._handleChange = this._handleChange.bind(this);
   }
 
   _handleChange(ev) {
     const { roleKey, onChange } = this.props;
-    onChange(roleKey, ev.target.checked);
+    let shouldContinue = true;
+
+    if (this.props.userId === this.context.currentUser.user_id) {
+      shouldContinue = window.confirm(warningMessage);
+    }
+
+    if (shouldContinue) {
+      onChange(roleKey, ev.target.checked);
+    }
   }
 
   render() {
@@ -45,6 +55,9 @@ export default class UserRoleControl extends React.Component {
   }
 };
 
+UserRoleControl.contextTypes = {
+  currentUser: React.PropTypes.object
+};
 UserRoleControl.propTypes = propTypes;
 UserRoleControl.defaultProps = {
   initialValue: false,

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -18,7 +18,8 @@ export default class UserRoleControl extends React.Component {
   }
 
   _handleChange(ev) {
-    this.props.onChange(ev.target.checked);
+    const { roleKey, onChange } = this.props;
+    onChange(roleKey, ev.target.checked);
   }
 
   render() {

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -10,6 +10,8 @@ const propTypes = {
   onChange: React.PropTypes.func
 };
 
+const dangerousRole = 'org_manager';
+
 const warningMessage = 'Performing this action will remove your ability to adjust user\'s roles! Are you sure you want to continue?';
 
 export default class UserRoleControl extends React.Component {
@@ -19,16 +21,24 @@ export default class UserRoleControl extends React.Component {
     this._handleChange = this._handleChange.bind(this);
   }
 
+  userSelfRemovingOrgManager(role, removing) {
+    const { userId } = this.props;
+    const { currentUser: { user_id: { currentUserId } } } = this.context;
+
+    return userId === currentUserId && role === dangerousRole && removing;
+  }
+
   _handleChange(ev) {
     const { roleKey, onChange } = this.props;
+    const { checked, name: { role } } = ev.target;
     let shouldContinue = true;
 
-    if (this.props.userId === this.context.currentUser.user_id) {
+    if (this.userSelfRemovingOrgManager(role, checked)) {
       shouldContinue = window.confirm(warningMessage);
     }
 
     if (shouldContinue) {
-      onChange(roleKey, ev.target.checked);
+      onChange(roleKey, checked);
     }
   }
 

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -65,25 +65,24 @@ const defaultProps = {
 export default class UserRoleListControl extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this._onChange = this._onChange.bind(this);
-    this.checkRole = this.checkRole.bind(this);
   }
 
   checkRole(roleKey) {
     return (this.roles().indexOf(roleKey) > -1);
   }
 
-  _onChange(roleKey, apiKey, checked) {
-    const handler = (!checked) ? this.props.onRemovePermissions :
+  _onChange(roleKey, checked) {
+    const handler = !checked ? this.props.onRemovePermissions :
       this.props.onAddPermissions;
+    const apiKey = this.roleMap.filter(role => role.key === roleKey)[0].apiKey;
 
     handler(roleKey, apiKey, this.props.user.guid);
   }
 
   roles() {
     const roles = this.props.user.roles;
-    if (!roles) return [];
     return roles ?
       (roles[this.props.entityGuid] || []) :
       []
@@ -92,7 +91,6 @@ export default class UserRoleListControl extends React.Component {
   get roleMap() {
     return roleMapping[this.props.userType];
   }
-
 
   render() {
     return (
@@ -105,7 +103,7 @@ export default class UserRoleListControl extends React.Component {
               roleKey={ role.key }
               initialValue={ this.checkRole(role.key) }
               initialEnableControl={ this.props.currentUserAccess }
-              onChange={ this._onChange.bind(this, role.key, role.apiKey) }
+              onChange={ this._onChange }
               userId={ this.props.user.guid }
             />
           </ElasticLineItem>
@@ -114,6 +112,7 @@ export default class UserRoleListControl extends React.Component {
       </span>
     );
   }
-}
+};
+
 UserRoleListControl.propTypes = propTypes;
 UserRoleListControl.defaultProps = defaultProps;

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -43,7 +43,6 @@ const roleMapping = {
     { key: 'billing_manager', apiKey: 'billing_managers', label: 'Billing Manager' },
     { key: 'org_auditor', apiKey: 'auditors', label: 'Org Auditor' }
   ]
-
 };
 
 const propTypes = {

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -14,6 +14,8 @@ import UsersInvite from './users_invite.jsx';
 import Notification from './notification.jsx';
 import UserStore from '../stores/user_store.js';
 
+import ErrorMessage from './error_message.jsx';
+
 const SPACE_NAME = SpaceStore.cfName;
 const ORG_NAME = OrgStore.cfName;
 
@@ -120,7 +122,6 @@ export default class Users extends React.Component {
 
   render() {
     let removeHandler;
-    let errorMessage;
 
     if (this.state.currentType === ORG_NAME) {
       removeHandler = this.handleRemove;
@@ -139,14 +140,6 @@ export default class Users extends React.Component {
       onRemovePermissions={ this.handleRemovePermissions }
     />);
 
-    if (this.state.error) {
-      // TODO make this an error message component
-      errorMessage = (
-        <div className="alert alert-danger" role="alert">
-          { this.state.error.description }</div>
-      );
-    }
-
     let notification;
     let userInvite;
 
@@ -164,6 +157,7 @@ export default class Users extends React.Component {
 
     if (this.state.currentType === ORG_NAME) {
       userInvite = (
+      <div className="test-users">
         <UsersInvite
           inviteDisabled={ this.state.inviteDisabled }
           currentUserAccess={ this.state.currentUserAccess }
@@ -174,7 +168,7 @@ export default class Users extends React.Component {
 
     return (
       <div className="test-users">
-        { errorMessage }
+        <ErrorMessage error={this.state.error} />
         { userInvite }
         { notification }
         <div>

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -157,12 +157,13 @@ export default class Users extends React.Component {
 
     if (this.state.currentType === ORG_NAME) {
       userInvite = (
-      <div className="test-users">
-        <UsersInvite
-          inviteDisabled={ this.state.inviteDisabled }
-          currentUserAccess={ this.state.currentUserAccess }
-          error={ this.state.userInviteError }
-        />
+        <div className="test-users">
+          <UsersInvite
+            inviteDisabled={ this.state.inviteDisabled }
+            currentUserAccess={ this.state.currentUserAccess }
+            error={ this.state.userInviteError }
+          />
+        </div>
       );
     }
 

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -252,6 +252,7 @@ const userActionTypes = keymirror({
   USER_ROLES_DELETE: null,
   // Action when user roles are deleted on the server.
   USER_ROLES_DELETED: null,
+  USER_ROLE_CHANGE_ERROR: null,
   // Action to request an invite link from UAA, with user GUID.
   USER_INVITE_TRIGGER: null,
   // Action to trigger when invite status is triggered for front end.

--- a/static_src/constants.js
+++ b/static_src/constants.js
@@ -252,6 +252,7 @@ const userActionTypes = keymirror({
   USER_ROLES_DELETE: null,
   // Action when user roles are deleted on the server.
   USER_ROLES_DELETED: null,
+  // Action when there is an error changing a user's role
   USER_ROLE_CHANGE_ERROR: null,
   // Action to request an invite link from UAA, with user GUID.
   USER_INVITE_TRIGGER: null,

--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -188,6 +188,14 @@ export class UserStore extends BaseStore {
         break;
       }
 
+      case userActionTypes.USER_ROLE_CHANGE_ERROR: {
+        this._error = Object.assign({}, action.error, {
+          description: action.message
+        });
+        this.emitChange();
+        break;
+      }
+
       case userActionTypes.USER_INVITE_STATUS_DISPLAYED: {
         this._inviteDisabled = false;
         const noticeType = action.noticeType;

--- a/static_src/test/functional/user_role.spec.js
+++ b/static_src/test/functional/user_role.spec.js
@@ -166,6 +166,24 @@ describe('User roles', function () {
           expect(userRoleElement.toggleBillingManagerAccess(guidManagerOrgY, false)).toBe(true);
           expect(userRoleElement.toggleOrgAuditorAccess(guidManagerOrgY, false)).toBe(true);
         });
+
+        describe('alerts when toggling user\s own org manager role', function () {
+          beforeEach(function () {
+            browser.click(`#org_manager${guidManagerOrgX}`);
+          });
+
+          it('should not toggle role when alert is dismissed', function () {
+            browser.alertDismiss();
+
+            expect(userRoleElement.isFirstUserRoleEnabled()).toBe(true);
+          });
+
+          it('should toggle role when alert is accepted', function () {
+            browser.alertAccept();
+
+            expect(userRoleElement.isFirstUserRoleEnabled()).toBe(false);
+          });
+        });
       });
     });
 

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -401,6 +401,7 @@ describe('userActions', function() {
       beforeEach(function(done) {
         sandbox.spy(cfApi, 'putOrgUserPermissions');
         sandbox.spy(userActions, 'addedUserRoles');
+        sandbox.spy(userActions, 'errorChangeUserRole');
         roles = ['org_manager'];
         apiKey = 'managers';
         userGuid = 'user-123';
@@ -433,8 +434,12 @@ describe('userActions', function() {
         ));
       });
 
-      it('should not call addedUserRoles action', function() {
+      it('should not call addedUserRoles action', () => {
         expect(userActions.addedUserRoles.called).toEqual(false);
+      });
+
+      it('should call `errorChangeUserRole`', () => {
+        expect(userActions.errorChangeUserRole.called).toEqual(true);
       });
     });
 


### PR DESCRIPTION
* Outputs error message via UI when user attempts to change a role while they do not have permission.

![screen shot 2017-06-26 at 12 34 53 pm](https://user-images.githubusercontent.com/1421848/27549995-f786deda-5a6b-11e7-99bc-b46ef6b3352e.png)

Currently, this error appears at the top of the user panel — it would make more sense as an inline error, but that will require some additional refactoring of the `error` and `user_role` components. 

* Displays a browser alert when a user attempts to remove their own org manager permissions.

![screen shot 2017-06-26 at 12 38 26 pm](https://user-images.githubusercontent.com/1421848/27550101-675aa110-5a6c-11e7-84f2-4c132681747a.png)

* Some minor code refactoring
