### PR TITLE
Clear `saving` message on error, specs

### DIFF
--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -189,9 +189,11 @@ export class UserStore extends BaseStore {
       }
 
       case userActionTypes.USER_ROLE_CHANGE_ERROR: {
+        this._saving = false;
         this._error = Object.assign({}, action.error, {
           description: action.message
         });
+
         this.emitChange();
         break;
       }

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -804,6 +804,17 @@ describe('userActions', function() {
     it('should not call deletedUserRoles', function() {
       expect(userActions.deletedUserRoles.called).toEqual(false);
     });
+
+    it('calls a handleViewAction with the correct type + params', () => {
+      const spy = sandbox.spy(AppDispatcher, 'handleViewAction');
+      const error = {};
+      const message = 'You don\'t have permission to perform that action';
+      const expectedParams = { error, message };
+
+      userActions.errorChangeUserRole({});
+
+      assertAction(spy, userActionTypes.USER_ROLE_CHANGE_ERROR, expectedParams);
+    });
   });
 
   describe('deletedUserRoles()', function() {

--- a/static_src/test/unit/components/user_list.spec.jsx
+++ b/static_src/test/unit/components/user_list.spec.jsx
@@ -1,0 +1,38 @@
+  import '../../global_setup.js';
+
+  import React from 'react';
+  import { shallow } from 'enzyme';
+  import UserList from '../../../components/user_list.jsx';
+  import Loading from '../../../components/loading.jsx';
+
+  describe('<UserList />', () => {
+    it('renders a saving `loading` badge when passed the correct props', () => {
+      const props = {
+        saving: true,
+        loading: false,
+        users: [{}, {}]
+      };
+
+      const userList = shallow(<UserList { ...props } />);
+      const loading = userList.find(Loading);
+      const loadingProps = loading.props();
+
+      expect(loading.length).toBe(1);
+      expect(loadingProps.active).toBe(true);
+      expect(loadingProps.text).toEqual('Saving');
+    });
+
+    it('does not render "Saving" `loading` badge when passed non-saving props', () => {
+      const props = {
+        saving: false,
+        loading: false,
+        users: [{}, {}]
+      };
+
+      const userList = shallow(<UserList {...props } />);
+      const loading = userList.find(Loading);
+
+      expect(loading.length).toBe(1);
+      expect(loading.props().active).toBe(false);
+    });
+  });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -285,6 +285,22 @@ describe('UserStore', function () {
     });
   });
 
+  describe('on user role toggle error', () => {
+    it('updates the error and saving properties of the user store', () => {
+      const message = 'oh no!';
+
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.USER_ROLE_CHANGE_ERROR,
+        error: {},
+        message
+      });
+
+      expect(UserStore.isSaving).toBe(false);
+      expect(UserStore.getError()).not.toBe(null);
+      expect(UserStore.getError().description).toEqual(message);
+    });
+  });
+
   describe('on user roles add', function() {
     it('should call the api for org add if type org to update the role',
         function() {


### PR DESCRIPTION
**WIP**
* Previously, the `saving` message was sticking around after a user attempted to change a role, but had the action fail. This PR clears that message on failure.