### PR TITLE
Check for user by e-mail before sending invite

### DIFF
--- a/controllers/uaa_test.go
+++ b/controllers/uaa_test.go
@@ -79,9 +79,15 @@ var inviteUsersTest = []BasicProxyTest{
 		Handlers: []Handler{
 			{
 				RequestMethod: "POST",
-				ExpectedPath:  "/invite_users",
+				ExpectedPath:  "/invite_users?redirect_uri=https://hostname",
 				Response:      "{\"new_invites\": [{\"email\": \"test@example.com\", \"userId\": \"user-guid\"}]}",
 				ResponseCode:  http.StatusOK,
+			},
+			{
+				RequestMethod: "GET",
+				ExpectedPath:  "/Users?filter=email+eq+%22test%40example.com%22",
+				ResponseCode:  http.StatusOK,
+				Response:      "{\"resources\": [{\"active\": true, \"verified\": false, \"id\": \"user-guid\", \"externalId\": \"user-guid@domain.com\" }]}",
 			},
 			{
 				RequestMethod: "GET",
@@ -112,9 +118,15 @@ var inviteUsersTest = []BasicProxyTest{
 		Handlers: []Handler{
 			{
 				RequestMethod: "POST",
-				ExpectedPath:  "/invite_users",
+				ExpectedPath:  "/invite_users?redirect_uri=https://hostname",
 				Response:      "{\"new_invites\": [{\"inviteLink\": \"http://some.link\", \"userId\": \"user-guid\"}]}",
 				ResponseCode:  http.StatusOK,
+			},
+			{
+				RequestMethod: "GET",
+				ExpectedPath:  "/Users?filter=email+eq+%22test%40example.com%22",
+				ResponseCode:  http.StatusOK,
+				Response:      "{\"resources\": [{\"active\": true, \"verified\": false, \"id\": \"user-guid\", \"externalId\": \"user-guid@domain.com\" }]}",
 			},
 			{
 				RequestMethod: "GET",
@@ -145,9 +157,15 @@ var inviteUsersTest = []BasicProxyTest{
 		Handlers: []Handler{
 			{
 				RequestMethod: "POST",
-				ExpectedPath:  "/invite_users",
+				ExpectedPath:  "/invite_users?redirect_uri=https://hostname",
 				Response:      "{\"new_invites\": [{\"email\": \"test@example.com\", \"userId\": \"user-guid\", \"inviteLink\": \"http://some.link\"}]}",
 				ResponseCode:  http.StatusOK,
+			},
+			{
+				RequestMethod: "GET",
+				ExpectedPath:  "/Users?filter=email+eq+%22test%40example.com%22",
+				ResponseCode:  http.StatusOK,
+				Response:      "{\"resources\": [{\"active\": true, \"verified\": false, \"id\": \"user-guid\", \"externalId\": \"user-guid@domain.com\" }]}",
 			},
 			{
 				RequestMethod: "GET",
@@ -178,20 +196,15 @@ var inviteUsersTest = []BasicProxyTest{
 		Handlers: []Handler{
 			{
 				RequestMethod: "POST",
-				ExpectedPath:  "/invite_users",
+				ExpectedPath:  "/invite_users?redirect_uri=https://hostname",
 				Response:      "{\"new_invites\": [{\"email\": \"test@example.com\", \"userId\": \"user-guid\", \"inviteLink\": \"http://some.link\"}]}",
 				ResponseCode:  http.StatusOK,
 			},
 			{
 				RequestMethod: "GET",
-				ExpectedPath:  "/Users/user-guid",
+				ExpectedPath:  "/Users?filter=email+eq+%22test%40example.com%22",
 				ResponseCode:  http.StatusOK,
-				Response:      "{\"active\": true, \"verified\": true, \"id\": \"user-guid\", \"externalId\": \"user-guid@domain.com\" }",
-			},
-			{
-				RequestMethod: "POST",
-				ExpectedPath:  "/v2/users",
-				ResponseCode:  http.StatusCreated,
+				Response:      "{\"resources\": [{\"active\": true, \"verified\": true, \"id\": \"user-guid\", \"externalId\": \"user-guid@domain.com\" }]}",
 			},
 		},
 	},

--- a/helpers/testhelpers/testhelpers.go
+++ b/helpers/testhelpers/testhelpers.go
@@ -210,7 +210,7 @@ func CreateExternalServerForPrivileged(t *testing.T, test BasicProxyTest) *httpt
 		} else {
 			foundHandler := false
 			for _, handler := range test.Handlers {
-				if r.URL.Path == handler.ExpectedPath && r.Method == handler.RequestMethod {
+				if r.URL.RequestURI() == handler.ExpectedPath && r.Method == handler.RequestMethod {
 					w.WriteHeader(handler.ResponseCode)
 					fmt.Fprintln(w, handler.Response)
 					foundHandler = true
@@ -226,7 +226,7 @@ func CreateExternalServerForPrivileged(t *testing.T, test BasicProxyTest) *httpt
 			}
 			if !foundHandler {
 				t.Errorf("Test name: (%s) Server received method %s\n", test.TestName, r.Method)
-				t.Errorf("Debug path: Got stuck on (%s) after frontend sent (%s)\n", r.URL.Path, test.RequestPath)
+				t.Errorf("Debug path: Got stuck on (%s) after frontend sent (%s)\n", r.URL.RequestURI(), test.RequestPath)
 				t.Errorf("Tried the following handlers %+v\n", test.Handlers)
 			}
 		}


### PR DESCRIPTION
This PR adds a function GetUAAUserByEmail
It also removes GetUAAUser which retrieved the user by id instead.

This check for user has also moved up and will happen before the invite
given that the user doesn't exist or isn't verified.

It also addresses https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-6136