### PR TITLE
Bump version to 1.16.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudgov-dashboard",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "engines": {
     "node": "6.x.x",
     "npm": "3.x.x"


### PR DESCRIPTION
This is to just include the clearing of notifications on user store. I rather not re-push on 1.16.6 since it wasn't technically broken