### PR TITLE
Remove superfluous props assignment in constructor

### DIFF
--- a/static_src/components/action.jsx
+++ b/static_src/components/action.jsx
@@ -44,7 +44,7 @@ const defaultProps = {
 export default class Action extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
   }
 

--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -64,7 +64,7 @@ function stateSetter() {
 export default class AppContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -39,7 +39,7 @@ function stateSetter() {
 export default class AppList extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
     this._onChange = this._onChange.bind(this);
     this.styler = createStyler(style);

--- a/static_src/components/box.jsx
+++ b/static_src/components/box.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 export default class Box extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = {};
   }
 

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -19,7 +19,7 @@ const CONFIRM_STYLES = [
 export default class ConfirmationBox extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = {};
     this.styler = createStyler(style);
     this._confirmHandler = this._confirmHandler.bind(this);

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -32,7 +32,7 @@ function stateSetter() {
 export default class CreateServiceInstance extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = {
       errs: [],
       spaces: SpaceStore.getAll(),

--- a/static_src/components/dropdown.jsx
+++ b/static_src/components/dropdown.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 export default class Dropdown extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = { open: false };
     this.handleTitleClick = this.handleTitleClick.bind(this);
   }

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -22,7 +22,7 @@ const defaultProps = {
 export default class EntityIcon extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
   }
 

--- a/static_src/components/form/form.jsx
+++ b/static_src/components/form/form.jsx
@@ -27,7 +27,7 @@ function stateSetter(props) {
 export default class Form extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter(props);
 
     this._onStoreChange = this._onStoreChange.bind(this);

--- a/static_src/components/form/form_select.jsx
+++ b/static_src/components/form/form_select.jsx
@@ -7,7 +7,7 @@ import FormError from './form_error.jsx';
 export default class FormSelect extends FormElement {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = this.state || {};
     this.state.value = '';
     this.state.err = null;

--- a/static_src/components/global_error.jsx
+++ b/static_src/components/global_error.jsx
@@ -17,7 +17,7 @@ const defaultProps = {};
 export default class GlobalError extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
 
     this.onNotificationDismiss = this.onNotificationDismiss.bind(this);

--- a/static_src/components/global_error_container.jsx
+++ b/static_src/components/global_error_container.jsx
@@ -24,7 +24,7 @@ function stateSetter() {
 export default class GlobalErrorContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
     this.styler = createStyler(style);
 

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -41,7 +41,7 @@ const defaultProps = {
 export default class Icon extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
   }
 

--- a/static_src/components/loading.jsx
+++ b/static_src/components/loading.jsx
@@ -33,7 +33,7 @@ const defaultProps = {
 class Loading extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
     this.state = {
       waitTimer: false

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -25,7 +25,7 @@ function stateSetter() {
 export class Nav extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
     this.styler = createStyler(style, overrideStyle);
     this._onChange = this._onChange.bind(this);

--- a/static_src/components/notification.jsx
+++ b/static_src/components/notification.jsx
@@ -29,7 +29,7 @@ const defaultProps = {
 export default class Notification extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
 
     this.onCloseClick = this.onCloseClick.bind(this);

--- a/static_src/components/route.jsx
+++ b/static_src/components/route.jsx
@@ -34,7 +34,7 @@ function stateSetter(props) {
 export default class Route extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
     this.state = stateSetter(props);
 

--- a/static_src/components/routes_panel.jsx
+++ b/static_src/components/routes_panel.jsx
@@ -61,7 +61,7 @@ function stateSetter() {
 export default class RoutesPanel extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
     this.styler = createStyler(style);
 

--- a/static_src/components/service_instance.jsx
+++ b/static_src/components/service_instance.jsx
@@ -30,7 +30,7 @@ const defaultProps = {
 export default class ServiceInstance extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
 
     this.bindHandler = this.bindHandler.bind(this);

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -25,7 +25,6 @@ const defaultProps = {
 export default class ServiceInstanceList extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
 
     this.styler = createStyler(style);
   }

--- a/static_src/components/service_instance_table.jsx
+++ b/static_src/components/service_instance_table.jsx
@@ -29,7 +29,7 @@ function stateSetter() {
 export default class ServiceInstanceTable extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -28,7 +28,7 @@ function stateSetter(props) {
 export default class ServiceList extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter(props);
     this.styler = createStyler(style);
   }

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -32,7 +32,7 @@ function stateSetter(serviceGuid) {
 export default class ServicePlanList extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter(props.initialServiceGuid);
 
     this._onChange = this._onChange.bind(this);

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -32,7 +32,7 @@ function stateSetter() {
 export default class SpaceContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
     this._onChange = this._onChange.bind(this);
     this.styler = createStyler(style);

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -52,7 +52,7 @@ function formGuid(app) {
 export default class UsageAndLimits extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
 
     // Create the form instance in the store

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -47,7 +47,7 @@ const defaultProps = {
 export default class UserList extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.styler = createStyler(style);
     this._handleDelete = this._handleDelete.bind(this);
   }

--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -63,7 +63,7 @@ function stateSetter() {
 export default class Users extends React.Component {
   constructor(props) {
     super(props);
-    this.props = props;
+
     this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);

--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -40,7 +40,7 @@ export default class UsersInvite extends React.Component {
   constructor(props) {
     super(props);
     FormStore.create(USERS_INVITE_FORM_GUID);
-    this.props = props;
+
     this.state = stateSetter(props);
 
     this.styler = createStyler(style);


### PR DESCRIPTION
Props get assigned automatically under the hood, and super(props)
handles the case wehre this.props needs to be accessed directly in the
constructor