### PR TITLE
Move/dedupe logic in routes

### DIFF
--- a/static_src/components/overview_container.jsx
+++ b/static_src/components/overview_container.jsx
@@ -92,21 +92,23 @@ export default class OverviewContainer extends React.Component {
       </span>
     );
 
-    if (state.empty) {
-      content = this.emptyState;
-    } else if (!state.loading && this.state.orgs.length > 0 || this.anyOrgsOpen()) {
-      content = (
-        <div>
-        { state.orgs.map((org) =>
-          <div key={ org.guid } className="test-panel-row-organizations">
-            <OrgQuicklook
-              org={ org }
-              spaces={ this.orgSpaces(org.guid) }
-            />
+    if (!state.loading) {
+      if (state.empty) {
+        content = this.emptyState;
+      } else if (this.state.orgs.length > 0 || this.anyOrgsOpen()) {
+        content = (
+          <div>
+          { state.orgs.map((org) =>
+            <div key={ org.guid } className="test-panel-row-organizations">
+              <OrgQuicklook
+                org={ org }
+                spaces={ this.orgSpaces(org.guid) }
+              />
+            </div>
+          )}
           </div>
-        )}
-        </div>
-      );
+        );
+      }
     }
 
     return (

--- a/static_src/routes.js
+++ b/static_src/routes.js
@@ -28,7 +28,6 @@ import userActions from './actions/user_actions.js';
 // TODO this is hard to stub since we query it at module load time. It should
 // be passed in or something.
 const mainEl = document.querySelector('.js-app');
-
 const MAX_OVERVIEW_SPACES = 10;
 
 export function login(next) {
@@ -44,18 +43,17 @@ export function overview(next) {
   spaceActions.changeCurrentSpace();
   appActions.changeCurrentApp();
 
-  spaceActions.fetchAll()
-    .then(spaces => {
-      let i = 0;
-      const max = Math.min(MAX_OVERVIEW_SPACES, spaces.length);
-      const fetches = [];
-      for (; i < max; i++) {
-        fetches.push(spaceActions.fetch(spaces[i].guid));
-      }
+  orgActions.fetchAll();
+  spaceActions.fetchAll().then(spaces => {
+    let i = 0;
+    const max = Math.min(MAX_OVERVIEW_SPACES, spaces.length);
+    const fetches = [];
+    for (; i < max; i++) {
+      fetches.push(spaceActions.fetch(spaces[i].guid));
+    }
 
-      return Promise.all(fetches);
-    })
-    .then(pageActions.loadSuccess, pageActions.loadError);
+    return Promise.all(fetches);
+  }).then(pageActions.loadSuccess, pageActions.loadError);
 
   ReactDOM.render(<MainContainer>
     <Overview />
@@ -182,8 +180,6 @@ export function checkAuth(...args) {
     })
     .then(() => {
       userActions.fetchCurrentUser({ orgGuid, spaceGuid });
-      orgActions.fetchAll();
-      spaceActions.fetchAll();
       next();
     });
 }

--- a/static_src/test/functional/global_error.spec.js
+++ b/static_src/test/functional/global_error.spec.js
@@ -69,13 +69,7 @@ describe('Global error', function () {
       beforeEach(function () {
         browser.refresh();
         globalErrorsElement = getErrorsComponent();
-
-        browser.waitForExist(BreadcrumbsElement.primarySelector);
-        const breadcrumbsElement = new BreadcrumbsElement(
-          browser,
-          browser.element(BreadcrumbsElement.primarySelector)
-        );
-        breadcrumbsElement.goToSpace();
+        browser.url('/#');
       });
 
       it('dismisses the error when navigating to any other route', function () {

--- a/static_src/test/unit/routes.spec.js
+++ b/static_src/test/unit/routes.spec.js
@@ -4,8 +4,6 @@ import ReactDOM from 'react-dom';
 import errorActions from '../../actions/error_actions';
 import loginActions from '../../actions/login_actions';
 import LoginStore from '../../stores/login_store';
-import orgActions from '../../actions/org_actions';
-import spaceActions from '../../actions/space_actions';
 import userActions from '../../actions/user_actions';
 import windowUtil from '../../util/window';
 import { checkAuth } from '../../routes';
@@ -26,8 +24,6 @@ describe('routes', function () {
     beforeEach(function () {
       sandbox.stub(loginActions, 'fetchStatus').returns(Promise.resolve({ status: 'authorized' }));
       sandbox.stub(userActions, 'fetchCurrentUser').returns(Promise.resolve());
-      sandbox.stub(orgActions, 'fetchAll').returns(Promise.resolve());
-      sandbox.stub(spaceActions, 'fetchAll').returns(Promise.resolve());
     });
 
     describe('given no arguments', function () {
@@ -47,10 +43,8 @@ describe('routes', function () {
         expect(loginActions.fetchStatus).toHaveBeenCalledOnce();
       });
 
-      it('fetches page data', function () {
+      it('fetches the current user', function () {
         expect(userActions.fetchCurrentUser).toHaveBeenCalledOnce();
-        expect(orgActions.fetchAll).toHaveBeenCalledOnce();
-        expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
       });
     });
 
@@ -71,10 +65,8 @@ describe('routes', function () {
         expect(loginActions.fetchStatus).toHaveBeenCalledOnce();
       });
 
-      it('fetches page data', function () {
+      it('fetches the current user', function () {
         expect(userActions.fetchCurrentUser).toHaveBeenCalledOnce();
-        expect(orgActions.fetchAll).toHaveBeenCalledOnce();
-        expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
       });
 
       it('calls userActions.fetchCurrentUser() with guids for filtered API calls', function () {
@@ -110,10 +102,8 @@ describe('routes', function () {
         expect(loginActions.fetchStatus).toHaveBeenCalledOnce();
       });
 
-      it('fetches page data', function () {
+      it('fetches the current user', function () {
         expect(userActions.fetchCurrentUser).toHaveBeenCalledOnce();
-        expect(orgActions.fetchAll).toHaveBeenCalledOnce();
-        expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
       });
 
       it('calls noticeError action', function () {
@@ -145,10 +135,8 @@ describe('routes', function () {
         expect(ReactDOM.render).toHaveBeenCalledOnce();
       });
 
-      it('does not fetch page data', function () {
+      it('does not fetch the current user', function () {
         expect(userActions.fetchCurrentUser).not.toHaveBeenCalled();
-        expect(orgActions.fetchAll).not.toHaveBeenCalled();
-        expect(spaceActions.fetchAll).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
* Remove duplicate call to spaceActions.fetchAll
* Move calls to fetch all orgs and spaces to overview, it is the only
place the user needs that information