### PR TITLE
Add prop-types package and update code

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudgov-dashboard",
-  "version": "1.16.2",
+  "version": "1.16.7",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -1787,6 +1787,28 @@
       "from": "entities@>=1.1.1 <1.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
+    "enzyme": {
+      "version": "2.9.1",
+      "from": "enzyme@>=2.7.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+        },
+        "fbjs": {
+          "version": "0.8.12",
+          "from": "fbjs@>=0.8.9 <0.9.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz"
+        },
+        "prop-types": {
+          "version": "15.5.10",
+          "from": "prop-types@>=15.5.10 <16.0.0",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+        }
+      }
+    },
     "enzyme-matchers": {
       "version": "2.1.2",
       "from": "enzyme-matchers@>=2.1.2 <3.0.0",
@@ -1878,6 +1900,11 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
         }
       }
+    },
+    "eslint-plugin-jasmine": {
+      "version": "2.6.2",
+      "from": "eslint-plugin-jasmine@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.6.2.tgz"
     },
     "eslint-plugin-react": {
       "version": "4.3.0",
@@ -3498,10 +3525,20 @@
       "from": "jasmine-core@>=2.3.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.1.tgz"
     },
+    "jasmine-enzyme": {
+      "version": "2.1.2",
+      "from": "jasmine-enzyme@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-enzyme/-/jasmine-enzyme-2.1.2.tgz"
+    },
     "jasmine-expect": {
       "version": "1.22.3",
       "from": "jasmine-expect@>=1.21.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-expect/-/jasmine-expect-1.22.3.tgz"
+    },
+    "jasmine-sinon": {
+      "version": "0.4.0",
+      "from": "jasmine-sinon@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine-sinon/-/jasmine-sinon-0.4.0.tgz"
     },
     "jodid25519": {
       "version": "1.0.2",
@@ -3671,6 +3708,11 @@
       "from": "karma-jasmine-matchers@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine-matchers/-/karma-jasmine-matchers-0.1.3.tgz"
     },
+    "karma-jasmine-sinon": {
+      "version": "1.0.4",
+      "from": "karma-jasmine-sinon@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine-sinon/-/karma-jasmine-sinon-1.0.4.tgz"
+    },
     "karma-sourcemap-loader": {
       "version": "0.3.7",
       "from": "karma-sourcemap-loader@>=0.3.7 <0.4.0",
@@ -3749,6 +3791,43 @@
       "version": "0.3.0",
       "from": "levn@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+    },
+    "lighthouse": {
+      "version": "1.6.5",
+      "from": "lighthouse@>=1.6.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-1.6.5.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "from": "window-size@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+        },
+        "ws": {
+          "version": "1.1.1",
+          "from": "ws@1.1.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "from": "yargs@3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+        }
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -4110,6 +4189,11 @@
       "version": "0.5.13",
       "from": "moment-timezone@>=0.5.10 <0.6.0",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz"
+    },
+    "moxios": {
+      "version": "0.4.0",
+      "from": "moxios@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/moxios/-/moxios-0.4.0.tgz"
     },
     "ms": {
       "version": "0.7.3",
@@ -4780,9 +4864,9 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "prop-types": {
-      "version": "15.5.8",
-      "from": "prop-types@>=15.5.7 <16.0.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.8.tgz",
+      "version": "15.5.10",
+      "from": "prop-types@latest",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
@@ -4906,6 +4990,11 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz"
         }
       }
+    },
+    "react-addons-test-utils": {
+      "version": "15.6.0",
+      "from": "react-addons-test-utils@>=15.4.2 <16.0.0",
+      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz"
     },
     "react-dom": {
       "version": "15.5.4",
@@ -6116,10 +6205,111 @@
       "from": "wdio-dot-reporter@>=0.0.8 <0.1.0",
       "resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.8.tgz"
     },
+    "wdio-jasmine-framework": {
+      "version": "0.2.19",
+      "from": "wdio-jasmine-framework@>=0.2.19 <0.3.0",
+      "resolved": "https://registry.npmjs.org/wdio-jasmine-framework/-/wdio-jasmine-framework-0.2.19.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "from": "babel-runtime@>=5.8.25 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz"
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "from": "core-js@^1.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+        }
+      }
+    },
+    "wdio-selenium-standalone-service": {
+      "version": "0.0.7",
+      "from": "wdio-selenium-standalone-service@0.0.7",
+      "resolved": "https://registry.npmjs.org/wdio-selenium-standalone-service/-/wdio-selenium-standalone-service-0.0.7.tgz"
+    },
     "wdio-sync": {
       "version": "0.6.10",
       "from": "wdio-sync@0.6.10",
       "resolved": "https://registry.npmjs.org/wdio-sync/-/wdio-sync-0.6.10.tgz"
+    },
+    "webdriverio": {
+      "version": "4.8.0",
+      "from": "webdriverio@>=4.6.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.8.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "from": "cli-cursor@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz"
+        },
+        "figures": {
+          "version": "2.0.0",
+          "from": "figures@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz"
+        },
+        "inquirer": {
+          "version": "3.0.6",
+          "from": "inquirer@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "from": "mute-stream@0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "from": "onetime@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz"
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "from": "punycode@1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "from": "restore-cursor@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz"
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "from": "run-async@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz"
+        },
+        "string-width": {
+          "version": "2.1.0",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "from": "strip-ansi@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "from": "supports-color@>=3.2.3 <3.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+        },
+        "url": {
+          "version": "0.11.0",
+          "from": "url@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz"
+        }
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "karma-jasmine-sinon": "^1.0.4",
     "lighthouse": "^1.6.3",
     "moxios": "^0.4.0",
+    "prop-types": "^15.5.10",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "selenium-standalone": "^5.11.0",

--- a/static_src/components/action.jsx
+++ b/static_src/components/action.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -21,14 +22,14 @@ const BUTTON_TYPES = [
 ];
 
 const propTypes = {
-  children: React.PropTypes.any,
-  classes: React.PropTypes.array,
-  clickHandler: React.PropTypes.func,
-  disabled: React.PropTypes.bool,
-  href: React.PropTypes.string,
-  label: React.PropTypes.string,
-  style: React.PropTypes.oneOf(BUTTON_STYLES),
-  type: React.PropTypes.oneOf(BUTTON_TYPES)
+  children: PropTypes.any,
+  classes: PropTypes.array,
+  clickHandler: PropTypes.func,
+  disabled: PropTypes.bool,
+  href: PropTypes.string,
+  label: PropTypes.string,
+  style: PropTypes.oneOf(BUTTON_STYLES),
+  type: PropTypes.oneOf(BUTTON_TYPES)
 };
 
 const defaultProps = {

--- a/static_src/components/activity_log.jsx
+++ b/static_src/components/activity_log.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Action from './action.jsx';
@@ -39,8 +40,8 @@ function stateSetter(props) {
 }
 
 const propTypes = {
-  initialAppGuid: React.PropTypes.string.isRequired,
-  maxItems: React.PropTypes.number
+  initialAppGuid: PropTypes.string.isRequired,
+  maxItems: PropTypes.number
 };
 
 const defaultProps = {

--- a/static_src/components/activity_log_item.jsx
+++ b/static_src/components/activity_log_item.jsx
@@ -1,8 +1,8 @@
 
 import moment from 'moment-timezone';
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
-
 import createStyler from '../util/create_styler';
 import ElasticLine from './elastic_line.jsx';
 import ElasticLineItem from './elastic_line_item.jsx';
@@ -194,8 +194,8 @@ export default class ActivityLogItem extends React.Component {
 }
 
 ActivityLogItem.propTypes = {
-  domain: React.PropTypes.object,
-  item: React.PropTypes.object.isRequired,
-  route: React.PropTypes.object,
-  service: React.PropTypes.object
+  domain: PropTypes.object,
+  item: PropTypes.object.isRequired,
+  route: PropTypes.object,
+  service: PropTypes.object
 };

--- a/static_src/components/app_count_status.jsx
+++ b/static_src/components/app_count_status.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -9,8 +10,8 @@ import { entityHealth } from '../constants.js';
 import { appHealth, worstHealth } from '../util/health';
 
 const propTypes = {
-  appCount: React.PropTypes.number,
-  apps: React.PropTypes.array
+  appCount: PropTypes.number,
+  apps: PropTypes.array
 };
 
 const defaultProps = {

--- a/static_src/components/app_list.jsx
+++ b/static_src/components/app_list.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -103,7 +104,7 @@ export default class AppList extends React.Component {
 }
 
 AppList.propTypes = {
-  initialApps: React.PropTypes.array
+  initialApps: PropTypes.array
 };
 
 AppList.defaultProps = {

--- a/static_src/components/app_quicklook.jsx
+++ b/static_src/components/app_quicklook.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ElasticLine from './elastic_line.jsx';
@@ -16,11 +17,11 @@ const EXTRA_INFO = [
 ];
 
 const propTypes = {
-  app: React.PropTypes.object.isRequired,
-  orgGuid: React.PropTypes.string.isRequired,
-  spaceGuid: React.PropTypes.string.isRequired,
-  spaceName: React.PropTypes.string,
-  extraInfo: React.PropTypes.arrayOf((propVal) => EXTRA_INFO.includes(propVal))
+  app: PropTypes.object.isRequired,
+  orgGuid: PropTypes.string.isRequired,
+  spaceGuid: PropTypes.string.isRequired,
+  spaceName: PropTypes.string,
+  extraInfo: PropTypes.arrayOf((propVal) => EXTRA_INFO.includes(propVal))
 };
 
 const defaultProps = {

--- a/static_src/components/breadcrumbs_item.jsx
+++ b/static_src/components/breadcrumbs_item.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -30,6 +31,6 @@ export default class BreadcrumbsItem extends React.Component {
 }
 
 BreadcrumbsItem.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  url: React.PropTypes.string
+  children: PropTypes.node.isRequired,
+  url: PropTypes.string
 };

--- a/static_src/components/complex_list.jsx
+++ b/static_src/components/complex_list.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ComplexListItem from './complex_list_item.jsx';
@@ -6,11 +7,11 @@ import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const propTypes = {
-  children: React.PropTypes.array,
-  className: React.PropTypes.string,
-  title: React.PropTypes.string,
-  titleElement: React.PropTypes.element,
-  emptyMessage: React.PropTypes.element
+  children: PropTypes.array,
+  className: PropTypes.string,
+  title: PropTypes.string,
+  titleElement: PropTypes.element,
+  emptyMessage: PropTypes.element
 };
 const defaultProps = {
   children: [],

--- a/static_src/components/complex_list_item.jsx
+++ b/static_src/components/complex_list_item.jsx
@@ -1,11 +1,12 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const propTypes = {
-  children: React.PropTypes.any
+  children: PropTypes.any
 };
 
 const defaultProps = {};

--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -4,6 +4,7 @@
  */
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -60,11 +61,11 @@ export default class ConfirmationBox extends React.Component {
 }
 
 ConfirmationBox.propTypes = {
-  style: React.PropTypes.oneOf(CONFIRM_STYLES),
-  message: React.PropTypes.any,
-  confirmationText: React.PropTypes.string,
-  confirmHandler: React.PropTypes.func.isRequired,
-  cancelHandler: React.PropTypes.func.isRequired
+  style: PropTypes.oneOf(CONFIRM_STYLES),
+  message: PropTypes.any,
+  confirmationText: PropTypes.string,
+  confirmHandler: PropTypes.func.isRequired,
+  cancelHandler: PropTypes.func.isRequired
 };
 
 ConfirmationBox.defaultProps = {

--- a/static_src/components/count_status.jsx
+++ b/static_src/components/count_status.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -14,10 +15,10 @@ const ICON_TYPES = [
 ];
 
 const propTypes = {
-  count: React.PropTypes.number,
-  name: React.PropTypes.string.isRequired,
-  health: React.PropTypes.oneOf(Object.values(entityHealth)),
-  iconType: React.PropTypes.oneOf(ICON_TYPES)
+  count: PropTypes.number,
+  name: PropTypes.string.isRequired,
+  health: PropTypes.oneOf(Object.values(entityHealth)),
+  iconType: PropTypes.oneOf(ICON_TYPES)
 };
 
 const defaultProps = {

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -3,6 +3,7 @@
  */
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -160,8 +161,8 @@ export default class CreateServiceInstance extends React.Component {
 }
 
 CreateServiceInstance.propTypes = {
-  service: React.PropTypes.object,
-  servicePlan: React.PropTypes.object.isRequired
+  service: PropTypes.object,
+  servicePlan: PropTypes.object.isRequired
 };
 
 CreateServiceInstance.defaultProps = {

--- a/static_src/components/dropdown.jsx
+++ b/static_src/components/dropdown.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -40,10 +41,10 @@ export default class Dropdown extends React.Component {
       </div>
     );
   }
-};
+}
 
 Dropdown.propTypes = {
-  title: React.PropTypes.string.isRequired,
-  items: React.PropTypes.any,
-  classes: React.PropTypes.array
+  title: PropTypes.string.isRequired,
+  items: PropTypes.any,
+  classes: PropTypes.array
 };

--- a/static_src/components/elastic_line.jsx
+++ b/static_src/components/elastic_line.jsx
@@ -1,11 +1,12 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const propTypes = {
-  children: React.PropTypes.array
+  children: PropTypes.array
 };
 const defaultProps = {
   children: null

--- a/static_src/components/elastic_line_item.jsx
+++ b/static_src/components/elastic_line_item.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -10,8 +11,8 @@ const ALIGN_STYLES = [
 ];
 
 const propTypes = {
-  align: React.PropTypes.oneOf(ALIGN_STYLES),
-  children: React.PropTypes.any
+  align: PropTypes.oneOf(ALIGN_STYLES),
+  children: PropTypes.any
 };
 
 const defaultProps = {

--- a/static_src/components/entity_empty.jsx
+++ b/static_src/components/entity_empty.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import PanelDocumentation from './panel_documentation.jsx';
@@ -7,8 +8,8 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 
 const propTypes = {
-  callout: React.PropTypes.node,
-  children: React.PropTypes.any
+  callout: PropTypes.node,
+  children: PropTypes.any
 };
 
 const defaultProps = {

--- a/static_src/components/entity_icon.jsx
+++ b/static_src/components/entity_icon.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Icon from './icon.jsx';
@@ -9,10 +10,10 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 const ENTITIES = ['app', 'service', 'space', 'org'];
 
 const propTypes = {
-  children: React.PropTypes.node,
-  entity: React.PropTypes.oneOf(ENTITIES).isRequired,
-  iconSize: React.PropTypes.string,
-  health: React.PropTypes.oneOf(Object.values(entityHealth))
+  children: PropTypes.node,
+  entity: PropTypes.oneOf(ENTITIES).isRequired,
+  iconSize: PropTypes.string,
+  health: PropTypes.oneOf(Object.values(entityHealth))
 };
 
 const defaultProps = {

--- a/static_src/components/error_message.jsx
+++ b/static_src/components/error_message.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -10,8 +11,8 @@ const DISPLAY_TYPES = [
 ];
 
 const propTypes = {
-  error: React.PropTypes.object,
-  displayType: React.PropTypes.oneOf(DISPLAY_TYPES)
+  error: PropTypes.object,
+  displayType: PropTypes.oneOf(DISPLAY_TYPES)
 };
 
 const defaultProps = {

--- a/static_src/components/expandable_box.jsx
+++ b/static_src/components/expandable_box.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -6,11 +7,11 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  children: React.PropTypes.any,
-  classes: React.PropTypes.array,
-  clickHandler: React.PropTypes.func,
-  clickableContent: React.PropTypes.any,
-  isExpanded: React.PropTypes.bool
+  children: PropTypes.any,
+  classes: PropTypes.array,
+  clickHandler: PropTypes.func,
+  clickableContent: PropTypes.any,
+  isExpanded: PropTypes.bool
 };
 const defaultProps = {
   children: null,

--- a/static_src/components/form/form.jsx
+++ b/static_src/components/form/form.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 /**
  * form.jsx
  *
@@ -89,13 +90,13 @@ export default class Form extends React.Component {
 }
 
 Form.propTypes = {
-  action: React.PropTypes.string,
-  children: React.PropTypes.node,
-  classes: React.PropTypes.array,
-  guid: React.PropTypes.string.isRequired,
-  method: React.PropTypes.string,
-  onSubmit: React.PropTypes.func,
-  errorOverride: React.PropTypes.string
+  action: PropTypes.string,
+  children: PropTypes.node,
+  classes: PropTypes.array,
+  guid: PropTypes.string.isRequired,
+  method: PropTypes.string,
+  onSubmit: PropTypes.func,
+  errorOverride: PropTypes.string
 };
 
 Form.defaultProps = {

--- a/static_src/components/form/form_element.jsx
+++ b/static_src/components/form/form_element.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import formActions from '../../actions/form_actions';
 
@@ -62,15 +63,15 @@ export default class FormElement extends React.Component {
 }
 
 FormElement.propTypes = {
-  classes: React.PropTypes.array,
-  className: React.PropTypes.string,
-  formGuid: React.PropTypes.string.isRequired,
-  key: React.PropTypes.string,
-  label: React.PropTypes.string,
-  name: React.PropTypes.string.isRequired,
-  onValidate: React.PropTypes.func,
-  validator: React.PropTypes.func,
-  value: React.PropTypes.any
+  classes: PropTypes.array,
+  className: PropTypes.string,
+  formGuid: PropTypes.string.isRequired,
+  key: PropTypes.string,
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  onValidate: PropTypes.func,
+  validator: PropTypes.func,
+  value: PropTypes.any
 };
 
 FormElement.defaultProps = {

--- a/static_src/components/form/form_error.jsx
+++ b/static_src/components/form/form_error.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -18,5 +19,5 @@ export default class FormError extends React.Component {
   }
 }
 
-FormError.propTypes = { message: React.PropTypes.string };
+FormError.propTypes = { message: PropTypes.string };
 FormError.defaultProps = { message: '' };

--- a/static_src/components/form/form_number.jsx
+++ b/static_src/components/form/form_number.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import FormText from './form_text.jsx';
@@ -21,6 +22,6 @@ export default class FormNumber extends React.Component {
 }
 
 FormNumber.propTypes = {
-  min: React.PropTypes.number,
-  max: React.PropTypes.number
+  min: PropTypes.number,
+  max: PropTypes.number
 };

--- a/static_src/components/form/form_select.jsx
+++ b/static_src/components/form/form_select.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import FormElement from './form_element.jsx';
@@ -47,7 +48,7 @@ export default class FormSelect extends FormElement {
   }
 }
 FormSelect.propTypes = Object.assign(FormSelect.propTypes, {
-  options: React.PropTypes.array
+  options: PropTypes.array
 });
 FormSelect.defaultProps = Object.assign(FormSelect.defaultProps, {
   options: []

--- a/static_src/components/form/form_text.jsx
+++ b/static_src/components/form/form_text.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -48,8 +49,8 @@ export default class FormText extends FormElement {
 }
 
 FormText.propTypes = Object.assign({}, FormElement.propTypes, {
-  inline: React.PropTypes.bool,
-  labelAfter: React.PropTypes.bool
+  inline: PropTypes.bool,
+  labelAfter: PropTypes.bool
 });
 
 FormText.defaultProps = Object.assign({}, FormElement.defaultProps, {

--- a/static_src/components/global_error.jsx
+++ b/static_src/components/global_error.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Notification from './notification.jsx';
@@ -9,7 +10,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 
 const propTypes = {
-  err: React.PropTypes.object
+  err: PropTypes.object
 };
 
 const defaultProps = {};

--- a/static_src/components/global_error_container.jsx
+++ b/static_src/components/global_error_container.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ErrorStore from '../stores/error_store.js';
@@ -7,7 +8,7 @@ import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const propTypes = {
-  maxItems: React.PropTypes.number
+  maxItems: PropTypes.number
 };
 const defaultProps = {
   maxItems: 1

--- a/static_src/components/header_link.jsx
+++ b/static_src/components/header_link.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -24,8 +25,8 @@ export default class HeaderLink extends React.Component {
 }
 
 HeaderLink.propTypes = {
-  url: React.PropTypes.string,
-  text: React.PropTypes.string,
-  children: React.PropTypes.any,
-  classes: React.PropTypes.array
+  url: PropTypes.string,
+  text: PropTypes.string,
+  children: PropTypes.any,
+  classes: PropTypes.array
 };

--- a/static_src/components/icon.jsx
+++ b/static_src/components/icon.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -24,12 +25,12 @@ const STYLE_TYPES = [
 ];
 
 const propTypes = {
-  children: React.PropTypes.node,
-  name: React.PropTypes.string.isRequired,
-  styleType: React.PropTypes.oneOf(STYLE_TYPES),
-  iconType: React.PropTypes.oneOf(ICON_TYPES),
-  iconSize: React.PropTypes.oneOf(ICON_SIZE),
-  bordered: React.PropTypes.bool
+  children: PropTypes.node,
+  name: PropTypes.string.isRequired,
+  styleType: PropTypes.oneOf(STYLE_TYPES),
+  iconType: PropTypes.oneOf(ICON_TYPES),
+  iconSize: PropTypes.oneOf(ICON_SIZE),
+  bordered: PropTypes.bool
 };
 
 const defaultProps = {

--- a/static_src/components/info_activities.jsx
+++ b/static_src/components/info_activities.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -28,7 +29,7 @@ export default class InfoActivities extends React.Component {
 }
 
 InfoActivities.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 InfoActivities.defaultProps = {

--- a/static_src/components/info_app_create.jsx
+++ b/static_src/components/info_app_create.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -8,10 +9,10 @@ import createStyler from '../util/create_styler';
 import UserStore from '../stores/user_store';
 
 const propTypes = {
-  org: React.PropTypes.object,
-  space: React.PropTypes.object,
-  brief: React.PropTypes.bool,
-  user: React.PropTypes.object
+  org: PropTypes.object,
+  space: PropTypes.object,
+  brief: PropTypes.bool,
+  user: PropTypes.object
 };
 
 const defaultProps = {

--- a/static_src/components/info_environments.jsx
+++ b/static_src/components/info_environments.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -21,7 +22,7 @@ export default class InfoEnvironment extends React.Component {
 }
 
 InfoEnvironment.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 InfoEnvironment.defaultProps = {

--- a/static_src/components/info_sandbox.jsx
+++ b/static_src/components/info_sandbox.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -22,7 +23,7 @@ export default class InfoSandbox extends React.Component {
 }
 
 InfoSandbox.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 InfoSandbox.defaultProps = {

--- a/static_src/components/info_structure.jsx
+++ b/static_src/components/info_structure.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -28,7 +29,7 @@ export default class InfoStructure extends React.Component {
 }
 
 InfoStructure.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 InfoStructure.defaultProps = {

--- a/static_src/components/loading.jsx
+++ b/static_src/components/loading.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import loadingImg from 'cloudgov-style/img/loading.gif';
@@ -17,10 +18,10 @@ const STYLES = [
 ];
 
 const propTypes = {
-  text: React.PropTypes.string,
-  active: React.PropTypes.bool,
-  loadingDelayMS: React.PropTypes.number,
-  style: React.PropTypes.oneOf(STYLES)
+  text: PropTypes.string,
+  active: PropTypes.bool,
+  loadingDelayMS: PropTypes.number,
+  style: PropTypes.oneOf(STYLES)
 };
 
 const defaultProps = {

--- a/static_src/components/main_container.jsx
+++ b/static_src/components/main_container.jsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 import overrideStyle from '../css/overrides.css';
 
@@ -26,6 +27,7 @@ function stateSetter() {
 
 class App extends React.Component {
   constructor(props) {
+    console.log(style, overrideStyle)
     super(props);
     this.styler = createStyler(style, overrideStyle);
     this.state = stateSetter();;
@@ -73,7 +75,7 @@ class App extends React.Component {
 };
 
 App.propTypes = {
-  children: React.PropTypes.any
+  children: PropTypes.any
 };
 
 App.defaultProps = {

--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -139,7 +140,7 @@ export class Nav extends React.Component {
   }
 }
 Nav.propTypes = {
-  subLinks: React.PropTypes.array
+  subLinks: PropTypes.array
 };
 Nav.defaultProps = {
   subLinks: []

--- a/static_src/components/notification.jsx
+++ b/static_src/components/notification.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import keymirror from 'keymirror';
 
@@ -13,10 +14,10 @@ const STATUSES = Object.assign({}, entityHealth, keymirror({
 
 
 const propTypes = {
-  message: React.PropTypes.node,
-  status: React.PropTypes.oneOf(Object.keys(STATUSES)),
-  actions: React.PropTypes.arrayOf(React.PropTypes.object),
-  onDismiss: React.PropTypes.func
+  message: PropTypes.node,
+  status: PropTypes.oneOf(Object.keys(STATUSES)),
+  actions: PropTypes.arrayOf(PropTypes.object),
+  onDismiss: PropTypes.func
 };
 
 const defaultProps = {

--- a/static_src/components/org_quicklook.jsx
+++ b/static_src/components/org_quicklook.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -16,8 +17,8 @@ import orgActions from '../actions/org_actions.js';
 import { orgHref } from '../util/url';
 
 const propTypes = {
-  org: React.PropTypes.object.isRequired,
-  spaces: React.PropTypes.array
+  org: PropTypes.object.isRequired,
+  spaces: PropTypes.array
 };
 
 const defaultProps = {

--- a/static_src/components/page_header.jsx
+++ b/static_src/components/page_header.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
@@ -31,6 +32,6 @@ export default class PageHeader extends React.Component {
 }
 
 PageHeader.propTypes = {
-  children: React.PropTypes.node,
-  title: React.PropTypes.node.isRequired
+  children: PropTypes.node,
+  title: PropTypes.node.isRequired
 };

--- a/static_src/components/panel.jsx
+++ b/static_src/components/panel.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -6,7 +7,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  title: React.PropTypes.string
+  title: PropTypes.string
 };
 
 const defaultProps = {

--- a/static_src/components/panel_actions.jsx
+++ b/static_src/components/panel_actions.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -8,8 +9,8 @@ import createStyler from '../util/create_styler';
 const ALIGN_TYPES = ['left', 'right', 'both'];
 
 const propTypes = {
-  children: React.PropTypes.any,
-  align: React.PropTypes.oneOf(ALIGN_TYPES)
+  children: PropTypes.any,
+  align: PropTypes.oneOf(ALIGN_TYPES)
 };
 const defaultProps = {
   children: [],

--- a/static_src/components/panel_block.jsx
+++ b/static_src/components/panel_block.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -6,7 +7,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  children: React.PropTypes.any
+  children: PropTypes.any
 };
 const defaultProps = {
   children: null

--- a/static_src/components/panel_documentation.jsx
+++ b/static_src/components/panel_documentation.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -6,8 +7,8 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  children: React.PropTypes.any,
-  description: React.PropTypes.bool
+  children: PropTypes.any,
+  description: PropTypes.bool
 };
 const defaultProps = {
   children: null,

--- a/static_src/components/panel_group.jsx
+++ b/static_src/components/panel_group.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -6,8 +7,8 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  columns: React.PropTypes.number,
-  children: React.PropTypes.any
+  columns: PropTypes.number,
+  children: PropTypes.any
 };
 const defaultProps = {
   columns: 0,

--- a/static_src/components/panel_row.jsx
+++ b/static_src/components/panel_row.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -13,10 +14,10 @@ const STYLES = [
 ];
 
 const propTypes = {
-  id: React.PropTypes.string,
-  className: React.PropTypes.string,
-  children: React.PropTypes.any,
-  styleClass: React.PropTypes.oneOf(STYLES)
+  id: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.any,
+  styleClass: PropTypes.oneOf(STYLES)
 };
 
 const defaultProps = {};

--- a/static_src/components/resource_usage.jsx
+++ b/static_src/components/resource_usage.jsx
@@ -1,5 +1,7 @@
 
 
+import PropTypes from 'prop-types';
+
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -9,15 +11,15 @@ import formatBytes from '../util/format_bytes';
 import Stat from './stat.jsx';
 
 const propTypes = {
-  formGuid: React.PropTypes.string,
-  max: React.PropTypes.number,
-  min: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  title: React.PropTypes.string.isRequired,
-  amountUsed: React.PropTypes.number,
-  amountTotal: React.PropTypes.number,
-  byteWarningThreshold: React.PropTypes.number,
-  secondaryInfo: React.PropTypes.node
+  formGuid: PropTypes.string,
+  max: PropTypes.number,
+  min: PropTypes.number,
+  onChange: PropTypes.func,
+  title: PropTypes.string.isRequired,
+  amountUsed: PropTypes.number,
+  amountTotal: PropTypes.number,
+  byteWarningThreshold: PropTypes.number,
+  secondaryInfo: PropTypes.node
 };
 
 const defaultProps = {

--- a/static_src/components/route.jsx
+++ b/static_src/components/route.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Action from './action.jsx';
@@ -16,8 +17,8 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 
 
 const propTypes = {
-  appGuid: React.PropTypes.string.isRequired,
-  route: React.PropTypes.object
+  appGuid: PropTypes.string.isRequired,
+  route: PropTypes.object
 };
 
 const defaultProps = {

--- a/static_src/components/route_form.jsx
+++ b/static_src/components/route_form.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Action from './action.jsx';
@@ -12,12 +13,12 @@ import formatRoute from '../util/format_route';
 import routeFormCss from '../css/route_form.css';
 
 const propTypes = {
-  domains: React.PropTypes.array.isRequired,
-  route: React.PropTypes.object,
-  routeLimit: React.PropTypes.number,
-  error: React.PropTypes.object,
-  submitHandler: React.PropTypes.func,
-  cancelHandler: React.PropTypes.func
+  domains: PropTypes.array.isRequired,
+  route: PropTypes.object,
+  routeLimit: PropTypes.number,
+  error: PropTypes.object,
+  submitHandler: PropTypes.func,
+  cancelHandler: PropTypes.func
 };
 
 const defaultProps = {

--- a/static_src/components/service_count_status.jsx
+++ b/static_src/components/service_count_status.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -11,8 +12,8 @@ import { appInstanceHealth, worstAppInstanceState } from '../util/health';
 
 
 const propTypes = {
-  serviceCount: React.PropTypes.number,
-  services: React.PropTypes.array
+  serviceCount: PropTypes.number,
+  services: PropTypes.array
 };
 
 const defaultProps = {

--- a/static_src/components/service_instance.jsx
+++ b/static_src/components/service_instance.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -17,9 +18,9 @@ import { OPERATION_FAILED } from '../stores/service_instance_store.js';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  currentAppGuid: React.PropTypes.string.isRequired,
-  serviceInstance: React.PropTypes.object,
-  bound: React.PropTypes.bool
+  currentAppGuid: PropTypes.string.isRequired,
+  serviceInstance: PropTypes.object,
+  bound: PropTypes.bool
 };
 
 const defaultProps = {

--- a/static_src/components/service_instance_list.jsx
+++ b/static_src/components/service_instance_list.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -9,11 +10,11 @@ import ServiceInstance from './service_instance.jsx';
 import createStyler from '../util/create_styler';
 
 const propTypes = {
-  currentAppGuid: React.PropTypes.string.isRequired,
-  serviceInstances: React.PropTypes.array,
-  bound: React.PropTypes.bool,
-  empty: React.PropTypes.bool,
-  titleElement: React.PropTypes.element
+  currentAppGuid: PropTypes.string.isRequired,
+  serviceInstances: PropTypes.array,
+  bound: PropTypes.bool,
+  empty: PropTypes.bool,
+  titleElement: PropTypes.element
 };
 
 const defaultProps = {

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -4,6 +4,7 @@
  */
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import ComplexList from './complex_list.jsx';
@@ -88,7 +89,7 @@ export default class ServiceList extends React.Component {
 }
 
 ServiceList.propTypes = {
-  initialServices: React.PropTypes.array
+  initialServices: PropTypes.array
 };
 
 ServiceList.defaultProps = {

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -4,6 +4,7 @@
  */
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Action from './action.jsx';
@@ -132,7 +133,7 @@ export default class ServicePlanList extends React.Component {
 }
 
 ServicePlanList.propTypes = {
-  initialServiceGuid: React.PropTypes.string
+  initialServiceGuid: PropTypes.string
 };
 
 ServicePlanList.defaultProps = {};

--- a/static_src/components/space_container.jsx
+++ b/static_src/components/space_container.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AppCountStatus from './app_count_status.jsx';
@@ -120,7 +121,7 @@ export default class SpaceContainer extends React.Component {
 }
 
 SpaceContainer.propTypes = {
-  currentPage: React.PropTypes.string
+  currentPage: PropTypes.string
 };
 
 SpaceContainer.defaultProps = {

--- a/static_src/components/space_count_status.jsx
+++ b/static_src/components/space_count_status.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import createStyler from '../util/create_styler';
@@ -7,7 +8,7 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 import CountStatus from './count_status.jsx';
 
 const propTypes = {
-  spaces: React.PropTypes.array
+  spaces: PropTypes.array
 };
 
 const defaultProps = {

--- a/static_src/components/space_quicklook.jsx
+++ b/static_src/components/space_quicklook.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -13,10 +14,10 @@ import OrgStore from '../stores/org_store.js';
 import { spaceHref } from '../util/url';
 
 const propTypes = {
-  space: React.PropTypes.object.isRequired,
-  orgGuid: React.PropTypes.string.isRequired,
-  showAppDetail: React.PropTypes.bool,
-  user: React.PropTypes.object
+  space: PropTypes.object.isRequired,
+  orgGuid: PropTypes.string.isRequired,
+  showAppDetail: PropTypes.bool,
+  user: PropTypes.object
 };
 
 const defaultProps = {

--- a/static_src/components/stat.jsx
+++ b/static_src/components/stat.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
@@ -17,16 +18,16 @@ const STATES = [
 ];
 
 const propTypes = {
-  formGuid: React.PropTypes.string,
-  name: React.PropTypes.string,
-  title: React.PropTypes.string,
-  editable: React.PropTypes.bool,
-  min: React.PropTypes.number,
-  max: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  primaryStat: React.PropTypes.number.isRequired,
-  statState: React.PropTypes.oneOf(STATES),
-  secondaryInfo: React.PropTypes.node
+  formGuid: PropTypes.string,
+  name: PropTypes.string,
+  title: PropTypes.string,
+  editable: PropTypes.bool,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  onChange: PropTypes.func,
+  primaryStat: PropTypes.number.isRequired,
+  statState: PropTypes.oneOf(STATES),
+  secondaryInfo: PropTypes.node
 };
 
 const defaultProps = {

--- a/static_src/components/usage_and_limits.jsx
+++ b/static_src/components/usage_and_limits.jsx
@@ -1,5 +1,6 @@
 
 import style from 'cloudgov-style/css/cloudgov-style.css';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import Action from './action.jsx';
@@ -296,9 +297,9 @@ export default class UsageAndLimits extends React.Component {
 }
 
 UsageAndLimits.propTypes = {
-  app: React.PropTypes.object,
-  editing: React.PropTypes.bool,
-  quota: React.PropTypes.object
+  app: PropTypes.object,
+  editing: PropTypes.bool,
+  quota: PropTypes.object
 };
 
 UsageAndLimits.defaultProps = {

--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 /**
  * Renders a list of users.
  */
@@ -20,18 +21,18 @@ import formatDateTime from '../util/format_date';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const propTypes = {
-  users: React.PropTypes.array,
-  userType: React.PropTypes.string,
-  entityGuid: React.PropTypes.string,
-  currentUserAccess: React.PropTypes.bool,
-  empty: React.PropTypes.bool,
-  loading: React.PropTypes.bool,
-  saving: React.PropTypes.bool,
-  savingText: React.PropTypes.string,
+  users: PropTypes.array,
+  userType: PropTypes.string,
+  entityGuid: PropTypes.string,
+  currentUserAccess: PropTypes.bool,
+  empty: PropTypes.bool,
+  loading: PropTypes.bool,
+  saving: PropTypes.bool,
+  savingText: PropTypes.string,
   // Set to a function when there should be a remove button.
-  onRemove: React.PropTypes.func,
-  onRemovePermissions: React.PropTypes.func,
-  onAddPermissions: React.PropTypes.func
+  onRemove: PropTypes.func,
+  onRemovePermissions: PropTypes.func,
+  onAddPermissions: PropTypes.func
 };
 
 const defaultProps = {

--- a/static_src/components/user_provider.jsx
+++ b/static_src/components/user_provider.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import UserStore from '../stores/user_store.js';
 
@@ -34,7 +35,7 @@ const userProvider = Component => {
   }
 
   UserProvider.childContextTypes = {
-    currentUser: React.PropTypes.object
+    currentUser: PropTypes.object
   };
 
   return UserProvider;

--- a/static_src/components/user_role_control.jsx
+++ b/static_src/components/user_role_control.jsx
@@ -1,13 +1,14 @@
 
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const propTypes = {
-  userId: React.PropTypes.string.isRequired,
-  roleName: React.PropTypes.string.isRequired,
-  roleKey: React.PropTypes.string.isRequired,
-  initialValue: React.PropTypes.bool,
-  initialEnableControl: React.PropTypes.bool,
-  onChange: React.PropTypes.func
+  userId: PropTypes.string.isRequired,
+  roleName: PropTypes.string.isRequired,
+  roleKey: PropTypes.string.isRequired,
+  initialValue: PropTypes.bool,
+  initialEnableControl: PropTypes.bool,
+  onChange: PropTypes.func
 };
 
 const dangerousRole = 'org_manager';
@@ -63,10 +64,10 @@ export default class UserRoleControl extends React.Component {
       </span>
     );
   }
-};
+}
 
 UserRoleControl.contextTypes = {
-  currentUser: React.PropTypes.object
+  currentUser: PropTypes.object
 };
 
 UserRoleControl.propTypes = propTypes;

--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 /*
  * Renders a users roles with controls to edit them
  */
@@ -46,12 +47,12 @@ const roleMapping = {
 };
 
 const propTypes = {
-  user: React.PropTypes.object.isRequired,
-  userType: React.PropTypes.string,
-  currentUserAccess: React.PropTypes.bool,
-  entityGuid: React.PropTypes.string,
-  onRemovePermissions: React.PropTypes.func,
-  onAddPermissions: React.PropTypes.func,
+  user: PropTypes.object.isRequired,
+  userType: PropTypes.string,
+  currentUserAccess: PropTypes.bool,
+  entityGuid: PropTypes.string,
+  onRemovePermissions: PropTypes.func,
+  onAddPermissions: PropTypes.func,
 };
 
 const defaultProps = {
@@ -111,7 +112,7 @@ export default class UserRoleListControl extends React.Component {
       </span>
     );
   }
-};
+}
 
 UserRoleListControl.propTypes = propTypes;
 UserRoleListControl.defaultProps = defaultProps;

--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types';
 /**
  * Renders a form that allows org users to invite new users
  * to cloud.gov
@@ -20,9 +21,9 @@ import style from 'cloudgov-style/css/cloudgov-style.css';
 const USERS_INVITE_FORM_GUID = 'users-invite-form';
 
 const propTypes = {
-  inviteDisabled: React.PropTypes.bool,
-  currentUserAccess: React.PropTypes.bool,
-  error: React.PropTypes.object
+  inviteDisabled: PropTypes.bool,
+  currentUserAccess: PropTypes.bool,
+  error: PropTypes.object
 };
 const defaultProps = {
   inviteDisabled: false,


### PR DESCRIPTION
* React.PropTypes is deprecated and was throwing a warning in the
console.

Just a lil day off coding..

There are a lot of changes but they can be boiled down to removing the `React` prefix from `PropTypes` and importing the `prop-types` library. I used [React codemod](https://github.com/reactjs/react-codemod) so I feel pretty confident about not missing anything.