### PR TITLE
Add indicator badge when deleting service instance

### DIFF
--- a/static_src/components/confirmation_box.jsx
+++ b/static_src/components/confirmation_box.jsx
@@ -2,31 +2,28 @@
 /**
  * A component that renders a box with a different style and background
  */
-
-import style from 'cloudgov-style/css/cloudgov-style.css';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import createStyler from '../util/create_styler';
-
 import Action from './action.jsx';
 
-const CONFIRM_STYLES = [
-  'nexto',
-  'over',
-  'block'
-];
+const CONFIRM_STYLES = {
+  INLINE: 'inline',
+  NEXTO: 'nexto',
+  OVER: 'over',
+  BLOCK: 'block'
+};
 
 const propTypes = {
-  style: PropTypes.oneOf(CONFIRM_STYLES),
+  style: PropTypes.oneOf(Object.keys(CONFIRM_STYLES).map(key => CONFIRM_STYLES[key])),
   message: PropTypes.any,
   confirmationText: PropTypes.string,
   confirmHandler: PropTypes.func.isRequired,
-  cancelHandler: PropTypes.func.isRequired
+  cancelHandler: PropTypes.func.isRequired,
+  disabled: PropTypes.bool
 };
 
 const defaultProps = {
-  style: 'inline',
+  style: CONFIRM_STYLES.INLINE,
   message: <div></div>,
   confirmationText: 'Confirm delete',
   confirmHandler: (ev) => { console.log('confirm ev', ev); },
@@ -34,40 +31,28 @@ const defaultProps = {
 };
 
 export default class ConfirmationBox extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {};
-    this.styler = createStyler(style);
-    this._confirmHandler = this._confirmHandler.bind(this);
-    this._cancelHandler = this._cancelHandler.bind(this);
-  }
-
-  _confirmHandler(ev) {
-    this.props.confirmHandler(ev);
-  }
-
-  _cancelHandler(ev) {
-    this.props.cancelHandler(ev);
-  }
-
   render() {
     const styleClass = `confirm-${this.props.style}`;
 
     return (
-      <div className={ this.styler('confirm', styleClass) }>
-        <span className={ this.styler('confirm-message') }>
-        { this.props.message }</span>
+      <div className={ `confirm ${ styleClass }` }>
+        <span className="confirm-message">
+          { this.props.message }
+        </span>
         <div>
           <Action label="Cancel"
               style="base"
               type="outline"
-              clickHandler={ this._cancelHandler }>
+              clickHandler={ this.props.cancelHandler }
+              disabled={ this.props.disabled }>
             <span>Cancel</span>
           </Action>
-          <Action label="Confirm"
-              style="warning"
-              clickHandler={ this._confirmHandler }>
+          <Action
+            label="Confirm"
+            style="warning"
+            clickHandler={ this.props.confirmHandler }
+            disabled={ this.props.disabled }
+          >
             <span>{ this.props.confirmationText }</span>
           </Action>
         </div>

--- a/static_src/components/loading.jsx
+++ b/static_src/components/loading.jsx
@@ -1,13 +1,9 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import style from 'cloudgov-style/css/cloudgov-style.css';
 import loadingImg from 'cloudgov-style/img/loading.gif';
 
-import createStyler from '../util/create_styler';
-
 const LOADING_TIME = 300;
-
 const STYLES = [
   // globalSaving is applied to saving notifications inside panels
   'globalSaving',
@@ -35,7 +31,6 @@ class Loading extends React.Component {
   constructor(props) {
     super(props);
 
-    this.styler = createStyler(style);
     this.state = {
       waitTimer: false
     };
@@ -61,68 +56,62 @@ class Loading extends React.Component {
     }
   }
 
+  get containerClasses() {
+    switch (this.props.style) {
+      case 'globalSaving': {
+        return 'saving saving-relative';
+      }
+      case 'cover': {
+        return 'loading loading-relative';
+      }
+      default: {
+        return 'loading-inline';
+      }
+    }
+  }
+
   render() {
-    let content = <div></div>;
-    if (this.props.active && !this.state.waitTimer) {
-      const classes = (() => {
-        switch (this.props.style) {
-          case 'globalSaving': {
-            return (
-            this.styler('saving', 'saving-relative')
-            );
-          }
-          case 'cover': {
-            return (
-            this.styler('loading', 'loading-relative')
-            );
-          }
-          default: {
-            return (
-            this.styler('loading-inline')
-            );
-          }
-        }
-      })();
-      content = (
-        <div className={ classes }
-          role="alertdialog"
-          aria-live="assertive"
-          aria-busy={ this.props.active }
-        >
+    const { style } = this.props;
+
+    if (!this.props.active || this.state.waitTimer) return null;
+
+    return (
+      <div className={ this.containerClasses }
+        role="alertdialog"
+        aria-live="assertive"
+        aria-busy={ this.props.active }
+      >
         {(() => {
-          switch (this.props.style) {
+          switch (style) {
             case 'globalSaving': {
               return (
-              <div>{ this.props.text }</div>
+                <div>{ this.props.text }</div>
               );
             }
             case 'cover': {
               return (
-              <img className={ this.styler('loading-indicator') }
-                src={ `/assets/${loadingImg}` } alt={ this.props.text }
-              />
+                <img className="loading-indicator"
+                  src={ `/assets/${loadingImg}` } alt={ this.props.text }
+                />
               );
             }
             case 'inline': {
               return (
-              <div>
-                <span className={ this.styler('loading-inline-dot') }>•</span>
-                <span className={ this.styler('loading-inline-dot') }>•</span>
-                <span className={ this.styler('loading-inline-dot') }>•</span>
-                <span className={ this.styler('loading-inline-text') }>
-                  { this.props.text }
-                </span>
-              </div>
+                <div>
+                  <span className="loading-inline-dot">•</span>
+                  <span className="loading-inline-dot">•</span>
+                  <span className="loading-inline-dot">•</span>
+                  <span className="loading-inline-text">
+                    { this.props.text }
+                  </span>
+                </div>
               );
             }
             default: return null;
           }
-        })()}
-        </div>
-      );
-    }
-
-    return content;
+        })() }
+      </div>
+    );
   }
 }
 

--- a/static_src/components/service_instance_table.jsx
+++ b/static_src/components/service_instance_table.jsx
@@ -8,10 +8,8 @@ import PanelDocumentation from './panel_documentation.jsx';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 import SpaceStore from '../stores/space_store.js';
 import { config } from 'skin';
-import createStyler from '../util/create_styler';
 import formatDateTime from '../util/format_date';
 import serviceActions from '../actions/service_actions.js';
-import style from 'cloudgov-style/css/cloudgov-style.css';
 
 function stateSetter() {
   const currentSpaceGuid = SpaceStore.currentSpaceGuid;
@@ -22,7 +20,8 @@ function stateSetter() {
     serviceInstances,
     currentSpaceGuid,
     loading: ServiceInstanceStore.loading,
-    empty: !ServiceInstanceStore.loading && !serviceInstances.length
+    empty: !ServiceInstanceStore.loading && !serviceInstances.length,
+    updating: ServiceInstanceStore.updating
   };
 }
 
@@ -36,8 +35,6 @@ export default class ServiceInstanceTable extends React.Component {
     this._handleDelete = this._handleDelete.bind(this);
     this._handleDeleteConfirmation = this._handleDeleteConfirmation.bind(this);
     this._handleDeleteCancel = this._handleDeleteCancel.bind(this);
-    this.renderConfirmationBox = this.renderConfirmationBox.bind(this);
-    this.styler = createStyler(style);
   }
 
   componentDidMount() {
@@ -101,6 +98,7 @@ export default class ServiceInstanceTable extends React.Component {
         style="nexto"
         confirmHandler={ this._handleDelete.bind(this, instanceGuid) }
         cancelHandler={ this._handleDeleteCancel.bind(this, instanceGuid) }
+        disabled={ this.state.updating }
       />
     );
   }
@@ -120,6 +118,11 @@ export default class ServiceInstanceTable extends React.Component {
       content = (
       <div>
         { this.documentation }
+        <Loading
+          style="globalSaving"
+          text="Deleting service instance"
+          active={ this.state.updating }
+        />
         <table>
           <thead>
             <tr>
@@ -169,7 +172,7 @@ export default class ServiceInstanceTable extends React.Component {
     }
 
     return (
-      <div className={ this.styler('tableWrapper') }>
+      <div className="tableWrapper">
         { content }
       </div>
     );

--- a/static_src/components/service_instance_table.jsx
+++ b/static_src/components/service_instance_table.jsx
@@ -11,6 +11,8 @@ import { config } from 'skin';
 import formatDateTime from '../util/format_date';
 import serviceActions from '../actions/service_actions.js';
 
+const propTypes = {};
+
 function stateSetter() {
   const currentSpaceGuid = SpaceStore.currentSpaceGuid;
   const serviceInstances = ServiceInstanceStore.getAllBySpaceGuid(
@@ -179,4 +181,4 @@ export default class ServiceInstanceTable extends React.Component {
   }
 }
 
-ServiceInstanceTable.propTypes = { };
+ServiceInstanceTable.propTypes = propTypes;

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -45,6 +45,7 @@ export class ServiceInstanceStore extends BaseStore {
     this._createdTempNotification = false;
     this._fetchAll = false;
     this._fetching = false;
+    this._updating = false;
   }
 
   get createInstanceForm() {
@@ -61,6 +62,10 @@ export class ServiceInstanceStore extends BaseStore {
 
   get createdTempNotification() {
     return this._createdTempNotification;
+  }
+
+  get updating() {
+    return this._updating;
   }
 
   get loading() {
@@ -230,6 +235,7 @@ export class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_DELETE: {
+        this._updating = true;
         const serviceInstance = this.get(action.serviceInstanceGuid);
         const toDelete = Object.assign({}, serviceInstance, { deleting: true });
         this.merge('guid', toDelete);
@@ -237,6 +243,7 @@ export class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_DELETED: {
+        this._updating = false;
         this.delete(action.serviceInstanceGuid);
         break;
       }

--- a/static_src/test/unit/components/service_instance_table.spec.jsx
+++ b/static_src/test/unit/components/service_instance_table.spec.jsx
@@ -1,0 +1,29 @@
+import '../../global_setup';
+import React from 'react';
+import ServiceInstanceTable from '../../../components/service_instance_table.jsx';
+import Loading from '../../../components/loading.jsx';
+import ServiceInstanceStore from '../../../stores/service_instance_store';
+import serviceInstances from '../../server/fixtures/service_instances';
+import Immutable from 'immutable';
+import { shallow } from 'enzyme';
+
+describe('<ServiceInstanceStore />', () => {
+  const instances = serviceInstances.map(instance => instance.entity);
+  let wrapper;
+
+  beforeEach(() => {
+    ServiceInstanceStore._data = Immutable.fromJS(instances);
+    wrapper = shallow(<ServiceInstanceTable />);
+    wrapper.setState({
+      serviceInstances: ServiceInstanceStore.getAll(),
+      empty: false,
+      updating: true
+    }, () => wrapper.update());
+  });
+
+  describe('deleting a service instance', () => {
+    it('renders a loading badge when updating state is true', () => {
+      expect(wrapper.find(Loading).length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Previously, we didn't give the user any feedback after they clicked the
'confirm delete' button.

Handy gif reference:
![delete-service-instance](https://user-images.githubusercontent.com/1421848/28216965-7b6fc41e-6881-11e7-8004-c58aa04e96b8.gif)
