### PR TITLE
Check that user has org manage role in space

### DIFF
--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -180,7 +180,7 @@ export default class Users extends React.Component {
       <UsersInvite
         inviteEntityType={ this.entityType }
         inviteDisabled={ this.state.inviteDisabled }
-        currentUserAccess={ this.state.currentUserAccess }
+        currentUserAccess={ this.currentUserIsOrgManager }
         error={ this.state.userListNoticeError }
       />
     );


### PR DESCRIPTION
* Previously we used a different computed variable that checked for
a manager role that matched the current entity (org or space). Now force
a check for the org_manager role independant of current entity type