### PR TITLE
Fix user state bug

### DIFF
--- a/static_src/components/router/route_provider.jsx
+++ b/static_src/components/router/route_provider.jsx
@@ -15,14 +15,6 @@ class RouteProvider extends React.Component {
     RouterStore.addChangeListener(this.onChange);
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    if (this.state === nextState) {
-      return false;
-    }
-
-    return true;
-  }
-
   componentWillUnmount() {
     RouterStore.removeChangeListener(this.onChange);
   }


### PR DESCRIPTION
Pairing with @el-mapache
we found that if you navigate to the org or space page from home, you
are able to successfully change people's roles. However, if you refresh
the page, it will not work because the currentUser context is not set
upon refresh.

This patch removes this bit which regulated state updates