### PR TITLE
Remove outdated info about GovCloud env

### DIFF
--- a/static_src/components/info_environments.jsx
+++ b/static_src/components/info_environments.jsx
@@ -22,8 +22,6 @@ export default class InfoEnvironment extends React.Component {
   render() {
     return (
       <section className={ this.props.className }>
-        <h4>Environments</h4>
-        <p>If your org <a href="https://cloud.gov/docs/apps/govcloud/">is in GovCloud</a>, use <a href="https://dashboard.fr.cloud.gov/">https://dashboard.fr.cloud.gov/</a> to see it.</p>
       </section>
     );
   }


### PR DESCRIPTION
This would support removing the outdated GovCloud page from the docs. Not sure whether this entire file should be removed, so this is a simple PR to remove the user-visible content.