### PR TITLE
Fix invite flow depending on permissions

### DIFF
--- a/static_src/components/users.jsx
+++ b/static_src/components/users.jsx
@@ -24,6 +24,14 @@ const ORG_MANAGER = 'org_manager';
 const SPACE_MANAGER = 'space_manager';
 const ORG_ENTITY = 'organization';
 const SPACE_ENTITY = 'space';
+const ORG_INVITE_HELP = 'Only an Org Manager can new invite users to this ' +
+  'organization via the dashboard. Speak to your Org Manager if you need to ' +
+  'add a user to this organization';
+const SPACE_INVITE_SPACE_MANAGER_HELP = 'As an Space Manager, you can invite existing ' +
+  'organization users into your space. If you wish to invite a person who is ' +
+  'not in the organization into your space, please ask an Org Manager';
+const SPACE_INVITE_HELP = 'If you wish to invite users into this space, please ' +
+  'ask an Org Manager or a Space Manager';
 
 function stateSetter() {
   const currentOrgGuid = OrgStore.currentOrgGuid;
@@ -175,44 +183,39 @@ export default class Users extends React.Component {
   }
 
   get userInvite() {
-    // When on the org page, only the org manager should see the user invite
+    // When on the org page, only the Org Manager should see the user invite
     // form. If not, display notification.
     if (this.isOrganization && !this.currentUserIsOrgManager) {
       return (
         <PanelDocumentation>
-          Only an org manager can new invite users to this organization via
-          the dashboard. Speak to your org manager if you need to add a user
-          to this organization
+          { ORG_INVITE_HELP }
         </PanelDocumentation>
       );
     }
-    // When on the space page, likewise, an org manager should always see the
+    // When on the space page, likewise, an Org Manager should always see the
     // invite form. Else, let's dig into what to display.
     if (this.isSpace && !this.currentUserIsOrgManager) {
-      // if the user is a space manager, let them know that they can invite
+      // if the user is a Space Manager, let them know that they can invite
       // existing org users but not new ones.
       if (this.currentUserIsSpaceManager) {
         return (
           <PanelDocumentation>
-            As an space manager, you can invite existing organization users into
-            your space. If you wish to invite a person who is not in the organization
-            into your space, please ask an org manager
+            { SPACE_INVITE_SPACE_MANAGER_HELP }
           </PanelDocumentation>
         );
       }
-      // Else, just tell the user to invite a space manager or org manager.
+      // Else, just tell the user to invite a Space Manager or Org Manager.
       // Let's not confuse the regular user with the difference between
       // new and existing org users.
       // We can figure out wording later.
       return (
         <PanelDocumentation>
-          If you wish to invite users into this space, please ask an
-          org manager or a space manager
+          { SPACE_INVITE_HELP }
         </PanelDocumentation>
       );
     }
 
-    // Only the org manager will get this far.
+    // Only the Org Manager will get this far.
     // We should only display the form then.
     return (
       <UsersInvite

--- a/static_src/routes.js
+++ b/static_src/routes.js
@@ -80,6 +80,7 @@ export function space(orgGuid, spaceGuid, next) {
   serviceActions.fetchAllInstances(spaceGuid);
   userActions.changeCurrentlyViewedType('space_users');
   userActions.fetchOrgUsers(orgGuid);
+  userActions.fetchOrgUserRoles(orgGuid);
   userActions.fetchSpaceUserRoles(spaceGuid);
   orgActions.fetch(orgGuid);
   serviceActions.fetchAllServices(orgGuid);

--- a/static_src/test/unit/components/users.spec.jsx
+++ b/static_src/test/unit/components/users.spec.jsx
@@ -98,8 +98,8 @@ describe('<Users />', () => {
         it('renders message telling user to ask an org manager to add users', () => {
           expect(users.find(PanelDocumentation).length).toBe(1);
           expect(users.find(PanelDocumentation).prop('children'))
-            .toEqual('Only an org manager can new invite users to this ' +
-            'organization via the dashboard. Speak to your org manager if ' +
+            .toEqual('Only an Org Manager can new invite users to this ' +
+            'organization via the dashboard. Speak to your Org Manager if ' +
             'you need to add a user to this organization');
         });
 
@@ -177,7 +177,7 @@ describe('<Users />', () => {
           expect(users.find(PanelDocumentation).length).toBe(1);
           expect(users.find(PanelDocumentation).prop('children'))
             .toEqual('If you wish to invite users into this space, please ask ' +
-            'an org manager or a space manager');
+            'an Org Manager or a Space Manager');
         });
       });
 
@@ -209,9 +209,9 @@ describe('<Users />', () => {
         it('should show a <PanelDocumentation />', () => {
           expect(users.find(PanelDocumentation).length).toBe(1);
           expect(users.find(PanelDocumentation).prop('children'))
-            .toEqual('As an space manager, you can invite existing organization ' +
+            .toEqual('As an Space Manager, you can invite existing organization ' +
             'users into your space. If you wish to invite a person who is not in ' +
-            'the organization into your space, please ask an org manager');
+            'the organization into your space, please ask an Org Manager');
         });
       });
     });

--- a/static_src/test/unit/components/users.spec.jsx
+++ b/static_src/test/unit/components/users.spec.jsx
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import Users from '../../../components/users.jsx';
 import PanelDocumentation from '../../../components/panel_documentation.jsx';
+import UsersSelector from '../../../components/users_selector.jsx';
 import UsersInvite from '../../../components/users_invite.jsx';
 import UserStore from '../../../stores/user_store';
 import SpaceStore from '../../../stores/space_store';
@@ -37,59 +38,181 @@ describe('<Users />', () => {
     });
 
     describe('when at org level', () => {
-      it('has an `entityType` of organization', () => {
+      beforeEach(() => {
         users.setState({ currentType: 'org_users' });
+      });
+
+      it('has an `entityType` of organization', () => {
         const actual = users.instance().entityType;
 
         expect(actual).toEqual('organization');
       });
+
+      describe('when a user is an org manager', () => {
+        beforeEach(() => {
+          const stub = sinon.stub(UserStore, 'hasRole');
+          stub.withArgs(userGuid, sinon.match.any, 'org_manager').returns(true);
+          stub.withArgs(userGuid, sinon.match.any, 'space_manager').returns(false);
+          users = shallow(<Users />);
+          users.setState({ currentType: 'org_users' });
+        });
+
+        afterEach(() => {
+          sinon.restore(UserStore);
+        });
+
+        it('renders a <UsersInvite /> component', () => {
+          expect(users.find(UsersInvite).length).toBe(1);
+        });
+
+        it('should not render a <UsersSelector />', () => {
+          expect(users.find(UsersSelector).length).toBe(0);
+        });
+
+        it('should render a <UsersInvite />', () => {
+          expect(users.find(UsersInvite).length).toBe(1);
+        });
+
+        it('should not render a <PanelDocumentation />', () => {
+          expect(users.find(PanelDocumentation).length).toBe(0);
+        });
+      });
+
+      describe('when a user is not an org manager', () => {
+        const spaceUser = Object.assign({}, user, {
+          roles: buildRoles(spaceGuid, ['space_manager'])
+        });
+
+        beforeEach(() => {
+          UserStore._data = Immutable.fromJS([spaceUser]);
+          users = shallow(<Users />);
+          users.setState({ currentType: 'org_users' });
+          const stub = sinon.stub(UserStore, 'hasRole');
+          stub.withArgs(userGuid, sinon.match.any, sinon.match.any).returns(false);
+        });
+
+        afterEach(() => {
+          sinon.restore(UserStore);
+        });
+
+        it('renders message telling user to ask an org manager to add users', () => {
+          expect(users.find(PanelDocumentation).length).toBe(1);
+          expect(users.find(PanelDocumentation).prop('children'))
+            .toEqual('Only an org manager can new invite users to this ' +
+            'organization via the dashboard. Speak to your org manager if ' +
+            'you need to add a user to this organization');
+        });
+
+        it('should not render a <UsersSelector />', () => {
+          expect(users.find(UsersSelector).length).toBe(0);
+        });
+
+        it('should not render a <UsersInvite /> component', () => {
+          expect(users.find(UsersInvite).length).toBe(0);
+        });
+      });
     });
 
     describe('when at space level', () => {
-      it('has an `entityType` of space', () => {
+      beforeEach(() => {
         users.setState({ currentType: 'space_users' });
-        const actual = users.instance().entityType;
+      });
 
+      it('has an `entityType` of space', () => {
+        const actual = users.instance().entityType;
         expect(actual).toEqual('space');
       });
-    });
 
-    describe('when a user is an org manager', () => {
-      afterEach(() => {
-        sinon.restore(UserStore);
+      describe('when a user is an org manager and not space manager', () => {
+        beforeEach(() => {
+          const stub = sinon.stub(UserStore, 'hasRole');
+          stub.withArgs(userGuid, sinon.match.any, 'org_manager').returns(true);
+          stub.withArgs(userGuid, sinon.match.any, 'space_manager').returns(false);
+          users = shallow(<Users />);
+        });
+
+        afterEach(() => {
+          sinon.restore(UserStore);
+        });
+
+        it('renders a <UsersInvite /> component', () => {
+          expect(users.find(UsersInvite).length).toBe(1);
+        });
+
+        it('should render a <UsersSelector />', () => {
+          expect(users.find(UsersSelector).length).toBe(1);
+        });
+
+        it('should not show a <PanelDocumentation />', () => {
+          expect(users.find(PanelDocumentation).length).toBe(0);
+        });
       });
 
-      it('renders a <UsersInvite /> component', () => {
-        sinon.stub(UserStore, 'hasRole').returns(true);
-        users = shallow(<Users />);
+      describe('when a user is not an org manager and not a space manager', () => {
+        const spaceUser = Object.assign({}, user, {
+          roles: buildRoles(spaceGuid, [])
+        });
 
-        expect(users.find(UsersInvite).length).toBe(1);
+        beforeEach(() => {
+          UserStore._data = Immutable.fromJS([spaceUser]);
+          users = shallow(<Users />);
+          const stub = sinon.stub(UserStore, 'hasRole');
+          stub.withArgs(userGuid, sinon.match.any, 'org_manager').returns(false);
+          stub.withArgs(userGuid, sinon.match.any, 'space_manager').returns(false);
+        });
+
+        afterEach(() => {
+          sinon.restore(UserStore);
+        });
+
+        it('should not render a <UsersInvite /> component', () => {
+          expect(users.find(UsersInvite).length).toBe(0);
+        });
+
+        it('should not show a <UsersSelector />', () => {
+          expect(users.find(UsersSelector).length).toBe(0);
+        });
+
+        it('should render a <PanelDocumentation />', () => {
+          expect(users.find(PanelDocumentation).length).toBe(1);
+          expect(users.find(PanelDocumentation).prop('children'))
+            .toEqual('If you wish to invite users into this space, please ask ' +
+            'an org manager or a space manager');
+        });
       });
-    });
 
-    describe('when a user is not an org manager', () => {
-      const spaceUser = Object.assign({}, user, {
-        roles: buildRoles(spaceGuid, ['space_manager'])
-      });
+      describe('when a user is not an org manager but is a space manager', () => {
+        const spaceUser = Object.assign({}, user, {
+          roles: buildRoles(spaceGuid, ['space_manager'])
+        });
 
-      beforeEach(() => {
-        UserStore._data = Immutable.fromJS([spaceUser]);
-        users = shallow(<Users />);
-      });
+        beforeEach(() => {
+          UserStore._data = Immutable.fromJS([spaceUser]);
+          users = shallow(<Users />);
+          const stub = sinon.stub(UserStore, 'hasRole');
+          stub.withArgs(userGuid, sinon.match.any, 'org_manager').returns(true);
+          stub.withArgs(userGuid, sinon.match.any, 'space_manager').returns(false);
+        });
 
-      it('renders message telling user to ask an org manager to add users', () => {
-        expect(users.find(UsersInvite).length).toBe(0);
-        expect(users.find(PanelDocumentation).length).toBe(1);
-      });
+        afterEach(() => {
+          sinon.restore(UserStore);
+        });
 
-      it('renders a link for the user to follow to get more information', () => {
-        const panelDoc = users.find(PanelDocumentation);
-        const link = panelDoc.find('a');
-        // eslint-disable-next-line max-len
-        const href = 'https://docs.cloudfoundry.org/adminguide/cli-user-management.html#space-roles';
+        it('should not render a <UsersInvite /> component', () => {
+          expect(users.find(UsersInvite).length).toBe(0);
+        });
 
-        expect(link.length).toBe(1);
-        expect(link.prop('href')).toBe(href);
+        it('should render a <UsersSelector />', () => {
+          expect(users.find(UsersSelector).length).toBe(1);
+        });
+
+        it('should show a <PanelDocumentation />', () => {
+          expect(users.find(PanelDocumentation).length).toBe(1);
+          expect(users.find(PanelDocumentation).prop('children'))
+            .toEqual('As an space manager, you can invite existing organization ' +
+            'users into your space. If you wish to invite a person who is not in ' +
+            'the organization into your space, please ask an org manager');
+        });
       });
     });
   });


### PR DESCRIPTION
## Before this PR: 
- The help message for asking people to invite users still said that you can only invite existing org users via the CLI. This was no longer the case when the UserSelector was introduced. So it needed to be updated.
- An org manager could not see the UsersSelector. So they couldn't invite existing org users to the space. So we need to allow org managers to see the selector too. 
![image](https://user-images.githubusercontent.com/7788930/28925819-fa41dfae-7833-11e7-80e1-3187d4cc9318.png)
- In the case when the user was not an org manager nor a space manager inside a space, they saw two panels with similar info. It was confusing. So let's reduce that to one (yes similar screenshot to the point above that show the same thing).
![image](https://user-images.githubusercontent.com/7788930/28925883-287cbc2c-7834-11e7-974c-e3f1bc1bc276.png)
- when a space manager was inside their space, they saw the old message saying they could not invite space users and instead needed to use the CLI. Let's get rid of that. 
![image](https://user-images.githubusercontent.com/7788930/28925550-2e7b0044-7833-11e7-9224-cc4b10911710.png)

## After this PR

### Help Message for a user has been split into three cases
1) When on the org page without org manager permissions
![image](https://user-images.githubusercontent.com/7788930/28926082-c2067356-7834-11e7-84e4-630bb979b55b.png)

2) When on the space page as an space manager
![image](https://user-images.githubusercontent.com/7788930/28926291-5a018d30-7835-11e7-8d79-22be00947657.png)


3) When on the space space not as a space manager
(I didn't bother to go into the difference between existing org users vs new org users because that might be confusing to a non-space manager/ non-org-manager user.)
![image](https://user-images.githubusercontent.com/7788930/28926216-1d331752-7835-11e7-9f24-e4aca1263373.png)

(The cases when the user is an org manager on either space or org page, there's no help text to ask someone for help or to do things via the CLI)

### Org Managers can invite existing org users to space

(This was because the space page didn't load the org roles)
![image](https://user-images.githubusercontent.com/7788930/28928034-2bbb18f6-783a-11e7-8457-097731542f1f.png)
 

The first commit is the tests adds coverage for the desired behavior mentioned above (CI will fail)
The second commit fixes the code to match the behavior.
(A third commit may be required to fix any functional tests + comments from reviewers)