### PR TITLE
Add Pagination for org users, org roles and org calls

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -27,7 +27,7 @@ const userActions = {
       orgGuid
     });
     return cfApi.fetchOrgUsers(orgGuid)
-      .then((users) => userActions.receivedOrgUsers(users, orgGuid));
+      .then(users => userActions.receivedOrgUsers(users, orgGuid));
   },
 
   fetchOrgUserRoles(orgGuid) {
@@ -36,7 +36,7 @@ const userActions = {
       orgGuid
     });
     return cfApi.fetchOrgUserRoles(orgGuid)
-      .then((orgUsers) => userActions.receivedOrgUserRoles(orgUsers, orgGuid));
+      .then(orgUsers => userActions.receivedOrgUserRoles(orgUsers, orgGuid));
   },
 
   fetchSpaceUserRoles(spaceGuid) {
@@ -46,7 +46,7 @@ const userActions = {
     });
 
     return cfApi.fetchSpaceUserRoles(spaceGuid)
-      .then((spaceUsers) => userActions.receivedSpaceUserRoles(spaceUsers, spaceGuid));
+      .then(spaceUsers => userActions.receivedSpaceUserRoles(spaceUsers, spaceGuid));
   },
 
   receivedOrgUsers(users, orgGuid) {

--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -26,6 +26,8 @@ const userActions = {
       type: userActionTypes.ORG_USERS_FETCH,
       orgGuid
     });
+    return cfApi.fetchOrgUsers(orgGuid)
+      .then((users) => userActions.receivedOrgUsers(users, orgGuid));
   },
 
   fetchOrgUserRoles(orgGuid) {
@@ -33,6 +35,8 @@ const userActions = {
       type: userActionTypes.ORG_USER_ROLES_FETCH,
       orgGuid
     });
+    return cfApi.fetchOrgUserRoles(orgGuid)
+      .then((orgUsers) => userActions.receivedOrgUserRoles(orgUsers, orgGuid));
   },
 
   fetchSpaceUserRoles(spaceGuid) {
@@ -40,6 +44,9 @@ const userActions = {
       type: userActionTypes.SPACE_USER_ROLES_FETCH,
       spaceGuid
     });
+
+    return cfApi.fetchSpaceUserRoles(spaceGuid)
+      .then((spaceUsers) => userActions.receivedSpaceUserRoles(spaceUsers, spaceGuid));
   },
 
   receivedOrgUsers(users, orgGuid) {
@@ -349,7 +356,8 @@ const userActions = {
   },
 
   fetchEntityUsers(entityGuid, entityType) {
-    return cfApi[(entityType === ORG_NAME) ? 'fetchOrgUsers' : 'fetchSpaceUserRoles'](entityGuid);
+    return cfApi[(entityType === ORG_NAME) ?
+      'fetchOrgUsers' : 'fetchSpaceUserRoles'](entityGuid);
   },
 
   createdUserAndAssociated(userGuid, entityGuid, entityUsers, entityType) {

--- a/static_src/routes.js
+++ b/static_src/routes.js
@@ -38,18 +38,21 @@ export function overview(next) {
   spaceActions.changeCurrentSpace();
   appActions.changeCurrentApp();
 
-  spaceActions.fetchAll()
-    .then(spaces => {
-      let i = 0;
-      const max = Math.min(MAX_OVERVIEW_SPACES, spaces.length);
-      const fetches = [];
-      for (; i < max; i++) {
-        fetches.push(spaceActions.fetch(spaces[i].guid));
-      }
+  Promise.all([
+    orgActions.fetchAll(),
+    spaceActions.fetchAll()
+      .then(spaces => {
+        let i = 0;
+        const max = Math.min(MAX_OVERVIEW_SPACES, spaces.length);
+        const fetches = [];
+        for (; i < max; i++) {
+          fetches.push(spaceActions.fetch(spaces[i].guid));
+        }
 
-      return Promise.all(fetches);
-    })
-    .then(pageActions.loadSuccess, pageActions.loadError);
+        return Promise.all(fetches);
+      })
+  ])
+  .then(pageActions.loadSuccess, pageActions.loadError);
   routerActions.navigate(Overview);
   next();
 }
@@ -91,6 +94,7 @@ export function space(orgGuid, spaceGuid, next) {
 export function app(orgGuid, spaceGuid, appGuid, next) {
   orgActions.toggleSpaceMenu(orgGuid);
   spaceActions.changeCurrentSpace(spaceGuid);
+  orgActions.fetch(orgGuid);
   spaceActions.fetch(spaceGuid);
   activityActions.fetchSpaceEvents(spaceGuid, appGuid);
   activityActions.fetchAppLogs(appGuid);
@@ -162,8 +166,6 @@ export function checkAuth(...args) {
     })
     .then(() => {
       userActions.fetchCurrentUser({ orgGuid, spaceGuid });
-      orgActions.fetchAll();
-      spaceActions.fetchAll();
       next();
     });
 }

--- a/static_src/test/unit/actions/user_actions.spec.js
+++ b/static_src/test/unit/actions/user_actions.spec.js
@@ -26,47 +26,83 @@ describe('userActions', function() {
   });
 
   describe('fetchOrgUsers()', function() {
+    const expectedOrgGuid = 'asdflkjz',
+        expectedParams = {
+          orgGuid: expectedOrgGuid
+        };
+    let spy;
+
+    beforeEach(function(done){
+      spy = setupViewSpy(sandbox);
+      sandbox.stub(cfApi, 'fetchOrgUsers').returns(Promise.resolve([]));
+      sandbox.spy(userActions, 'receivedOrgUsers');
+      userActions.fetchOrgUsers(expectedOrgGuid).then(done, done.fail);
+    });
+
     it('should dispatch a view event of type org users fetch', function() {
-      var expectedOrgGuid = 'asdflkjz',
-          expectedParams = {
-            orgGuid: expectedOrgGuid
-          };
-
-      let spy = setupViewSpy(sandbox);
-
-      userActions.fetchOrgUsers(expectedOrgGuid);
-
       assertAction(spy, userActionTypes.ORG_USERS_FETCH, expectedParams);
+    });
+
+    it('should call cf api fetchOrgUsers', function() {
+      expect(cfApi.fetchOrgUsers).toHaveBeenCalledOnce();
+    });
+
+    it('should call receivedOrgUsers', function() {
+      expect(userActions.receivedOrgUsers).toHaveBeenCalledOnce();
     });
   });
 
   describe('fetchOrgUserRoles()', function() {
+    const expectedOrgGuid = 'zknxvzmnxjkafakdlsxcv',
+        expectedParams = {
+          orgGuid: expectedOrgGuid
+        };
+    let spy;
+
+    beforeEach(function(done){
+      spy = setupViewSpy(sandbox);
+      sandbox.stub(cfApi, 'fetchOrgUserRoles').returns(Promise.resolve([]));
+      sandbox.spy(userActions, 'receivedOrgUserRoles');
+      userActions.fetchOrgUserRoles(expectedOrgGuid).then(done, done.fail);
+    });
+
     it('should dispatch a view event of type org user roles fetch', function() {
-      var expectedOrgGuid = 'zknxvzmnxjkafakdlsxcv',
-          expectedParams = {
-            orgGuid: expectedOrgGuid
-          };
-
-      let spy = setupViewSpy(sandbox);
-
-      userActions.fetchOrgUserRoles(expectedOrgGuid);
-
       assertAction(spy, userActionTypes.ORG_USER_ROLES_FETCH, expectedParams);
+    });
+
+    it('should call cf api fetchOrgUserRoles', function() {
+      expect(cfApi.fetchOrgUserRoles).toHaveBeenCalledOnce();
+    });
+
+    it('should call receivedOrgUserRoles', function() {
+      expect(userActions.receivedOrgUserRoles).toHaveBeenCalledOnce();
     });
   });
 
   describe('fetchSpaceUserRoles()', function() {
+    const expectedSpaceGuid = 'asdflkjz',
+        expectedParams = {
+          spaceGuid: expectedSpaceGuid
+        };
+    let spy;
+
+    beforeEach(function(done){
+      spy = setupViewSpy(sandbox);
+      sandbox.stub(cfApi, 'fetchSpaceUserRoles').returns(Promise.resolve([]));
+      sandbox.spy(userActions, 'receivedSpaceUserRoles');
+      userActions.fetchSpaceUserRoles(expectedSpaceGuid).then(done, done.fail);
+    });
+
     it('should dispatch a view event of type space users fetch', function() {
-      var expectedSpaceGuid = 'asdflkjz',
-          expectedParams = {
-            spaceGuid: expectedSpaceGuid
-          };
-
-      let spy = setupViewSpy(sandbox);
-
-      userActions.fetchSpaceUserRoles(expectedSpaceGuid);
-
       assertAction(spy, userActionTypes.SPACE_USER_ROLES_FETCH, expectedParams);
+    });
+
+    it('should call cf api fetchSpaceUserRoles', function() {
+      expect(cfApi.fetchSpaceUserRoles).toHaveBeenCalledOnce();
+    });
+
+    it('should call receivedSpaceUserRoles', function() {
+      expect(userActions.receivedSpaceUserRoles).toHaveBeenCalledOnce();
     });
   });
 

--- a/static_src/test/unit/routes.spec.js
+++ b/static_src/test/unit/routes.spec.js
@@ -8,7 +8,7 @@ import orgActions from '../../actions/org_actions';
 import spaceActions from '../../actions/space_actions';
 import userActions from '../../actions/user_actions';
 import windowUtil from '../../util/window';
-import { checkAuth } from '../../routes';
+import { checkAuth, overview } from '../../routes';
 
 
 describe('routes', function () {
@@ -20,6 +20,19 @@ describe('routes', function () {
 
   afterEach(function () {
     sandbox.restore();
+  });
+
+  describe('overview()', function () {
+    beforeEach(function (done) {
+      sandbox.stub(orgActions, 'fetchAll').returns(Promise.resolve());
+      sandbox.stub(spaceActions, 'fetchAll').returns(Promise.resolve());
+      overview(done);
+    });
+
+    it('fetches page data', function () {
+      expect(orgActions.fetchAll).toHaveBeenCalledOnce();
+      expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
+    });
   });
 
   describe('checkAuth()', function () {
@@ -49,8 +62,6 @@ describe('routes', function () {
 
       it('fetches page data', function () {
         expect(userActions.fetchCurrentUser).toHaveBeenCalledOnce();
-        expect(orgActions.fetchAll).toHaveBeenCalledOnce();
-        expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
       });
     });
 
@@ -73,8 +84,6 @@ describe('routes', function () {
 
       it('fetches page data', function () {
         expect(userActions.fetchCurrentUser).toHaveBeenCalledOnce();
-        expect(orgActions.fetchAll).toHaveBeenCalledOnce();
-        expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
       });
 
       it('calls userActions.fetchCurrentUser() with guids for filtered API calls', function () {
@@ -112,8 +121,6 @@ describe('routes', function () {
 
       it('fetches page data', function () {
         expect(userActions.fetchCurrentUser).toHaveBeenCalledOnce();
-        expect(orgActions.fetchAll).toHaveBeenCalledOnce();
-        expect(spaceActions.fetchAll).toHaveBeenCalledOnce();
       });
 
       it('calls noticeError action', function () {
@@ -147,8 +154,6 @@ describe('routes', function () {
 
       it('does not fetch page data', function () {
         expect(userActions.fetchCurrentUser).not.toHaveBeenCalled();
-        expect(orgActions.fetchAll).not.toHaveBeenCalled();
-        expect(spaceActions.fetchAll).not.toHaveBeenCalled();
       });
     });
   });

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -35,26 +35,10 @@ describe('UserStore', function () {
   });
 
   describe('on space users fetch', function() {
-    it('should fetch space users through api', function() {
-      var spy = sandbox.spy(cfApi, 'fetchSpaceUserRoles'),
-          expectedGuid = 'axckzvjxcov';
-
-      AppDispatcher.handleViewAction({
-        type: userActionTypes.SPACE_USER_ROLES_FETCH,
-        spaceGuid: expectedGuid
-      });
-
-      expect(spy).toHaveBeenCalledOnce();
-      let arg = spy.getCall(0).args[0];
-      expect(arg).toEqual(expectedGuid);
-    });
-
     it('should set loading', function() {
-      const expectedGuid = 'axckzvjxcov';
-
       AppDispatcher.handleViewAction({
         type: userActionTypes.SPACE_USER_ROLES_FETCH,
-        spaceGuid: expectedGuid
+        spaceGuid: 'axckzvjxcov'
       });
 
       expect(UserStore.loading).toEqual(true);
@@ -63,17 +47,14 @@ describe('UserStore', function () {
 
   describe('on org users fetch', function() {
     it('should fetch org users through the api', function() {
-      var spy = sandbox.spy(cfApi, 'fetchOrgUsers'),
-          expectedGuid = 'axckzvjxcov';
+      const expectedGuid = 'axckzvjxcov';
 
       AppDispatcher.handleViewAction({
         type: userActionTypes.ORG_USERS_FETCH,
-        orgGuid: expectedGuid
+        orgGuid: 'axckzvjxcov'
       });
 
-      expect(spy).toHaveBeenCalledOnce();
-      let arg = spy.getCall(0).args[0];
-      expect(arg).toEqual(expectedGuid);
+      expect(UserStore.loading).toEqual(true);
     });
   });
 
@@ -86,19 +67,78 @@ describe('UserStore', function () {
 
       expect(UserStore.loading).toEqual(true);
     });
+  });
 
-    it('should fetch org user roles through api', function() {
-      var spy = sandbox.spy(cfApi, 'fetchOrgUserRoles'),
-          expectedGuid = 'axckzvjxcov';
-
+  describe('disable loading upon all calls completing for org page', function() {
+    const expectedGuid = 'axckzvjxcov';
+    beforeEach(() => {
       AppDispatcher.handleViewAction({
         type: userActionTypes.ORG_USER_ROLES_FETCH,
         orgGuid: expectedGuid
       });
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.ORG_USERS_FETCH,
+        orgGuid: expectedGuid
+      });
+    });
 
-      expect(spy).toHaveBeenCalledOnce();
-      let arg = spy.getCall(0).args[0];
-      expect(arg).toEqual(expectedGuid);
+    it('should see that loading is true.', function() {
+      expect(UserStore.loading).toEqual(true);
+    });
+
+    it('should see that loading is still true after only org user roles are received', function() {
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
+        orgUserRoles: [],
+        expectedGuid
+      });
+      expect(UserStore.loading).toEqual(true);
+    });
+
+    it('should see that loading is still true after only org users are received', function() {
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.ORG_USERS_RECEIVED,
+        users: [],
+        expectedGuid
+      });
+      expect(UserStore.loading).toEqual(true);
+    });
+
+    it('should see that loading is false after both calls', function() {
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.ORG_USERS_RECEIVED,
+        users: [],
+        expectedGuid
+      });
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.ORG_USER_ROLES_RECEIVED,
+        orgUserRoles: [],
+        expectedGuid
+      });
+      expect(UserStore.loading).toEqual(false);
+    });
+  });
+
+  describe('disable loading upon all calls completing for space page', function() {
+    const expectedGuid = 'axckzvjxcov';
+    beforeEach(() => {
+      AppDispatcher.handleViewAction({
+        type: userActionTypes.SPACE_USER_ROLES_FETCH,
+        spaceGuid: expectedGuid
+      });
+    });
+
+    it('should see that loading is true.', function() {
+      expect(UserStore.loading).toEqual(true);
+    });
+
+    it('should see that loading is false after only space users & roles are received', function() {
+      AppDispatcher.handleServerAction({
+        type: userActionTypes.SPACE_USER_ROLES_RECEIVED,
+        users: [],
+        expectedGuid
+      });
+      expect(UserStore.loading).toEqual(false);
     });
   });
 

--- a/static_src/test/unit/util/cf_api.spec.js
+++ b/static_src/test/unit/util/cf_api.spec.js
@@ -905,7 +905,7 @@ describe('cfApi', function() {
     it('should call fetch with spaces user roles url with space guid and the' +
        ' received space users action', function() {
       var expected = 'yyyybba1',
-          spy = sandbox.stub(cfApi, 'fetchMany');
+          spy = sandbox.spy(cfApi, 'fetchAllPages');
 
       cfApi.fetchSpaceUserRoles(expected);
 
@@ -915,9 +915,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp('spaces'));
       expect(actual).toMatch(new RegExp('user_roles'));
       actual = spy.getCall(0).args[1];
-      expect(actual).toEqual(userActions.receivedSpaceUserRoles);
-      actual = spy.getCall(0).args[2];
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(jasmine.any(Function));
     });
   });
 
@@ -925,7 +923,7 @@ describe('cfApi', function() {
     it('should call fetch org users with org guid and received org users action',
         function() {
       var expected = 'yyyybba1',
-          spy = sandbox.stub(cfApi, 'fetchMany');
+          spy = sandbox.spy(cfApi, 'fetchAllPages');
 
       cfApi.fetchOrgUsers(expected);
 
@@ -935,9 +933,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp('organizations'));
       expect(actual).toMatch(new RegExp('users'));
       actual = spy.getCall(0).args[1];
-      expect(actual).toEqual(userActions.receivedOrgUsers);
-      actual = spy.getCall(0).args[2];
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(jasmine.any(Function));
     });
   });
 
@@ -945,7 +941,7 @@ describe('cfApi', function() {
     it(`should call fetch org user roles with org guid and received org user
         roles action and org guid`, function() {
       var expectedOrgGuid = 'zkjvczcvzwexdvzdfa',
-          spy = sandbox.stub(cfApi, 'fetchMany');
+          spy = sandbox.spy(cfApi, 'fetchAllPages');
 
       cfApi.fetchOrgUserRoles(expectedOrgGuid);
       expect(spy).toHaveBeenCalledOnce();
@@ -954,9 +950,7 @@ describe('cfApi', function() {
       expect(actual).toMatch(new RegExp('organizations'));
       expect(actual).toMatch(new RegExp('roles'));
       actual = spy.getCall(0).args[1];
-      expect(actual).toEqual(userActions.receivedOrgUserRoles);
-      actual = spy.getCall(0).args[2];
-      expect(actual).toEqual(expectedOrgGuid);
+      expect(actual).toEqual(jasmine.any(Function));
     });
   });
 

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -368,15 +368,13 @@ export default {
    * @param {String} orgGuid - The guid of the org that the users belong to.
    */
   fetchOrgUsers(orgGuid) {
-    return this.fetchMany(`/organizations/${orgGuid}/users`,
-                          userActions.receivedOrgUsers,
-                          orgGuid);
+    return this.fetchAllPages(`/organizations/${orgGuid}/users`,
+              (results) => userActions.receivedOrgUsers(results, orgGuid));
   },
 
   fetchOrgUserRoles(orgGuid) {
-    return this.fetchMany(`/organizations/${orgGuid}/user_roles`,
-                          userActions.receivedOrgUserRoles,
-                          orgGuid);
+    return this.fetchAllPages(`/organizations/${orgGuid}/user_roles`,
+              (results) => userActions.receivedOrgUserRoles(results, orgGuid));
   },
 
   deleteUser(userGuid, orgGuid) {

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -5,7 +5,6 @@ import domainActions from '../actions/domain_actions.js';
 import errorActions from '../actions/error_actions.js';
 import quotaActions from '../actions/quota_actions.js';
 import routeActions from '../actions/route_actions.js';
-import userActions from '../actions/user_actions.js';
 
 const APIV = '/v2';
 
@@ -247,8 +246,8 @@ export default {
   },
 
   fetchOrgs() {
-    return http.get(`${APIV}/organizations`)
-      .then(res => this.formatSplitResponses(res.data.resources))
+    return this.fetchAllPages('/organizations',
+      (res) => Promise.resolve(res))
       .catch(err => {
         handleError(err);
         return Promise.reject(err);
@@ -357,9 +356,8 @@ export default {
    * @param {String} spaceGuid - The guid of the space that the users belong to.
    */
   fetchSpaceUserRoles(spaceGuid) {
-    return this.fetchMany(`/spaces/${spaceGuid}/user_roles`,
-                          userActions.receivedSpaceUserRoles,
-                          spaceGuid);
+    return this.fetchAllPages(`/spaces/${spaceGuid}/user_roles`,
+      (results) => Promise.resolve(results));
   },
 
   /**
@@ -369,12 +367,12 @@ export default {
    */
   fetchOrgUsers(orgGuid) {
     return this.fetchAllPages(`/organizations/${orgGuid}/users`,
-              (results) => userActions.receivedOrgUsers(results, orgGuid));
+      (results) => Promise.resolve(results));
   },
 
   fetchOrgUserRoles(orgGuid) {
     return this.fetchAllPages(`/organizations/${orgGuid}/user_roles`,
-              (results) => userActions.receivedOrgUserRoles(results, orgGuid));
+      (results) => Promise.resolve(results));
   },
 
   deleteUser(userGuid, orgGuid) {

--- a/static_src/util/cf_api.js
+++ b/static_src/util/cf_api.js
@@ -247,7 +247,7 @@ export default {
 
   fetchOrgs() {
     return this.fetchAllPages('/organizations',
-      (res) => Promise.resolve(res))
+      results => Promise.resolve(results))
       .catch(err => {
         handleError(err);
         return Promise.reject(err);
@@ -357,7 +357,7 @@ export default {
    */
   fetchSpaceUserRoles(spaceGuid) {
     return this.fetchAllPages(`/spaces/${spaceGuid}/user_roles`,
-      (results) => Promise.resolve(results));
+      results => Promise.resolve(results));
   },
 
   /**
@@ -367,12 +367,12 @@ export default {
    */
   fetchOrgUsers(orgGuid) {
     return this.fetchAllPages(`/organizations/${orgGuid}/users`,
-      (results) => Promise.resolve(results));
+      results => Promise.resolve(results));
   },
 
   fetchOrgUserRoles(orgGuid) {
     return this.fetchAllPages(`/organizations/${orgGuid}/user_roles`,
-      (results) => Promise.resolve(results));
+      results => Promise.resolve(results));
   },
 
   deleteUser(userGuid, orgGuid) {


### PR DESCRIPTION
The tests do not check if the appropriate action is still called but instead now I check for a function.
Eventually, we want to move the actions out of the cf api util file because it shouldn't be so tightly coupled with the actions.

addresses number 2 in https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-6974

## More about the PR

This PR turned out to be a mini refactor as well.
### Use `fetchAllPages` in cf api file
This function was already available but we just weren't using it. We need to revisit the naming of `fetchMany` which actually doesn't get all the pages.
In process of moving to this other function, I removed the use of `userActions` in the CF API file because CF API should not depend on the userActions file. Instead of using one of the userAction promises, I just return the data (via `Promise.resolve`) This decopuling is better but now since the userAction doesn't happen in CF API now, I would need to chain the CF API call with the receivedCall. However, before this PR, all the async work happened in the stores which is an [anti-pattern](https://github.com/18F/cg-dashboard/blob/master/CONTRIBUTING.md#doing-async-work-in-the-stores) so I fixed that. 

### Less Async Work in Store
As mentioned beforehand, now that we removed the userActions from the CF API, the single calls in the store (e.g. `this.load([cfApi.fetchOrgUsers(action.orgGuid)]);`) would now need to be chained with their appropriate userAction
```
return cfApi.fetchOrgUsers(orgGuid)
       .then((users) => userActions.receivedOrgUsers(users, orgGuid));
```
But instead of doing that in the store, just moved those chains to the Fetch actions.

### Change how we track loading state
Previous to this PR, since the store did the async work, it also controlled the loading. (It happens in `this.load` and there's a counter that the base class `BaseStore` has which controls whether it's loading). Now that the actions do the async work, we need a new way to track loading state. The OrgStore and SpaceStore already have `get loading()` but UserStore did not and it would cause the page to stay in an infinite loading spinner. So there's now a `get loading()` for the UserStore that the `userActions` can use and is better than the internal counter.

#### Misc changes
1) For the overview route, the page only loads when `pageActions.loadSuccess` runs. Now that there's more async calls, wrapped them all in a `Promise.all`

2) I moved the loading of all the orgs and spaces to only happen on the overview page. As a result, the app page needed org info so I added an extra `orgActions.fetch(orgGuid);` to the app route