### PR TITLE
Remove old text from old login page

### DIFF
--- a/static_src/components/login.jsx
+++ b/static_src/components/login.jsx
@@ -12,13 +12,6 @@ export default class Login extends React.Component {
       <h1>Welcome to the cloud.gov dashboard</h1>
       <a href="/handshake" className="test-login">
         Login</a>
-      <div className="text-right">
-        <h3>Version: <span>Alpha</span></h3>
-        <a href="https://github.com/18F/cg-dashboard" className="test-contribute_link">
-          <span aria-hidden="true">
-            Contribute</span>
-        </a>
-      </div>
     </div>
     );
   }


### PR DESCRIPTION
So that if it shows up briefly due to a bug (which has happened a few times at various points due to various bugs), at least all it says is "welcome to the cloud.gov dashboard" and "login" instead of having additional confusing text.