### PR TITLE
Ab 1 1 instance errors

### DIFF
--- a/static_src/actions/service_actions.js
+++ b/static_src/actions/service_actions.js
@@ -113,13 +113,13 @@ const serviceActions = {
   },
 
   createInstanceForm(serviceGuid, planGuid) {
-    AppDispatcher.handleViewAction({
-      type: serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM,
-      serviceGuid,
-      servicePlanGuid: planGuid
+    return serviceActions.createInstanceFormCancel().then(() => {
+      AppDispatcher.handleViewAction({
+        type: serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM,
+        serviceGuid,
+        servicePlanGuid: planGuid
+      });
     });
-
-    return Promise.resolve();
   },
 
   createInstanceFormCancel() {

--- a/static_src/components/create_service_instance.jsx
+++ b/static_src/components/create_service_instance.jsx
@@ -12,11 +12,13 @@ import OrgStore from '../stores/org_store.js';
 import SpaceStore from '../stores/space_store.js';
 import ServiceInstanceStore from '../stores/service_instance_store.js';
 import serviceActions from '../actions/service_actions.js';
+import formActions from '../actions/form_actions';
 import { validateString } from '../util/validators';
 
 const CREATE_SERVICE_INSTANCE_FORM_GUID = 'create-service-form';
 
 const propTypes = {
+  error: PropTypes.object,
   service: PropTypes.object,
   servicePlan: PropTypes.object.isRequired
 };
@@ -27,7 +29,6 @@ const defaultProps = {
 
 function stateSetter() {
   return {
-    createError: ServiceInstanceStore.createError,
     createLoading: ServiceInstanceStore.createLoading,
     createdTempNotification: ServiceInstanceStore.createdTempNotification,
     spaces: SpaceStore.getAll()
@@ -40,8 +41,7 @@ export default class CreateServiceInstance extends React.Component {
 
     this.state = {
       errs: [],
-      spaces: SpaceStore.getAll(),
-      createError: ServiceInstanceStore.createError
+      spaces: SpaceStore.getAll()
     };
 
     this.validateString = validateString().bind(this);
@@ -109,24 +109,31 @@ export default class CreateServiceInstance extends React.Component {
     });
   }
 
-  render() {
-    let createError;
+  get contextualAction() {
+    const { createLoading, createdTempNotification } = this.state;
+
     let createAction = (
       <Action label="submit" type="submit">Create service instance</Action>
     );
 
-    if (this.state.createError) {
-      createError = <FormError message={ this.state.createError.description } />
-    }
-
-    if (this.state.createLoading) {
+    if (createLoading) {
       createAction = <Loading style="inline" />;
-    } else if (this.state.createdTempNotification) {
+    } else if (createdTempNotification) {
       createAction = (
         <span className="status status-ok">
           Created! To bind the service instance to an app, go to an application page and use the services panel.
         </span>
       );
+    }
+
+    return createAction;
+  }
+
+  render() {
+    let createError;
+
+    if (this.props.error) {
+      createError = <FormError message={ this.props.error.description } />
     }
 
     return (
@@ -162,7 +169,7 @@ export default class CreateServiceInstance extends React.Component {
             options={ this.validSpaceTargets }
             validator={ this.validateString }
           />
-          { createAction }
+          { this.contextualAction }
           <Action
             label="cancel"
             style="base"

--- a/static_src/components/form/form.jsx
+++ b/static_src/components/form/form.jsx
@@ -33,6 +33,7 @@ const defaultProps = {
 
 function stateSetter(props) {
   const model = FormStore.get(props.guid);
+
   return {
     errors: [],
     model

--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -78,20 +78,24 @@ export default class Marketplace extends React.Component {
     if (state.createInstanceForm) {
       form = (
         <CreateServiceInstance
+          error={ state.createInstanceForm.error }
           service={ state.createInstanceForm.service }
           servicePlan={ state.createInstanceForm.servicePlan }
         />
       );
     }
 
-    let loading = <Loading text="Loading marketplace services" />;
-    let content = <div>{ loading }</div>;
+    let content = (
+      <div>
+        <Loading text="Loading marketplace services" />;
+      </div>
+    );
+
     if (!this.state.loading) {
-      let list = <ServiceList />;
       content = (
         <div>
           { this.documentation }
-          { list }
+          <ServiceList />
           { form }
         </div>
       );

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -2,11 +2,8 @@
 /**
  * Renders a list of services
  */
-
-import style from 'cloudgov-style/css/cloudgov-style.css';
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import ComplexList from './complex_list.jsx';
 import ElasticLine from './elastic_line.jsx';
 import ElasticLineItem from './elastic_line_item.jsx';
@@ -14,7 +11,6 @@ import PanelGroup from './panel_group.jsx';
 import ServiceStore from '../stores/service_store.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
 import ServicePlanList from './service_plan_list.jsx';
-import createStyler from '../util/create_styler';
 import formatDateTime from '../util/format_date.js';
 
 function stateSetter() {
@@ -34,7 +30,6 @@ export default class ServiceList extends React.Component {
   constructor(props) {
     super(props);
     this.state = stateSetter();
-    this.styler = createStyler(style);
   }
 
   componentDidMount() {
@@ -53,7 +48,7 @@ export default class ServiceList extends React.Component {
     let content = <div></div>;
 
     if (this.state.empty) {
-      let content = <h4 className="test-none_message">No services</h4>;
+      content = <h4 className="test-none_message">No services</h4>;
     } else if (this.state.services.length) {
       const state = this.state;
       content = (
@@ -69,10 +64,10 @@ export default class ServiceList extends React.Component {
 
             // TODO use new panel section component
             return (
-              <div className={ this.styler('panel-section') } key={ service.guid }>
+              <div className="panel-section" key={ service.guid }>
                 <ElasticLine>
                   <ElasticLineItem>
-                    <h3 className={ this.styler('sans-s6') }>
+                    <h3 className="sans-s6">
                       <strong>{ service.label }</strong>
                     </h3>
                     <span>{ service.description }</span>

--- a/static_src/components/service_plan.jsx
+++ b/static_src/components/service_plan.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Action from './action.jsx';
+
+const propTypes = {
+  cost: PropTypes.string,
+  onAddInstance: PropTypes.func,
+  plan: PropTypes.shape({
+    guid: PropTypes.string,
+    name: PropTypes.string,
+    description: PropTypes.string
+  })
+};
+
+class ServicePlan extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    const { plan, onAddInstance } = this.props;
+
+    onAddInstance(plan.guid);
+  }
+
+  render() {
+    const { cost, plan } = this.props;
+
+    return (
+      <tr>
+        <td label="Name">{ plan.name }</td>
+        <td label="Description">{ plan.description }</td>
+        <td label="Cost">{ cost }</td>
+        <td label="Actions">
+          <Action
+            classes={ ['test-create_service_instance'] }
+            clickHandler={ this.handleClick }
+            label="create"
+          >
+            Create service instance
+          </Action>
+        </td>
+      </tr>
+    );
+  }
+}
+
+ServicePlan.propTypes = propTypes;
+
+export default ServicePlan;

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -2,15 +2,11 @@
 /**
  * Renders a list of service plans
  */
-
-import style from 'cloudgov-style/css/cloudgov-style.css';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-import Action from './action.jsx';
+import ServicePlan from './service_plan.jsx';
 import serviceActions from '../actions/service_actions.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
-import createStyler from '../util/create_styler';
 
 const propTypes = {
   serviceGuid: PropTypes.string
@@ -42,7 +38,6 @@ export default class ServicePlanList extends React.Component {
 
     this._onChange = this._onChange.bind(this);
     this._handleAdd = this._handleAdd.bind(this);
-    this.styler = createStyler(style);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -54,8 +49,7 @@ export default class ServicePlanList extends React.Component {
   }
 
   _handleAdd(planGuid) {
-    serviceActions.createInstanceForm(this.state.serviceGuid,
-      planGuid);
+    serviceActions.createInstanceForm(this.state.serviceGuid, planGuid);
   }
 
   get columns() {
@@ -91,45 +85,33 @@ export default class ServicePlanList extends React.Component {
           <tr>
             { this.columns.map((column) => {
               return (
-                <th className={ column.key }
-                  key={ column.key }
-                >
-                  { column.label }</th>
+                <th className={ column.key } key={ column.key }>
+                  { column.label }
+                </th>
               );
             })}
           </tr>
         </thead>
         <tbody>
-          { this.rows.map((plan) => {
-            return (
-              <tr key={ plan.guid }>
-                <td label="Name">
-                  <span>{ plan.name }</span>
-                </td>
-                <td label="Description">{ plan.description }</td>
-                <td label="Cost">
-                  <span>
-                    { this.cost(plan) }
-                  </span>
-                </td>
-                <td label="Actions">
-                  <Action
-                    classes={ ["test-create_service_instance"] }
-                    clickHandler={ this._handleAdd.bind(this, plan.guid) }
-                    label="create">
-                      <span>Create service instance</span>
-                  </Action>
-                </td>
-              </tr>
-            )
-          })}
+          {
+            this.rows.map((plan, index) => {
+              return (
+                <ServicePlan
+                  cost={ this.cost(plan) }
+                  key={ index }
+                  onAddInstance={ this._handleAdd }
+                  plan={ plan }
+                />
+              );
+            })
+          }
         </tbody>
       </table>
       );
     }
 
     return (
-    <div className={ this.styler('tableWrapper') }>
+    <div className='tableWrapper'>
       { content }
     </div>
     );

--- a/static_src/stores/service_instance_store.js
+++ b/static_src/stores/service_instance_store.js
@@ -47,8 +47,6 @@ const BINDING_ERROR_MAP = {
 const getFriendlyError = (error, errorMap) => {
   const { code, error_code: errorCode } = error;
 
-  debugger;
-
   if (errorCode in errorMap) {
     return errorMap[errorCode];
   }
@@ -187,16 +185,20 @@ export class ServiceInstanceStore extends BaseStore {
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM: {
         AppDispatcher.waitFor([ServiceStore.dispatchToken]);
+
         this._createInstanceForm = {
+          error: null,
           service: ServiceStore.get(action.serviceGuid),
           servicePlan: ServicePlanStore.get(action.servicePlanGuid)
         };
+
         this.emitChange();
         break;
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM_CANCEL:
         this._createInstanceForm = null;
+
         this.emitChange();
         break;
 
@@ -221,11 +223,15 @@ export class ServiceInstanceStore extends BaseStore {
       }
 
       case serviceActionTypes.SERVICE_INSTANCE_CREATE_ERROR: {
-        this._createError = {
-          description: getFriendlyError(action.error, SERVICE_INSTANCE_CREATE_ERROR_MAP)
-        };
+        this._createInstanceForm = Object.assign({}, this._createInstanceForm || {}, {
+          error: {
+            description: getFriendlyError(action.error, SERVICE_INSTANCE_CREATE_ERROR_MAP)
+          }
+        });
         this._createLoading = false;
+
         this.emitChange();
+
         break;
       }
 

--- a/static_src/test/unit/actions/service_actions.spec.js
+++ b/static_src/test/unit/actions/service_actions.spec.js
@@ -258,23 +258,36 @@ describe('serviceActions', function() {
     });
   });
 
-  describe('createInstanceForm()', function() {
-    it(`should dispatch a view event of type create instance form with the
-        service guid and service plan guid`, function() {
-      var expectedServiceGuid = 'wqphjhajkajkhadjhfd',
-          expectedServicePlanGuid = 'fp2ajkdsfadgh32fasd';
+  describe('createInstanceForm()', () => {
+    const expectedServiceGuid = 'wqphjhajkajkhadjhfd';
+    const expectedServicePlanGuid = 'fp2ajkdsfadgh32fasd';
 
-      let expectedParams = {
-        servicePlanGuid: expectedServicePlanGuid,
-        serviceGuid: expectedServiceGuid
-      };
-      let spy = setupViewSpy(sandbox);
+    const expectedParams = {
+      servicePlanGuid: expectedServicePlanGuid,
+      serviceGuid: expectedServiceGuid
+    };
+
+    it('should dispatch a form cancel action', (done) => {
+      let uiSpy = setupUISpy(sandbox);
 
       serviceActions.createInstanceForm(expectedServiceGuid,
-        expectedServicePlanGuid);
+        expectedServicePlanGuid).then(() => {
+          assertAction(uiSpy, serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM_CANCEL);
+          done();
+        }, done.fail);
+    });
 
-      assertAction(spy, serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM,
-                   expectedParams);
+    it('should dispatch a form create action', (done) => {
+      let viewSpy = setupViewSpy(sandbox);
+
+      sandbox.stub(serviceActions, 'createInstanceFormCancel').returns(Promise.resolve());
+
+      serviceActions.createInstanceForm(expectedServiceGuid,
+        expectedServicePlanGuid).then(() => {
+          assertAction(viewSpy, serviceActionTypes.SERVICE_INSTANCE_CREATE_FORM,
+                       expectedParams);
+          done();
+        }, done.fail);
     });
   });
 

--- a/static_src/test/unit/components/create_service_instance.spec.jsx
+++ b/static_src/test/unit/components/create_service_instance.spec.jsx
@@ -3,25 +3,13 @@ import '../../global_setup';
 import React from 'react';
 import CreateServiceInstance from '../../../components/create_service_instance.jsx';
 import FormError from '../../../components/form/form_error.jsx';
-import Immutable from 'immutable';
-import SpaceStore from '../../../stores/space_store';
-import ServiceInstanceStore from '../../../stores/service_instance_store';
 import serviceActions from '../../../actions/service_actions';
 import { shallow } from 'enzyme';
 
 describe('<CreateServiceInstance />', () => {
-  beforeEach(() => {
-    ServiceInstanceStore._createError = { description: 'Bad stuff everyone' };
-  });
-
-  afterEach(() => {
-    ServiceInstanceStore._createError = null;
-  });
-
   it('displays an error message when ServiceInstanceStore has one', () => {
-    SpaceStore._data = Immutable.fromJS([]);
-
-    const wrapper = shallow(<CreateServiceInstance servicePlan={ {} } />);
+    const error = { description: 'Bad stuff everyone' };
+    const wrapper = shallow(<CreateServiceInstance servicePlan={ {} } error={ error } />);
 
     expect(wrapper.find(FormError).length).toBe(1);
   });

--- a/static_src/test/unit/components/service_plan.spec.jsx
+++ b/static_src/test/unit/components/service_plan.spec.jsx
@@ -1,0 +1,57 @@
+import '../../global_setup';
+import React from 'react';
+import { shallow } from 'enzyme';
+import ServicePlan from '../../../components/service_plan.jsx';
+import Action from '../../../components/action.jsx';
+
+describe('<ServicePlan />', () => {
+  const props = {
+    cost: 'Free',
+    onAddInstance: sinon.spy(),
+    plan: {
+      guid: 'zgwefzexst4',
+      name: 'redis',
+      description: 'in-memory key value store'
+    }
+  };
+  const findPlanNodeByLabel = (wrapper, label) =>
+    wrapper.find('td').filterWhere(node => node.prop('label') === label);
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<ServicePlan { ...props } />);
+  });
+
+  it('renders an action button for service instance creation', () => {
+    const button = wrapper.find(Action);
+
+    expect(button.length).toBe(1);
+    expect(button.props().children).toBe('Create service instance');
+  });
+
+  it('renders the name of the plan', () => {
+    const name = findPlanNodeByLabel(wrapper, 'Name');
+
+    expect(name.text()).toBe(props.plan.name);
+  });
+
+  it('renders the plan description', () => {
+    const description = findPlanNodeByLabel(wrapper, 'Description');
+
+    expect(description.text()).toBe(props.plan.description);
+  });
+
+  it('renders the cost of the plan', () => {
+    const cost = findPlanNodeByLabel(wrapper, 'Cost');
+
+    expect(cost.text()).toBe(props.cost);
+  });
+
+  it('calls its `onAddInstance` prop passing the plan guid from handler', () => {
+    wrapper.instance().handleClick();
+
+    expect(props.onAddInstance.calledOnce).toBe(true);
+    expect(props.onAddInstance.calledWith(props.plan.guid)).toBe(true);
+  });
+});

--- a/static_src/test/unit/stores/service_instance_store.spec.js
+++ b/static_src/test/unit/stores/service_instance_store.spec.js
@@ -245,22 +245,24 @@ describe('ServiceInstanceStore', function() {
     });
   });
 
-  describe('on service instance create ui', function() {
-    it('should set createInstanceForm to object with service and plan from stores',
-        function() {
-      var expectedService = { guid: 'adsf3232222a' },
-          expectedServicePlan = { guid: 'zxvczvqe' };
+  describe('on service instance create ui', () => {
+    it('should set createInstanceForm to object with service and plan from stores', (done) => {
+      const expectedService = { guid: 'adsf3232222a' };
+      const expectedServicePlan = { guid: 'zxvczvqe' };
 
       sandbox.stub(ServiceStore, 'get').returns(expectedService);
       sandbox.stub(ServicePlanStore, 'get').returns(expectedServicePlan);
+      sandbox.stub(serviceActions, 'createInstanceFormCancel').returns(Promise.resolve());
 
-      serviceActions.createInstanceForm('adfkjvnzxczv', 'aldsfjalqwe');
+      serviceActions.createInstanceForm('adfkjvnzxczv', 'aldsfjalqwe').then(() => {
+        const actual = ServiceInstanceStore.createInstanceForm;
 
-      let actual = ServiceInstanceStore.createInstanceForm;
-
-      expect(actual).toBeTruthy();
-      expect(actual.service).toEqual(expectedService);
-      expect(actual.servicePlan).toEqual(expectedServicePlan);
+        expect(actual).toBeTruthy();
+        expect(actual.error).toBe(null);
+        expect(actual.service).toEqual(expectedService);
+        expect(actual.servicePlan).toEqual(expectedServicePlan);
+        done();
+      }, done);
     });
 
     it('should emit a change event', function() {
@@ -295,7 +297,7 @@ describe('ServiceInstanceStore', function() {
       return { response: { data: { error_code: code } } };
     };
 
-    it('should set `createError` based on error received', () => {
+    it('should set error props of instance form based on error received', () => {
       const serverError = { code: 500 };
       const argumentError = serviceInstanceError('CF-MessageParseError');
       const spaceError = serviceInstanceError('CF-ServiceInstanceInvalid');
@@ -307,35 +309,35 @@ describe('ServiceInstanceStore', function() {
       let actual;
 
       serviceActions.errorCreateInstance(serverError);
-      actual = ServiceInstanceStore.createError;
+      actual = ServiceInstanceStore._createInstanceForm.error;
 
       expect(actual).toEqual({
         description: serverErrorMsg
       });
 
       serviceActions.errorCreateInstance(argumentError);
-      actual = ServiceInstanceStore.createError;
+      actual = ServiceInstanceStore._createInstanceForm.error;
 
       expect(actual).toEqual({
         description: SERVICE_INSTANCE_CREATE_ERROR_MAP['CF-MessageParseError']
       });
 
       serviceActions.errorCreateInstance(spaceError);
-      actual = ServiceInstanceStore.createError;
+      actual = ServiceInstanceStore._createInstanceForm.error;
 
       expect(actual).toEqual({
         description: SERVICE_INSTANCE_CREATE_ERROR_MAP['CF-ServiceInstanceInvalid']
       });
 
       serviceActions.errorCreateInstance(configError);
-      actual = ServiceInstanceStore.createError;
+      actual = ServiceInstanceStore._createInstanceForm.error;
 
       expect(actual).toEqual({
         description: SERVICE_INSTANCE_CREATE_ERROR_MAP['CF-ServiceBrokerBadResponse']
       });
 
       serviceActions.errorCreateInstance(dupeNameError);
-      actual = ServiceInstanceStore.createError;
+      actual = ServiceInstanceStore._createInstanceForm.error;
 
       expect(actual).toEqual({
         description: SERVICE_INSTANCE_CREATE_ERROR_MAP['CF-ServiceInstanceNameTaken']


### PR DESCRIPTION
Maps service instance creation form errors to the underlying form object in the `ServiceInstanceStore`, not to the `Form` or `CreateServiceInstance` components. We clear the existing form each time a new service instance is selected for creation by calling the `SERVICE_INSTANCE_CREATE_FORM_CANCEL` action type

**Handy GIF reference**:
![1-to-1-errors](https://user-images.githubusercontent.com/1421848/29124269-73498cce-7ce6-11e7-869a-af3e3d098a51.gif)
