### PR TITLE
Fix instances of leftover React.PropTypes

### DIFF
--- a/static_src/components/action.jsx
+++ b/static_src/components/action.jsx
@@ -26,7 +26,7 @@ const propTypes = {
   href: PropTypes.string,
   label: PropTypes.string,
   style: PropTypes.oneOf(BUTTON_STYLES),
-  type: PropTypes.oneOf(BUTTON_TYPES)
+  type: PropTypes.oneOf(Object.keys(BUTTON_TYPES).map(t => BUTTON_TYPES[t]))
 };
 const defaultProps = {
   style: 'primary',

--- a/static_src/components/action/button.jsx
+++ b/static_src/components/action/button.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
-  children: React.PropTypes.any,
-  className: React.PropTypes.string,
-  clickHandler: React.PropTypes.func,
-  disabled: React.PropTypes.bool,
-  label: React.PropTypes.string,
-  type: React.PropTypes.string
+  children: PropTypes.any,
+  className: PropTypes.string,
+  clickHandler: PropTypes.func,
+  disabled: PropTypes.bool,
+  label: PropTypes.string,
+  type: PropTypes.string
 };
 
 const button = ({ className, label, clickHandler, disabled, type, children }) =>

--- a/static_src/components/action/link.jsx
+++ b/static_src/components/action/link.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const propTypes = {
-  children: React.PropTypes.any,
-  className: React.PropTypes.string,
-  clickHandler: React.PropTypes.func,
-  href: React.PropTypes.string,
-  label: React.PropTypes.string
+  children: PropTypes.any,
+  className: PropTypes.string,
+  clickHandler: PropTypes.func,
+  href: PropTypes.string,
+  label: PropTypes.string
 };
 const defaultHref = '#';
 

--- a/static_src/components/complex_list.jsx
+++ b/static_src/components/complex_list.jsx
@@ -1,15 +1,14 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-
 import ComplexListItem from './complex_list_item.jsx';
 import createStyler from '../util/create_styler';
 import style from 'cloudgov-style/css/cloudgov-style.css';
 
 const propTypes = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object
+  children: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object
   ]),
   className: PropTypes.string,
   title: PropTypes.string,


### PR DESCRIPTION
There were a few files that still used `React.PropTypes`, this removes those references in lieu of the `prop-types` package