### PR TITLE
Split out space roles into own property for user

### DIFF
--- a/static_src/components/user_role_list_control.jsx
+++ b/static_src/components/user_role_list_control.jsx
@@ -82,7 +82,12 @@ export default class UserRoleListControl extends React.Component {
   }
 
   roles() {
-    const roles = this.props.user.roles;
+    let roles;
+    if (this.props.userType == 'space_users') {
+      roles = this.props.user.space_roles;
+    } else {
+      roles = this.props.user.roles;
+    }
     return roles ?
       (roles[this.props.entityGuid] || []) :
       []

--- a/static_src/stores/base_store.js
+++ b/static_src/stores/base_store.js
@@ -78,6 +78,17 @@ export default class BaseStore extends EventEmitter {
     return !Immutable.is(this._data, c);
   }
 
+  deleteProp(guid, prop, cb = defaultChangedCallback.bind(this)) {
+    const index = this._data.findIndex((d) =>
+      d.get('guid') === guid
+    );
+
+    if (index === -1) return cb(false);
+
+    this._data = this._data.deleteIn([index, prop]);
+    return cb(true);
+  }
+
   delete(guid, cb = defaultChangedCallback.bind(this)) {
     const index = this._data.findIndex((d) =>
       d.get('guid') === guid

--- a/static_src/test/unit/components/user_role_list_control.spec.jsx
+++ b/static_src/test/unit/components/user_role_list_control.spec.jsx
@@ -73,7 +73,7 @@ describe('<UserRoleListControl />', function () {
       const userGuid = 'a-user-guid';
       const user = {
         guid: userGuid,
-        roles: []
+        space_roles: {}
       };
 
       userRoleListControl = shallow(
@@ -103,7 +103,7 @@ describe('<UserRoleListControl />', function () {
         const user = {
           guid: 'user-123',
           entityGuid: spaceGuid,
-          roles: {
+          space_roles: {
             [spaceGuid]: ['space_manager']
           }
         };

--- a/static_src/test/unit/stores/base_store.spec.js
+++ b/static_src/test/unit/stores/base_store.spec.js
@@ -214,6 +214,80 @@ describe('BaseStore', () => {
     });
   });
 
+  describe('deleteProp', function() {
+    const existingEntityA = {
+      guid: 'zznbmbz',
+      name: 'ea',
+      cpu: 34
+    };
+    const existingEntityB = {
+      guid: 'zzlkcxv',
+      name: 'eb',
+      cpu: 66
+    };
+
+    beforeEach(function() {
+      store.push(existingEntityA);
+      store.push(existingEntityB);
+    });
+
+    it('should remove the property that match the guid and prop and call .emitChange()', function () {
+      var spy = sandbox.spy(store, 'emitChange');
+      var guidA = existingEntityA.guid;
+      var guidB = existingEntityB.guid
+
+      expect(store.getAll().length).toEqual(2);
+      expect(store.get(guidB)).toEqual(existingEntityB);
+      expect(store.get(guidA)).toEqual(existingEntityA);
+
+      store.deleteProp(guidB, 'cpu');
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(store.getAll().length).toEqual(2);
+      expect(store.get(guidB).cpu).toEqual(undefined);
+      expect(store.get(guidB).guid).toEqual(existingEntityB.guid);
+      expect(store.get(guidB).name).toEqual(existingEntityB.name);
+      expect(store.get(guidA)).toEqual(existingEntityA);
+    });
+
+    it('should do nothing if the guid does not match', function () {
+      var spy = sandbox.spy(store, 'emitChange');
+      var guidA = existingEntityA.guid;
+      var guidB = existingEntityB.guid
+
+      expect(store.getAll().length).toEqual(2);
+      expect(store.get(guidB)).toEqual(existingEntityB);
+      expect(store.get(guidA)).toEqual(existingEntityA);
+
+      store.deleteProp('nonExistentFakeGuid', 'cpu');
+
+      expect(spy).not.toHaveBeenCalledOnce();
+      expect(store.getAll().length).toEqual(2);
+      expect(store.get(guidB)).toEqual(existingEntityB);
+      expect(store.get(guidA)).toEqual(existingEntityA);
+    });
+
+    it('should do nothing if the prop does not match but will call emitChange', function () {
+      // Currently there's no way to detect in a thread safe way that the deleteIn
+      // was successful, so emitChange will be called.
+      // There will still be no change though.
+      var spy = sandbox.spy(store, 'emitChange');
+      var guidA = existingEntityA.guid;
+      var guidB = existingEntityB.guid
+
+      expect(store.getAll().length).toEqual(2);
+      expect(store.get(guidB)).toEqual(existingEntityB);
+      expect(store.get(guidA)).toEqual(existingEntityA);
+
+      store.deleteProp(guidA, 'ram');
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(store.getAll().length).toEqual(2);
+      expect(store.get(guidB)).toEqual(existingEntityB);
+      expect(store.get(guidA)).toEqual(existingEntityA);
+    });
+  });
+
   describe('merge()', function() {
     var existingEntityA = {
       guid: 'zznbmbz',

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -169,19 +169,17 @@ describe('UserStore', function () {
       const currentUsers = [
         {
           guid: userGuidB,
-          roles: { [spaceGuid]: ['space_developer'] }
+          space_roles: { [spaceGuid]: ['space_developer'] }
         }
       ];
       expectedUsers = [
         {
           guid: userGuidA,
-          roles: { [spaceGuid]: ['space_developer'] },
-          space_roles: [ 'space_developer' ]
+          space_roles: { [spaceGuid]: ['space_developer'] }
         },
         {
           guid: userGuidB,
-          roles: { [spaceGuid]: ['space_developer', 'space_manager'] },
-          space_roles: [ 'space_developer', 'space_manager' ]
+          space_roles: { [spaceGuid]: ['space_developer', 'space_manager'] }
         }
       ];
 
@@ -384,8 +382,10 @@ describe('UserStore', function () {
       beforeEach(function() {
         const existingUser = {
           guid: userGuid,
+          space_roles: {
+            [spaceGuid]: [existingRole]
+          },
           roles: {
-            [spaceGuid]: [existingRole],
             [otherOrgGuid]: ['org_manager']
           }
         };
@@ -401,12 +401,12 @@ describe('UserStore', function () {
         expect(UserStore.emitChange).toHaveBeenCalledOnce();
       });
 
-      it('should add the role for that org', function() {
-        expect(user.roles[spaceGuid]).toContain(addedRole);
+      it('should add the role for that space', function() {
+        expect(user.space_roles[spaceGuid]).toContain(addedRole);
       });
 
       it('should not change any other roles', function() {
-        expect(user.roles[spaceGuid]).toContain(existingRole);
+        expect(user.space_roles[spaceGuid]).toContain(existingRole);
         expect(user.roles[otherOrgGuid]).toContain('org_manager');
       });
     });
@@ -427,7 +427,7 @@ describe('UserStore', function () {
       });
 
       it('should add the role for that org', function() {
-        expect(user.roles[spaceGuid]).toContain(addedRole);
+        expect(user.space_roles[spaceGuid]).toContain(addedRole);
       });
     });
   });
@@ -699,7 +699,7 @@ describe('UserStore', function () {
     // TODO possibly move this functionality to shared place.
     it('should find all user that have the space guid passed in', function() {
       var spaceGuid = 'asdfa';
-      var testUser = { guid: 'adfzxcv', roles: { [spaceGuid]: [ 'space_user'] } };
+      var testUser = { guid: 'adfzxcv', space_roles: { [spaceGuid]: [ 'space_user'] } };
 
       UserStore.push(testUser);
 


### PR DESCRIPTION
Desired behavior: ability to reflect users in the store correctly so that the drop down and user list render correctly with users w/o permissions to the space and users w/ permissions to the space.

Problem found:
When we load the page, the space roles are loaded correctly in the .`roles` property of the user but they are not loaded into the same layout as the org permissions.
Org permissions were mapped from a org guid to an array of strings.
The Space permissions were just an array of strings (only showing perms for the current space)
On the space page, both were loaded into `.roles`. 
The logic to add and remove roles depending on a map `user.roles[guid]`
It worked for org stuff but since it wouldn't find the right role for spaces, it wouldn't actually add or delete to the store (but upon refresh, fresh API calls would get the new data)

Solution:
## Part 1 
Added conditional to `mergeRoles` which creates a `.space_roles` property on the user in the user store and splits it out from `.roles`.
- Reason: now that we have both the org roles and the space roles loaded at the same time on the space page, I chose to keep the similar logic of using a map so the code wouldn't get too complicated (i started down that route initially but it was weird) 

We also, couldn't map into the same `roles` because there could be a org with the same guid as the space guid
if guid-2 and guid were equal, it could get weird.
Example
  ```
  {
  'guid': 'user-guid',
  'roles': { 'guid' : ['org-manager'], 'guid-2': ['space-manager']}
  }
  ```

As a result of this introduction of `space_roles`, you'll see that there's multiple checks for whether we are on the space view or not (determines whether it will use `roles` vs `space_roles` property of the user)
## Part 2
Created `deleteProp` so that the remove all users from space would just drop the `space_roles` property from the user which would make them automagically disappear.
Previous to this, the user itself was just being deleted from the store but we want to keep the user but just remove their space_roles