### PR TITLE
Fetch Services and Plans once in <Marketplace/> component

### DIFF
--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -3,7 +3,6 @@
  */
 
 import React from 'react';
-
 import CreateServiceInstance from './create_service_instance.jsx';
 import Loading from './loading.jsx';
 import OrgStore from '../stores/org_store.js';
@@ -12,9 +11,9 @@ import ServiceInstanceStore from '../stores/service_instance_store.js';
 import ServiceList from './service_list.jsx';
 import ServicePlanStore from '../stores/service_plan_store.js';
 import ServiceStore from '../stores/service_store.js';
-import createStyler from '../util/create_styler';
 import { config } from 'skin';
-import style from 'cloudgov-style/css/cloudgov-style.css';
+
+const propTypes = {};
 
 function stateSetter() {
   const loading = ServiceStore.loading || ServicePlanStore.loading;
@@ -24,7 +23,11 @@ function stateSetter() {
     currentOrgGuid,
     loading: loading,
     currentOrg: OrgStore.get(currentOrgGuid),
-    createInstanceForm: ServiceInstanceStore.createInstanceForm
+    createInstanceForm: ServiceInstanceStore.createInstanceForm,
+    services: ServiceStore.getAll().map((service) => {
+      const plan = ServicePlanStore.getAllFromService(service.guid);
+      return { ...service, servicePlans: plan };
+    })
   };
 }
 
@@ -35,7 +38,6 @@ export default class Marketplace extends React.Component {
     this.state = stateSetter();
 
     this._onChange = this._onChange.bind(this);
-    this.styler = createStyler(style);
   }
 
   componentDidMount() {
@@ -85,17 +87,13 @@ export default class Marketplace extends React.Component {
       );
     }
 
-    let content = (
-      <div>
-        <Loading text="Loading marketplace services" />;
-      </div>
-    );
+    let content = <Loading text="Loading marketplace services" />;
 
-    if (!this.state.loading) {
+    if (!state.loading) {
       content = (
         <div>
           { this.documentation }
-          <ServiceList />
+          <ServiceList services={ state.services } />
           { form }
         </div>
       );
@@ -109,4 +107,4 @@ export default class Marketplace extends React.Component {
   }
 }
 
-Marketplace.propTypes = { };
+Marketplace.propTypes = propTypes;

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -4,96 +4,60 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import ComplexList from './complex_list.jsx';
 import ElasticLine from './elastic_line.jsx';
 import ElasticLineItem from './elastic_line_item.jsx';
-import PanelGroup from './panel_group.jsx';
 import ServiceStore from '../stores/service_store.js';
-import ServicePlanStore from '../stores/service_plan_store.js';
 import ServicePlanList from './service_plan_list.jsx';
 import formatDateTime from '../util/format_date.js';
 
-function stateSetter() {
-  const services = ServiceStore.getAll().map((service) => {
-    const plan = ServicePlanStore.getAllFromService(service.guid);
-    return { ...service, servicePlans: plan };
-  });
+const propTypes = {
+  services: PropTypes.array
+};
 
-  return {
-    empty: !ServiceStore.loading && !services.length,
-    services
+const empty = services => !ServiceStore.loading && !services.length;
+
+const ServiceList = ({ services }) => {
+  const { services } = this.props;
+
+  let content = <div></div>;
+
+  if (empty(services)) {
+    content = <h4 className="test-none_message">No services</h4>;
+  } else if (services.length) {
+    content = (
+      <div>
+        { services.map((service) => {
+          const { servicePlans, guid, label, description, updated_at } = service;
+
+          return (
+            <div className="panel-section" key={ guid }>
+              <ElasticLine>
+                <ElasticLineItem>
+                  <h3 className="sans-s6">
+                    <strong>{ label }</strong>
+                  </h3>
+                  <span>{ description }</span>
+                </ElasticLineItem>
+                <ElasticLineItem align="end">
+                  Updated { formatDateTime(updated_at) }
+                </ElasticLineItem>
+              </ElasticLine>
+              <ServicePlanList plans={ servicePlans } serviceGuid={ guid } />
+            </div>
+          );
+        })}
+      </div>
+    );
   }
-}
 
-
-export default class ServiceList extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = stateSetter();
-  }
-
-  componentDidMount() {
-    ServiceStore.addChangeListener(this._onChange);
-  }
-
-  componentWillUnmount() {
-    ServiceStore.removeChangeListener(this._onChange);
-  }
-
-  _onChange() {
-    this.setState(stateSetter());
-  }
-
-  render() {
-    let content = <div></div>;
-
-    if (this.state.empty) {
-      content = <h4 className="test-none_message">No services</h4>;
-    } else if (this.state.services.length) {
-      const state = this.state;
-      content = (
-        <div>
-          { state.services.map((service) => {
-            let servicePlans;
-
-            if (service.servicePlans.length) {
-              servicePlans = (
-                <ServicePlanList serviceGuid={ service.guid } />
-              );
-            }
-
-            // TODO use new panel section component
-            return (
-              <div className="panel-section" key={ service.guid }>
-                <ElasticLine>
-                  <ElasticLineItem>
-                    <h3 className="sans-s6">
-                      <strong>{ service.label }</strong>
-                    </h3>
-                    <span>{ service.description }</span>
-                  </ElasticLineItem>
-                  <ElasticLineItem align="end">
-                    Updated { formatDateTime(service.updated_at) }
-                  </ElasticLineItem>
-                </ElasticLine>
-                { servicePlans }
-              </div>
-            );
-          })}
-        </div>
-      );
-    }
-
-    return (
+  return (
     <div>
       { content }
     </div>
-    );
-  }
-}
-
-ServiceList.propTypes = {
-  initialServices: PropTypes.array
+  );
 };
 
+ServiceList.propTypes = propTypes;
 ServiceList.defaultProps = {};
+
+export default ServiceList;

--- a/static_src/components/service_list.jsx
+++ b/static_src/components/service_list.jsx
@@ -4,11 +4,8 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import ElasticLine from './elastic_line.jsx';
-import ElasticLineItem from './elastic_line_item.jsx';
+import ServiceListItem from './service_list_item.jsx';
 import ServiceStore from '../stores/service_store.js';
-import ServicePlanList from './service_plan_list.jsx';
-import formatDateTime from '../util/format_date.js';
 
 const propTypes = {
   services: PropTypes.array
@@ -16,11 +13,9 @@ const propTypes = {
 
 const empty = services => !ServiceStore.loading && !services.length;
 
+let content = null;
+
 const ServiceList = ({ services }) => {
-  const { services } = this.props;
-
-  let content = <div></div>;
-
   if (empty(services)) {
     content = <h4 className="test-none_message">No services</h4>;
   } else if (services.length) {
@@ -30,20 +25,14 @@ const ServiceList = ({ services }) => {
           const { servicePlans, guid, label, description, updated_at } = service;
 
           return (
-            <div className="panel-section" key={ guid }>
-              <ElasticLine>
-                <ElasticLineItem>
-                  <h3 className="sans-s6">
-                    <strong>{ label }</strong>
-                  </h3>
-                  <span>{ description }</span>
-                </ElasticLineItem>
-                <ElasticLineItem align="end">
-                  Updated { formatDateTime(updated_at) }
-                </ElasticLineItem>
-              </ElasticLine>
-              <ServicePlanList plans={ servicePlans } serviceGuid={ guid } />
-            </div>
+            <ServiceListItem
+              key={ guid }
+              guid={ guid }
+              label={ label }
+              description={ description }
+              updatedAt={ updated_at }
+              servicePlans={ servicePlans }
+            />
           );
         })}
       </div>

--- a/static_src/components/service_list_item.jsx
+++ b/static_src/components/service_list_item.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ElasticLine from './elastic_line.jsx';
+import ElasticLineItem from './elastic_line_item.jsx';
+import ServicePlanList from './service_plan_list.jsx';
+import formatDateTime from '../util/format_date.js';
+
+const ServiceListItem = ({ guid, label, description, updatedAt, servicePlans}) =>
+  <div className="panel-section">
+    <ElasticLine>
+      <ElasticLineItem>
+        <h3 className="sans-s6">
+          <strong>{ label }</strong>
+        </h3>
+        <span>{ description }</span>
+      </ElasticLineItem>
+      <ElasticLineItem align="end">
+        Updated { formatDateTime(updatedAt) }
+      </ElasticLineItem>
+    </ElasticLine>
+    <ServicePlanList plans={ servicePlans } serviceGuid={ guid } />
+  </div>;
+
+export default ServiceListItem;

--- a/static_src/components/service_list_item.jsx
+++ b/static_src/components/service_list_item.jsx
@@ -5,7 +5,15 @@ import ElasticLineItem from './elastic_line_item.jsx';
 import ServicePlanList from './service_plan_list.jsx';
 import formatDateTime from '../util/format_date.js';
 
-const ServiceListItem = ({ guid, label, description, updatedAt, servicePlans}) =>
+const propTypes = {
+  guid: PropTypes.string,
+  label: PropTypes.string,
+  description: PropTypes.string,
+  updatedAt: PropTypes.string,
+  servicePlans: PropTypes.array
+};
+
+const ServiceListItem = ({ guid, label, description, updatedAt, servicePlans }) =>
   <div className="panel-section">
     <ElasticLine>
       <ElasticLineItem>
@@ -20,5 +28,7 @@ const ServiceListItem = ({ guid, label, description, updatedAt, servicePlans}) =
     </ElasticLine>
     <ServicePlanList plans={ servicePlans } serviceGuid={ guid } />
   </div>;
+
+ServiceListItem.propTypes = propTypes;
 
 export default ServiceListItem;

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -48,10 +48,6 @@ export default class ServicePlanList extends React.Component {
     return columns;
   }
 
-  get rows() {
-    return this.props.plans;
-  }
-
   cost(plan) {
     const cost = ServicePlanStore.getCost(plan);
     if (plan.free || cost === 0) return 'Free';
@@ -59,12 +55,12 @@ export default class ServicePlanList extends React.Component {
   }
 
   render() {
-    const { plans } = this.props;
+    const plans = sortPlansByCost(this.props.plans);
     let content = <div></div>;
 
     if (empty(plans)) {
       content = <h4 className="test-none_message">No service plans</h4>;
-    } else if (this.rows.length) {
+    } else if (plans.length) {
       content = (
         <table>
           <thead>
@@ -80,7 +76,7 @@ export default class ServicePlanList extends React.Component {
           </thead>
           <tbody>
             {
-              this.rows.map((plan, index) => {
+              plans.map((plan, index) => {
                 return (
                   <ServicePlan
                     cost={ this.cost(plan) }

--- a/static_src/components/service_plan_list.jsx
+++ b/static_src/components/service_plan_list.jsx
@@ -9,11 +9,14 @@ import serviceActions from '../actions/service_actions.js';
 import ServicePlanStore from '../stores/service_plan_store.js';
 
 const propTypes = {
+  plans: PropTypes.array,
   serviceGuid: PropTypes.string
 };
 
-function stateSetter(serviceGuid) {
-  const servicePlans = ServicePlanStore.getAllFromService(serviceGuid).sort((a, b) => {
+const empty = plans => !ServicePlanStore.loading && !plans.length;
+
+const sortPlansByCost = (plans) =>
+  plans.sort((a, b) => {
     const costA = ServicePlanStore.getCost(a);
     const costB = ServicePlanStore.getCost(b);
     if (costA === costB) {
@@ -23,33 +26,15 @@ function stateSetter(serviceGuid) {
     }
   });
 
-  return {
-    serviceGuid,
-    servicePlans,
-    empty: !ServicePlanStore.loading && !servicePlans.length
-  };
-}
-
 export default class ServicePlanList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = stateSetter(props.serviceGuid);
-
-    this._onChange = this._onChange.bind(this);
     this._handleAdd = this._handleAdd.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState(stateSetter(nextProps.serviceGuid));
-  }
-
-  _onChange() {
-    this.setState(stateSetter(this.state.serviceGuid));
-  }
-
   _handleAdd(planGuid) {
-    serviceActions.createInstanceForm(this.state.serviceGuid, planGuid);
+    serviceActions.createInstanceForm(this.props.serviceGuid, planGuid);
   }
 
   get columns() {
@@ -64,7 +49,7 @@ export default class ServicePlanList extends React.Component {
   }
 
   get rows() {
-    return this.state.servicePlans;
+    return this.props.plans;
   }
 
   cost(plan) {
@@ -74,46 +59,47 @@ export default class ServicePlanList extends React.Component {
   }
 
   render() {
+    const { plans } = this.props;
     let content = <div></div>;
 
-    if (this.state.empty) {
+    if (empty(plans)) {
       content = <h4 className="test-none_message">No service plans</h4>;
     } else if (this.rows.length) {
       content = (
-      <table>
-        <thead>
-          <tr>
-            { this.columns.map((column) => {
-              return (
-                <th className={ column.key } key={ column.key }>
-                  { column.label }
-                </th>
-              );
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {
-            this.rows.map((plan, index) => {
-              return (
-                <ServicePlan
-                  cost={ this.cost(plan) }
-                  key={ index }
-                  onAddInstance={ this._handleAdd }
-                  plan={ plan }
-                />
-              );
-            })
-          }
-        </tbody>
-      </table>
+        <table>
+          <thead>
+            <tr>
+              { this.columns.map((column) => {
+                return (
+                  <th className={ column.key } key={ column.key }>
+                    { column.label }
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {
+              this.rows.map((plan, index) => {
+                return (
+                  <ServicePlan
+                    cost={ this.cost(plan) }
+                    key={ index }
+                    onAddInstance={ this._handleAdd }
+                    plan={ plan }
+                  />
+                );
+              })
+            }
+          </tbody>
+        </table>
       );
     }
 
     return (
-    <div className='tableWrapper'>
-      { content }
-    </div>
+      <div className='tableWrapper'>
+        { content }
+      </div>
     );
   }
 }

--- a/static_src/test/unit/components/service_list_item.spec.jsx
+++ b/static_src/test/unit/components/service_list_item.spec.jsx
@@ -1,0 +1,32 @@
+import '../../global_setup';
+import React from 'react';
+import { shallow } from 'enzyme';
+import ServiceListItem from '../../../components/service_list_item.jsx';
+import ServicePlanList from '../../../components/service_plan_list.jsx';
+
+const props = {
+  guid: 'abc',
+  label: 'service',
+  description: 'it does things',
+  updatedAt: new Date(),
+  servicePlans: []
+};
+
+describe('<ServiceListItem />', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(<ServiceListItem { ...props } />);
+  });
+
+  it('renders a <ServicePlanList /> component', () => {
+    const planList = wrapper.find(ServicePlanList);
+
+    expect(planList.length).toBe(1);
+    expect(planList.props()).toEqual({
+      serviceGuid: props.guid,
+      plans: props.servicePlans
+    });
+  });
+});
+


### PR DESCRIPTION
Rather than perform multiple fetches and rely on state in component, fetch services and associated plans once in <Marketplace />, and pass those down to child components.

I _think_ this also resolves the bug where a user on a space page sees a service, but no associated plans.