### PR TITLE
Restore call to `receivedSpaceUserRoles` after inviting user to space

### DIFF
--- a/static_src/actions/user_actions.js
+++ b/static_src/actions/user_actions.js
@@ -71,6 +71,8 @@ const userActions = {
       users,
       spaceGuid
     });
+
+    return Promise.resolve(users);
   },
 
   receivedOrgSpacesToExtractSpaceUsers(orgSpaces) {
@@ -350,6 +352,7 @@ const userActions = {
 
     return cfApiRequest()
       .then(() => userActions.fetchEntityUsers(entityGuid, entityType))
+      .then(users => userActions.receivedSpaceUserRoles(users, entityGuid))
       .then(entityUsers => {
         userActions.createdUserAndAssociated(userGuid, entityGuid, entityUsers, entityType);
       });


### PR DESCRIPTION
**WIP**

Fixes bug where user was invited to space but not populated in the space user list. There is still an outstanding bug where user email is not populated in list.