### PR TITLE
flatten associated users roles

### DIFF
--- a/static_src/stores/user_store.js
+++ b/static_src/stores/user_store.js
@@ -89,8 +89,7 @@ export class UserStore extends BaseStore {
       case userActionTypes.USER_ORG_ASSOCIATED : {
         this._inviteInputActive = true;
         const user = Object.assign({}, {
-          guid: action.userGuid,
-          roles: { [action.entityGuid]: [] }
+          guid: action.userGuid
         }, action.user);
         this.associateUsersAndRolesToEntity([user], action.entityGuid,
           'organization_roles');
@@ -101,8 +100,7 @@ export class UserStore extends BaseStore {
       case userActionTypes.USER_SPACE_ASSOCIATED: {
         this._inviteInputActive = true;
         const user = Object.assign({}, action.user, {
-          guid: action.userGuid,
-          space_roles: { [action.entityGuid]: action.user.space_roles }
+          guid: action.userGuid
         });
         this.associateUsersAndRolesToEntity([user], action.entityGuid,
           'space_roles');
@@ -385,9 +383,13 @@ export class UserStore extends BaseStore {
     return this._loading.currentUser === true;
   }
 
+  getDefaultUserInfo(user) {
+    return { guid: user.guid, username: user.username };
+  }
+
   mergeRoles(roles, entityGuid, entityType) {
     return roles.map((role) => {
-      const user = Object.assign({}, this.get(role.guid) || { guid: role.guid });
+      const user = Object.assign({}, this.get(role.guid) || this.getDefaultUserInfo(role));
       const updatingRoles = role[entityType] || [];
 
       if (entityType === 'space_roles') {

--- a/static_src/test/unit/stores/user_store.spec.js
+++ b/static_src/test/unit/stores/user_store.spec.js
@@ -159,6 +159,7 @@ describe('UserStore', function () {
       const spaceUserRoles = [
         {
           guid: userGuidA,
+          username: "userA",
           space_roles: [ 'space_developer' ]
         },
         {
@@ -169,16 +170,19 @@ describe('UserStore', function () {
       const currentUsers = [
         {
           guid: userGuidB,
+          username: "userB",
           space_roles: { [spaceGuid]: ['space_developer'] }
         }
       ];
       expectedUsers = [
         {
           guid: userGuidA,
+          username: "userA",
           space_roles: { [spaceGuid]: ['space_developer'] }
         },
         {
           guid: userGuidB,
+          username: "userB",
           space_roles: { [spaceGuid]: ['space_developer', 'space_manager'] }
         }
       ];


### PR DESCRIPTION
this allows us to use the same mergeRoles
also create a getDefaultUserInfo so that regardless of whatever merge we do, we need to make sure we have at least these attributes (guid and username)

Before this PR
#1194 almost fixed it but at the end a last minute change went untested.
This PR finishes the work of #1194.
