### PR TITLE
Fix display button on multi param plans

### DIFF
--- a/static_src/components/service_plan.jsx
+++ b/static_src/components/service_plan.jsx
@@ -13,9 +13,13 @@ const propTypes = {
 };
 
 // This should be removed when solution is setup
-// for service instancemultiple params
-const CF_CLI_SERVICE_LIST = [
-  'cdn-route', 'cloud-gov-identity-provider', 'cloud-gov-service-account'
+// for service instance multiple params (e.g. cdn-route) or services
+// that only return information via the cf cli (e.g. space-deployer).
+const CF_CLI_SERVICE_PLAN_LIST = [
+  'cdn-route',
+  'space-auditor',
+  'space-deployer',
+  'oauth-client'
 ];
 
 class ServicePlan extends React.Component {
@@ -35,7 +39,7 @@ class ServicePlan extends React.Component {
     let text;
     const { plan } = this.props;
 
-    if (CF_CLI_SERVICE_LIST.indexOf(plan.name) === -1) {
+    if (CF_CLI_SERVICE_PLAN_LIST.indexOf(plan.name) === -1) {
       text = 'Create service instance';
     } else {
       text = 'Display documentation link';

--- a/static_src/test/unit/components/service_plan.spec.jsx
+++ b/static_src/test/unit/components/service_plan.spec.jsx
@@ -63,8 +63,9 @@ describe('with multi param plan', () => {
     let button;
     const plans = [
       'cdn-route',
-      'cloud-gov-identity-provider',
-      'cloud-gov-service-account'
+      'space-auditor',
+      'space-deployer',
+      'oauth-client'
     ];
     const props = {
       cost: 'Free',


### PR DESCRIPTION
Previously, the service list used to determine which button text to show
depending on the service name. This was fine for cdn-route because the
service name was the same as the service plan. However it didn't work
for the others.
This commit just fixes the list to filter on

Example of what was happening before:
![image](https://user-images.githubusercontent.com/7788930/29717272-8a778e12-897c-11e7-92e8-3af373cfee76.png)
