### PR TITLE
Create an check before displaying user data without a username

### DIFF
--- a/static_src/components/user_list.jsx
+++ b/static_src/components/user_list.jsx
@@ -126,47 +126,49 @@ export default class UserList extends React.Component {
         { this.documentation }
         <ComplexList>
           { this.props.users.map((user) => {
-            let actions;
-            if (this.props.onRemove) {
-              let button = <span></span>;
-              if (this.props.currentUserAccess) {
-                if (this.props.userType === 'org_users') {
-                  buttonText = 'Remove User From Org';
-                } else if (this.props.userType === 'space_users') {
-                  buttonText = 'Remove All Space Roles';
+            if (!!user.username) {
+              let actions;
+              if (this.props.onRemove) {
+                let button = <span></span>;
+                if (this.props.currentUserAccess) {
+                  if (this.props.userType === 'org_users') {
+                    buttonText = 'Remove User From Org';
+                  } else if (this.props.userType === 'space_users') {
+                    buttonText = 'Remove All Space Roles';
+                  }
+                  button = (
+                    <Action
+                      style="base"
+                      clickHandler={ this._handleDelete.bind(this, user.guid) }
+                      label="delete">
+                      <span>{ buttonText }</span>
+                    </Action>
+                  );
                 }
-                button = (
-                  <Action
-                    style="base"
-                    clickHandler={ this._handleDelete.bind(this, user.guid) }
-                    label="delete">
-                    <span>{ buttonText }</span>
-                  </Action>
+                actions = (
+                  <ElasticLineItem align="end">
+                    { button }
+                  </ElasticLineItem>
                 );
               }
-              actions = (
-                <ElasticLineItem align="end">
-                  { button }
-                </ElasticLineItem>
+
+              return (
+                <ElasticLine key={ user.guid }>
+                  <ElasticLineItem>{ user.username }</ElasticLineItem>
+                  <ElasticLineItem key={ `${user.guid}-role` } align="end">
+                    <UserRoleListControl
+                      userType={ this.props.userType }
+                      currentUserAccess={ this.props.currentUserAccess }
+                      onAddPermissions={ this.props.onAddPermissions }
+                      onRemovePermissions={ this.props.onRemovePermissions }
+                      entityGuid={ this.props.entityGuid }
+                      user={ user }
+                    />
+                  </ElasticLineItem>
+                  { actions }
+                </ElasticLine>
               );
             }
-
-            return (
-              <ElasticLine key={ user.guid }>
-                <ElasticLineItem>{ user.username }</ElasticLineItem>
-                <ElasticLineItem key={ `${user.guid}-role` } align="end">
-                  <UserRoleListControl
-                    userType={ this.props.userType }
-                    currentUserAccess={ this.props.currentUserAccess }
-                    onAddPermissions={ this.props.onAddPermissions }
-                    onRemovePermissions={ this.props.onRemovePermissions }
-                    entityGuid={ this.props.entityGuid }
-                    user={ user }
-                  />
-                </ElasticLineItem>
-                { actions }
-              </ElasticLine>
-              );
           })}
         </ComplexList>
       </div>


### PR DESCRIPTION
# Problem

Users that have been deleted, but still have roles associate with orgs/spaces show up as blank.

# Solution

Short term: Dont show users in the user list if they dont have a username.

Longer term: Change the functions that "delete" users and make sure to run a check for any associated org/space roles.

<img width="1025" alt="screen shot 2017-08-26 at 5 51 06 pm" src="https://user-images.githubusercontent.com/1332366/29745386-33bd94b6-8a87-11e7-8c67-4924f26b2215.png">
