### PR TITLE
Help users find docs about services

### DIFF
--- a/static_src/components/marketplace.jsx
+++ b/static_src/components/marketplace.jsx
@@ -63,9 +63,10 @@ export default class Marketplace extends React.Component {
       <PanelDocumentation description>
         <p>
           Use this marketplace to create service instances for apps in this space. Then bind service instances to apps.
+          See <a href="https://cloud.gov/docs/services/">docs for these services</a>, and 
           { config.docs.managed_services &&
             <span>
-              <a href={ config.docs.managed_services }> Learn about using service instances</a>.
+              <a href={ config.docs.managed_services }> learn about using service instances</a>.
             </span>
           }
         </p>

--- a/static_src/components/service_instance_table.jsx
+++ b/static_src/components/service_instance_table.jsx
@@ -56,7 +56,7 @@ export default class ServiceInstanceTable extends React.Component {
     return (
       <PanelDocumentation description>
         <p>
-          To create service instances for this space, use this org’s marketplace (at left or on the command line). Then bind instances to apps using the command line.
+          To create service instances for this space, use this org’s marketplace (below or on the command line).
           { config.docs.managed_services &&
             <span>
               (<a href={ config.docs.managed_services }>Learn about using service instances and marketplaces</a>.)

--- a/static_src/skins/cg/index.js
+++ b/static_src/skins/cg/index.js
@@ -91,10 +91,10 @@ export const config = {
     concepts_roles: 'https://docs.cloudfoundry.org/concepts/roles.html',
     concepts_spaces: 'https://cloud.gov/docs/getting-started/concepts/',
     deploying_apps: 'https://cloud.gov/docs/getting-started/your-first-deploy/',
-    use: 'https://cloud.gov/docs/intro/overview/using-cloudgov-paas/',
-    invite_user: 'https://cloud.gov/docs/apps/managing-teammates',
+    use: 'https://cloud.gov/overview/overview/using-cloudgov-paas/',
+    invite_user: 'https://cloud.gov/docs/apps/managing-teammates/',
     roles: 'https://cloud.gov/docs/apps/managing-teammates/#give-roles-to-a-teammate',
-    managed_services: 'https://docs.cloud.gov/apps/managed-services/',
+    managed_services: 'https://cloud.gov/docs/apps/managed-services/',
     status: 'https://cloudgov.statuspage.io/',
     contact: 'https://cloud.gov/docs/help/'
   },


### PR DESCRIPTION
In order to help dashboard users use services successfully, here are a few copy suggestions for review (I didn't test these locally, so they probably need adjustment):

* At the top of the marketplace section, link to a page with docs about the services (https://cloud.gov/docs/services/). This may help people find the correct price information about services (since the incorrect price column is being removed in https://github.com/18F/cg-dashboard/pull/1207).
* At the top of the service instance table, update the old location of the marketplace (left instead of below), and remove the old note about binding using the CLI (since you can do that on the dashboard).
* Update a few of the docs links to their current locations (the redirects were working, but it's nice to link to the current location).