### PR TITLE
Move staging to CF staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Climate](https://codeclimate.com/github/18F/cg-dashboard/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-dashboard)
 
 Environments: [Production](https://dashboard.fr.cloud.gov)
-[Staging](https://dashboard-staging.app.cloud.gov)
+[Staging](https://dashboard.fr-stage.cloud.gov)
 [Testing Server](https://dashboard-testing-server.app.cloud.gov)
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,7 @@ Currently, the site does not have visual regression testing so must be manually
 tested for breaking visual changes. Here is a simple script to assist in manual
 testing. Generally, it's best to look through all the pages and check if
 anything looks off. Testing should generally be done on the staging environment,
-[dashboard-staging.apps.cloud.gov](https://dashboard-staging.apps.cloud.gov/),
+[dashboard.fr-stage.cloud.gov](https://dashboard.fr-stage.cloud.gov/),
 when all the necessary code is on the master branch and has been deployed. To
 check that the master branch has been deployed, check [Circle
 CI](https://circleci.com/gh/18F/cg-dashboard).

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,6 @@ machine:
   environment:
     GODIST: "go1.8.linux-amd64.tar.gz"
     WS: "/home/ubuntu/.go_workspace/src/github.com/18F/cg-dashboard"
-    CF_API: "https://api.fr.cloud.gov"
     CF_ORGANIZATION: "cloud-gov"
   post:
     - cd cg-dashboard && nvm install && nvm use && nvm alias default $(cat .nvmrc)

--- a/deploy/circle_deploy.sh
+++ b/deploy/circle_deploy.sh
@@ -18,42 +18,28 @@ cf install-plugin -f /home/ubuntu/.go_workspace/bin/autopilot
 # Only the organization, api, deployer account password differ.
 
 
+CF_APP="cg-dashboard"
+CF_SPACE="dashboard"
 
 if [[ "$CIRCLE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]
 then
 	CF_MANIFEST="manifest-prod.yml"
-	CF_SPACE="dashboard-prod"
-	CF_APP="cg-dashboard"
+	CF_API="https://api.fr.cloud.gov"
+	CF_USERNAME=$CF_USERNAME_PROD_SPACE
+	CF_PASSWORD=$CF_PASSWORD_PROD_SPACE
 elif [ "$CIRCLE_BRANCH" == "master" ]
 then
 	CF_MANIFEST="manifest-staging.yml"
-	CF_SPACE="dashboard-stage"
-	CF_APP="cg-dashboard-staging"
+	CF_API="https://api.fr-stage.cloud.gov"
+	CF_USERNAME=$CF_USERNAME_STAGE_SPACE
+	CF_PASSWORD=$CF_PASSWORD_STAGE_SPACE
 elif [ "$CIRCLE_BRANCH" == "demo" ]
 then
 	CF_MANIFEST="manifest-demo.yml"
-	CF_SPACE="dashboard-stage"
 	CF_APP="cg-dashboard-demo"
 else
   echo Unknown environment, quitting. >&2
   exit 1
-fi
-
-# We use the deployer-account broker to get the credentials of
-# our deployer accounts.
-# Currently, the deployer accounts are scoped to a single space.
-# As a result, we will filter by space for which credentials to use.
-if [ "$CF_SPACE" == "dashboard-prod" ]
-then
-	CF_USERNAME=$CF_USERNAME_PROD_SPACE
-	CF_PASSWORD=$CF_PASSWORD_PROD_SPACE
-elif [ "$CF_SPACE" == "dashboard-stage" ]
-then
-	CF_USERNAME=$CF_USERNAME_STAGE_SPACE
-	CF_PASSWORD=$CF_PASSWORD_STAGE_SPACE
-else
-	echo "Unknown space. Do not know how to deploy $CF_SPACE."
-	exit 1
 fi
 
 echo manifest: $CF_MANIFEST

--- a/manifests/manifest-base.yml
+++ b/manifests/manifest-base.yml
@@ -1,15 +1,10 @@
 ---
 buildpack: go_buildpack
 memory: 256M
-domain: app.cloud.gov
 services:
 - dashboard-ups
 - dashboard-redis
 env:
-  CONSOLE_LOGIN_URL: https://login.fr.cloud.gov/
-  CONSOLE_UAA_URL: https://uaa.fr.cloud.gov/
-  CONSOLE_API_URL: https://api.fr.cloud.gov/
-  CONSOLE_LOG_URL: https://loggregator.fr.cloud.gov/
   SECURE_COOKIES: true
   GA_TRACKING_ID: UA-48605964-34
   GOVERSION: go1.8

--- a/manifests/manifest-prod.yml
+++ b/manifests/manifest-prod.yml
@@ -9,3 +9,7 @@ applications:
     CONSOLE_HOSTNAME: https://dashboard.fr.cloud.gov
     NEW_RELIC_ID: "20390582"
     NEW_RELIC_BROWSER_LICENSE_KEY: "5d4bc714a6"
+    CONSOLE_LOGIN_URL: https://login.fr.cloud.gov/
+    CONSOLE_UAA_URL: https://uaa.fr.cloud.gov/
+    CONSOLE_API_URL: https://api.fr.cloud.gov/
+    CONSOLE_LOG_URL: https://loggregator.fr.cloud.gov/

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -1,7 +1,13 @@
 ---
 inherit: manifest-base.yml
+domain: fr-stage.cloud.gov
 applications:
-- name: cg-dashboard-staging
-  host: dashboard-staging
+- name: cg-dashboard
+  host: dashboard
+  instances: 3
   env:
-    CONSOLE_HOSTNAME: https://dashboard-staging.app.cloud.gov
+    CONSOLE_HOSTNAME: https://dashboard.fr-stage.cloud.gov
+    CONSOLE_LOGIN_URL: https://login.fr-stage.cloud.gov/
+    CONSOLE_UAA_URL: https://uaa.fr-stage.cloud.gov/
+    CONSOLE_API_URL: https://api.fr-stage.cloud.gov/
+    CONSOLE_LOG_URL: https://loggregator.fr-stage.cloud.gov/


### PR DESCRIPTION
This PR moves staging dashboard to the CF staging environment.
The url will be https://dashboard.fr-stage.cloud.gov
This will help with testing #1219

Prior to merging, the following need to happen:

- [x] Manual deploy of the app to CF staging
- [x] Manual login and click around on the CF staging dashboard
- [x] Change `CF_USERNAME_STAGE_SPACE` and `CF_PASSWORD_STAGE_SPACE` with deployer credentials for the CF staging env in CircleCI
- [x] Rename space in CF Prod to `dashboard`
