### PR TITLE
Use a more idiomatic React outlet

### DIFF
--- a/helpers/testdata/index.html
+++ b/helpers/testdata/index.html
@@ -37,7 +37,7 @@
     <title>cloud.gov dashboard</title>
   </head>
   <body>
-    <div class="js-app"></div>
+    <div id="root"></div>
 
     <script>
       (function (GA_TRACKING_ID) {

--- a/static/index.html
+++ b/static/index.html
@@ -37,7 +37,7 @@
     <title>cloud.gov dashboard</title>
   </head>
   <body>
-    <div class="js-app"></div>
+    <div id="root"></div>
 
     <script>
       (function (GA_TRACKING_ID) {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -44,4 +44,5 @@ const cRouter = {
 };
 
 initCSRFHeader(document.querySelector('meta[name="gorilla.csrf.Token"]'));
-cRouter.run(routes, document.querySelector('.js-app'));
+
+cRouter.run(routes, document.getElementById('root'));


### PR DESCRIPTION
As seen in CRA-generated apps (https://github.com/facebookincubator/create-react-app) and most React apps.

Also, while it's not a bottleneck (and going into micro optimisation territory), I suspect that `document.getElementById` is much more performant than `document.querySelector`. Still, the idiomaticity is nice.