### PR TITLE
Fix `GetValidToken` to save refreshed access tokens

### DIFF
--- a/controllers/root.go
+++ b/controllers/root.go
@@ -108,7 +108,7 @@ func (c *Context) Ping(rw web.ResponseWriter, req *web.Request) {
 
 // LoginHandshake is the handler where we authenticate the user and the user authorizes this application access to information.
 func (c *Context) LoginHandshake(rw web.ResponseWriter, req *web.Request) {
-	if token := helpers.GetValidToken(req.Request, c.Settings); token != nil {
+	if token := helpers.GetValidToken(req.Request, rw, c.Settings); token != nil {
 		// We should just go to dashboard if the user already has a valid token.
 		dashboardURL := fmt.Sprintf("%s%s", c.Settings.AppURL, "/#/dashboard")
 		http.Redirect(rw, req.Request, dashboardURL, http.StatusFound)

--- a/controllers/secure.go
+++ b/controllers/secure.go
@@ -27,7 +27,7 @@ type ResponseHandler func(http.ResponseWriter, *http.Response)
 // If the token is 1) present and expired or 2) not present, it will return unauthorized.
 func (c *SecureContext) OAuth(rw web.ResponseWriter, req *web.Request, next web.NextMiddlewareFunc) {
 	// Get valid token if it exists from session store.
-	if token := helpers.GetValidToken(req.Request, c.Settings); token != nil {
+	if token := helpers.GetValidToken(req.Request, rw, c.Settings); token != nil {
 		c.Token = *token
 	} else {
 		// If no token, return unauthorized.
@@ -53,7 +53,7 @@ func (c *SecureContext) LoginRequired(rw web.ResponseWriter, r *web.Request, nex
 	rw.Header().Set("pragma", "no-cache")
 	rw.Header().Set("expires", "-1")
 
-	token := helpers.GetValidToken(r.Request, c.Settings)
+	token := helpers.GetValidToken(r.Request, rw, c.Settings)
 	if token != nil {
 		next(rw, r)
 	} else {

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,6 +1,8 @@
 package helpers_test
 
 import (
+	"net/http/httptest"
+
 	"github.com/18F/cg-dashboard/helpers"
 	"github.com/18F/cg-dashboard/helpers/testhelpers"
 
@@ -41,6 +43,7 @@ var getValidTokenTests = []tokenTestData{
 func TestGetValidToken(t *testing.T) {
 	mockRequest, _ := http.NewRequest("GET", "", nil)
 	mockSettings := helpers.Settings{}
+	mockResponse := httptest.NewRecorder()
 
 	for _, test := range getValidTokenTests {
 		// Initialize a new session store.
@@ -48,7 +51,7 @@ func TestGetValidToken(t *testing.T) {
 		store.ResetSessionData(test.sessionData, test.sessionName)
 		mockSettings.Sessions = store
 
-		value := helpers.GetValidToken(mockRequest, &mockSettings)
+		value := helpers.GetValidToken(mockRequest, mockResponse, &mockSettings)
 		if (value == nil) == test.returnValueNull {
 		} else {
 			t.Errorf("Test %s did not meet expected value. Expected: %t. Actual: %t\n", test.testName, test.returnValueNull, (value == nil))


### PR DESCRIPTION
`GetValidToken` is called on every request to fetch a non-expired access token,
refreshing if needed, however prior to this change it never saved this token
back to the session, meaning that after an access token expires (typically after 1 hour)
all subsequent requests require a refresh first.

Part 3 of #1234 