### PR TITLE
Add support for opaque tokens and cookiestore "backend"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ cf create-user-provided-service dashboard-ups -p @<(cat <<EOF
   "CONSOLE_CLIENT_ID": "your-client-id",
   "CONSOLE_CLIENT_SECRET": "your-client-secret",
   "CSRF_KEY": "$(openssl rand -hex 32)",
+  "SESSION_BACKEND": "cookiestore",
   "SESSION_AUTHENTICATION_KEY": "$(openssl rand -hex 64)",
+  "SESSION_ENCRYPTION_KEY": "$(openssl rand -hex 32)",
   "SMTP_HOST": "smtp.host.com",
   "SMTP_PORT": "25",
   "SMTP_USER": "username",
@@ -62,12 +64,6 @@ cf create-user-provided-service dashboard-ups -p @<(cat <<EOF
 }
 EOF
 )
-```
-
-Create a redis service instance:
-
-```bash
-cf create-service redis28 standard dashboard-redis
 ```
 
 ### Create a Client with UAAC

--- a/controllers/root_test.go
+++ b/controllers/root_test.go
@@ -21,7 +21,7 @@ func TestPing(t *testing.T) {
 		t.Fatal(err)
 	}
 	router.ServeHTTP(response, request)
-	expectedResponse := `{"status":"alive","build-info":"developer-build","session-store-health":{"store-type":"file","store-up":true}}`
+	expectedResponse := `{"status":"alive","build-info":"developer-build","session-store-health":{"store-type":"cookiestore","store-up":true}}`
 	if response.Body.String() != expectedResponse {
 		t.Errorf("Expected %s. Found %s\n", expectedResponse, response.Body.String())
 	}

--- a/helpers/env_vars.go
+++ b/helpers/env_vars.go
@@ -66,6 +66,8 @@ var (
 	CSRFKeyEnvVar = "CSRF_KEY"
 	// SessionAuthenticationEnvVar used to sign user sessions. Must be 32 or 64 hex-encoded bytes, e.g. openssl rand -hex 64
 	SessionAuthenticationEnvVar = "SESSION_AUTHENTICATION_KEY"
+	// SessionEncryptionEnvVar used to encrypt user sessions. Used by "SESSION_BACKEND=cookiestore". Must be 16, 24 or 32 hex-encoded bytes, e.g. openssl rand -hex 32
+	SessionEncryptionEnvVar = "SESSION_ENCRYPTION_KEY"
 )
 
 // EnvVars provides a convenient method to access environment variables

--- a/helpers/settings.go
+++ b/helpers/settings.go
@@ -74,6 +74,8 @@ type Settings struct {
 	TICSecret string
 	// CSRFKey used for gorilla CSRF validation
 	CSRFKey []byte
+	// OpaqueUAATokens if set requests smaller opaque tokens from UAA
+	OpaqueUAATokens bool
 }
 
 // CreateContext returns a new context to be used for http connections.

--- a/helpers/settings_test.go
+++ b/helpers/settings_test.go
@@ -26,6 +26,8 @@ var initSettingsTests = []initSettingsTest{
 			helpers.UAAURLEnvVar:                "uaaurl",
 			helpers.APIURLEnvVar:                "apiurl",
 			helpers.LogURLEnvVar:                "logurl",
+			helpers.SessionBackendEnvVar:        "cookiestore",
+			helpers.SessionEncryptionEnvVar:     "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 			helpers.SessionAuthenticationEnvVar: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 			helpers.CSRFKeyEnvVar:               "00112233445566778899aabbccddeeff",
 			helpers.SMTPFromEnvVar:              "blah@blah.com",
@@ -63,6 +65,8 @@ var initSettingsTests = []initSettingsTest{
 			helpers.UAAURLEnvVar:                "uaaurl",
 			helpers.APIURLEnvVar:                "apiurl",
 			helpers.LogURLEnvVar:                "logurl",
+			helpers.SessionBackendEnvVar:        "cookiestore",
+			helpers.SessionEncryptionEnvVar:     "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 			helpers.SessionAuthenticationEnvVar: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 			helpers.CSRFKeyEnvVar:               "00112233445566778899aabbccddeeff",
 			helpers.SMTPFromEnvVar:              "blah@blah.com",
@@ -235,9 +239,9 @@ var initSettingsTests = []initSettingsTest{
 }
 
 func TestInitSettings(t *testing.T) {
-	s := helpers.Settings{}
 	env, _ := cfenv.Current()
 	for _, test := range initSettingsTests {
+		s := helpers.Settings{}
 		ret := s.InitSettings(helpers.NewEnvVarsFromPath(testhelpers.NewEnvLookupFromMap(test.envVars)), env)
 		if (ret == nil) != test.returnValueNull {
 			t.Errorf("Test %s did not return correct value. Expected %t, Actual %t", test.testName, test.returnValueNull, (ret == nil))

--- a/helpers/testhelpers/testhelpers.go
+++ b/helpers/testhelpers/testhelpers.go
@@ -246,6 +246,8 @@ func GetMockCompleteEnvVars() map[string]string {
 		helpers.APIURLEnvVar:                "https://apiurl",
 		helpers.LogURLEnvVar:                "https://logurl",
 		helpers.PProfEnabledEnvVar:          "true",
+		helpers.SessionBackendEnvVar:        "cookiestore",
+		helpers.SessionEncryptionEnvVar:     "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 		helpers.SessionAuthenticationEnvVar: "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
 		helpers.CSRFKeyEnvVar:               "00112233445566778899aabbccddeeff",
 		helpers.BasePathEnvVar:              os.Getenv(helpers.BasePathEnvVar),


### PR DESCRIPTION
This is the intended final part of this set of changes for https://github.com/18F/cg-dashboard/issues/1234.

It adds a `SESSION_BACKEND=cookiestore` which requires a `SESSION_ENCRYPTION_KEY` which in turn enables use of opaque refresh tokens, which is enough to keep our cookie at around 2922 bytes (under the IE limit of 4096).

This is probably easier reviewed once the other PRs are in, and if happy with the direction, would probably benefit from some end to end tests which I can look at adding tomorrow.