### PR TITLE
Add ability to skip tests that require Docker

### DIFF
--- a/controllers/root_test.go
+++ b/controllers/root_test.go
@@ -34,7 +34,7 @@ func TestPingWithRedis(t *testing.T) {
 	// Create a request
 	response, request := NewTestRequest("GET", "/ping", nil)
 	// Start up redis.
-	redisURI, cleanUpRedis, pauseRedis, unapuaseRedis := CreateTestRedis()
+	redisURI, cleanUpRedis, pauseRedis, unapuaseRedis := CreateTestRedis(t)
 	os.Setenv("REDIS_URI", redisURI)
 	// Remove redis when finished.
 	defer cleanUpRedis()

--- a/helpers/testhelpers/docker/docker.go
+++ b/helpers/testhelpers/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"testing"
 
 	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/garyburd/redigo/redis"
@@ -45,9 +46,17 @@ func connectToDockerNetwork(pool *dockertest.Pool,
 	return "", false
 }
 
+// skipIfNoDocker will detect if Docker is unable to run, and if not, will skip the test
+func skipIfNoDocker(t *testing.T) {
+	if os.Getenv("SKIP_DOCKER") == "1" {
+		t.Skip("No support for docker")
+	}
+}
+
 // CreateTestRedis creates a actual redis instance with docker.
 // Useful for unit tests.
-func CreateTestRedis() (string, func(), func(), func()) {
+func CreateTestRedis(t *testing.T) (string, func(), func(), func()) {
+	skipIfNoDocker(t)
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		log.Fatalf("Could not connect to docker: %s", err)
@@ -89,7 +98,8 @@ func CreateTestRedis() (string, func(), func(), func()) {
 
 // CreateTestMailCatcher creates a actual redis instance with docker.
 // Useful for unit tests.
-func CreateTestMailCatcher() (string, string, string, func()) {
+func CreateTestMailCatcher(t *testing.T) (string, string, string, func()) {
+	skipIfNoDocker(t)
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		log.Fatalf("Could not connect to docker: %s", err)

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSendEmail(t *testing.T) {
-	hostname, smtpPort, apiPort, cleanup := CreateTestMailCatcher()
+	hostname, smtpPort, apiPort, cleanup := CreateTestMailCatcher(t)
 	// Test InitSMTPMailer with valid path for templates.
 	settings := helpers.Settings{
 		BasePath: os.Getenv(helpers.BasePathEnvVar),


### PR DESCRIPTION
Set env variable SKIP_DOCKER=1, and then tests that require Docker are skipped.

Why? In some CI environments it is problematic to allow Docker containers to be created, this change gives the operator the choice to accept the risk of these tests failing.