### PR TITLE
Fix overrides.css removed in previous commit

### DIFF
--- a/static_src/components/navbar.jsx
+++ b/static_src/components/navbar.jsx
@@ -1,4 +1,3 @@
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -1,6 +1,7 @@
 import 'cloudgov-style/css/base.css';
 import 'cloudgov-style/css/cloudgov-style.css';
 import './css/main.css';
+import './css/overrides.css';
 // Icon used in cg-uaa.
 import './img/dashboard-uaa-icon.jpg';
 import 'cloudgov-style/img/favicon.ico';


### PR DESCRIPTION
Was accidentally removed in https://github.com/18F/cg-dashboard/commit/f625baedffc737bbb74548c9de58d737d39e7360#diff-ffc4cd1d697e1a83c4e5b8444783a22bL6

This caused the header banner up/down icon to be displayed incorrectly.