### PR TITLE
webpack: ignore node_modules in any dir, not root

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,9 +36,7 @@ const config = {
           presets: ['es2015', 'react'],
           plugins: ['transform-object-rest-spread', 'transform-runtime']
         },
-        exclude: [
-          path.resolve(__dirname, 'node_modules')
-        ]
+        exclude: /node_modules/
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
In our cloud.gov.au skin, we have a node_modules directory. Prior to
this change, we would encounter an error building the application
because of the descendent node_modules directory. With this change, any
node_modules directory in the tree will be ignored.