### PR TITLE
Fix incorrect loading state calculation in app page

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -31,7 +31,7 @@ function appReady(app) {
 
 function mapStoreToState() {
   let route;
-  const currentAppGuid = AppStore.currentAppGuid;
+  const { currentAppGuid } = AppStore;
   const app = AppStore.get(currentAppGuid);
   const envRequest = EnvStore.getEnvRequest(currentAppGuid);
   const envUpdateError = EnvStore.getUpdateError(currentAppGuid);
@@ -56,7 +56,11 @@ function mapStoreToState() {
     empty: !AppStore.loading && !appReady(app) && !QuotaStore.loading,
     envRequest,
     envUpdateError,
-    loading: AppStore.loading || QuotaStore.loading,
+    loading:
+      OrgStore.loading ||
+      SpaceStore.loading ||
+      AppStore.loading ||
+      QuotaStore.loading,
     org,
     route,
     quota,


### PR DESCRIPTION
The app page is nested under an org and a space.

Thus the `loading` flag should be set to true if any of the org, space or app are loading (plus if the quota is loading).

We want this because we don't want the `AppContainer` component to try and render anything that depends on the org, space or app if those objects are not yet loaded.

By the way, this is necessary as part of the upgrade to React 16. 