### PR TITLE
Rename CF_SKIN to SKIN_NAME

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -44,8 +44,8 @@ export SECURE_COOKIES=true
 # needed before anything insecure can be used (e.g. insecure cookies.)
 # export LOCAL_CF=0
 
-# <optional> Which skin to use (defaults to cg)
-# export CF_SKIN=cg
+# <optional> The name of the skin to use (defaults to cg)
+# export SKIN_NAME=cg
 
 # The SMTP HOST for mailcatcher
 export SMTP_HOST=localhost

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,11 @@ const webpack = require('webpack');
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-const PRODUCTION = (process.env.NODE_ENV === 'prod');
-const TEST = (process.env.NODE_ENV === 'test');
+const PRODUCTION = process.env.NODE_ENV === 'prod';
+const TEST = process.env.NODE_ENV === 'test';
 const CG_STYLE_PATH = process.env.CG_STYLE_PATH;
-const CF_SKIN = process.env.CF_SKIN || 'cg';
+
+const SKIN_NAME = process.env.SKIN_NAME || 'cg';
 
 const srcDir = './static_src';
 const compiledDir = './static/assets';
@@ -14,10 +15,7 @@ const compiledDir = './static/assets';
 const config = {
   bail: false,
 
-  entry: [
-    'babel-polyfill',
-    `${srcDir}/main.js`
-  ],
+  entry: ['babel-polyfill', `${srcDir}/main.js`],
 
   output: {
     path: path.resolve(compiledDir),
@@ -49,7 +47,8 @@ const config = {
         test: /\.(svg|ico|png|gif|jpe?g)$/,
         loader: 'url-loader?limit=1024&name=img/[name].[ext]'
       },
-      { test: /\.(ttf|woff2?|eot)$/,
+      {
+        test: /\.(ttf|woff2?|eot)$/,
         loader: 'url-loader?limit=1024&name=font/[name].[ext]'
       }
     ]
@@ -59,7 +58,7 @@ const config = {
     alias: {
       'cloudgov-style': 'cloudgov-style',
       dashboard: path.resolve(__dirname, 'static_src'),
-      skin: path.resolve(__dirname, `static_src/skins/${CF_SKIN}`)
+      skin: path.resolve(__dirname, `static_src/skins/${SKIN_NAME}`)
     },
 
     modules: ['node_modules'],
@@ -95,12 +94,18 @@ if (TEST) {
   };
 }
 
+const processEnv = {
+  SKIN_NAME: JSON.stringify(SKIN_NAME)
+};
+
 if (PRODUCTION) {
-  config.plugins.push(new webpack.DefinePlugin({
-    'process.env': {
-      NODE_ENV: JSON.stringify('production')
-    }
-  }));
+  processEnv.NODE_ENV = JSON.stringify('production');
 }
+
+config.plugins.push(
+  new webpack.DefinePlugin({
+    'process.env': processEnv
+  })
+);
 
 module.exports = config;


### PR DESCRIPTION
The CF prefix is redundant. Env var will also then match `SKIN_PROVIDES_TRANSLATIONS` if we add that.

Cherry-picked from https://github.com/18F/cg-dashboard/pull/1248

Because the default (`cg`) skin does not need to provide translation files, the `SKIN_NAME` (formerly `CF_SKIN`) variable has been passed into `process.env`. This is deliberate because now any i18n module can remove dead code at build time. Particularly, if we use i18next, the i18next-xhr-backend module can be entirely removed for cloud.gov.

See https://github.com/18F/cg-dashboard/pull/1248#issue-263012641