### PR TITLE
api: don't handle response code in submitRequest

### DIFF
--- a/controllers/log.go
+++ b/controllers/log.go
@@ -31,10 +31,12 @@ func (c *LogContext) RecentLogs(rw web.ResponseWriter, req *web.Request) {
 func (c *LogContext) logMessageResponseHandler(rw http.ResponseWriter, response *http.Response) {
 	messages, err := c.ParseLogMessages(&(response.Body), response.Header.Get("Content-Type"))
 	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
 		rw.Write([]byte(err.Error()))
 		return
 	}
-	rw.Write([]byte(messages.String()))
+	rw.WriteHeader(response.StatusCode)
+	rw.Write(messages.Bytes())
 	return
 
 }

--- a/controllers/secure.go
+++ b/controllers/secure.go
@@ -133,13 +133,14 @@ func (c *SecureContext) submitRequest(rw http.ResponseWriter, req *http.Request,
 		rw.Write([]byte("unknown error. try again"))
 		return
 	}
-	// Should return the same status.
-	rw.WriteHeader(res.StatusCode)
 	responseHandler(rw, res)
 }
 
 // GenericResponseHandler is a normal handler for responses received from the proxy requests.
 func (c *SecureContext) GenericResponseHandler(rw http.ResponseWriter, response *http.Response) {
+	// Should return the same status.
+	rw.WriteHeader(response.StatusCode)
+
 	// Write the body into response that is going back to the frontend.
 	_, err := io.Copy(rw, response.Body)
 	if err != nil {


### PR DESCRIPTION
End handlers should be able to set the HTTP response code. E.g.
logMessageResponseHandler should be able to set the response code to 500
if there is an error.