### PR TITLE
mailer: allowing overriding address for dev

### DIFF
--- a/controllers/routes.go
+++ b/controllers/routes.go
@@ -77,7 +77,7 @@ func InitApp(envVars *env.VarSet, app *cfenv.App) (*web.Router, *helpers.Setting
 	if err := settings.InitSettings(envVars, app); err != nil {
 		return nil, nil, err
 	}
-	mailer, err := mailer.InitSMTPMailer(settings)
+	mailer, err := mailer.NewSMTPMailer(settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controllers/uaa.go
+++ b/controllers/uaa.go
@@ -336,9 +336,13 @@ func (c *UAAContext) TriggerInvite(inviteReq inviteEmailRequest) *UaaError {
 	if tplErr != nil {
 		return newUaaError(http.StatusInternalServerError, tplErr.Error())
 	}
-	emailErr := c.mailer.SendEmail(inviteReq.Email, "Invitation to join cloud.gov", emailHTML.Bytes())
-	if emailErr != nil {
-		return newUaaError(http.StatusInternalServerError, emailErr.Error())
+	if err := c.mailer.SendEmail(
+		inviteReq.Email,
+		"Invitation to join cloud.gov",
+		emailHTML.Bytes(),
+		nil,
+	); err != nil {
+		return newUaaError(http.StatusInternalServerError, err.Error())
 	}
 	return nil
 }

--- a/helpers/env_vars.go
+++ b/helpers/env_vars.go
@@ -52,6 +52,9 @@ var (
 	SMTPPassEnvVar = "SMTP_PASS"
 	// SMTPFromEnvVar is SMTP from address for UAA invites
 	SMTPFromEnvVar = "SMTP_FROM"
+	// DeliveryAddressEnvVar allows overriding the address to which mail is
+	// sent.
+	DeliveryAddressEnvVar = "DELIVERY_ADDRESS"
 	// TICSecretEnvVar is the shared secret with CF API proxy for forwarding client IPs
 	TICSecretEnvVar = "TIC_SECRET"
 	// CSRFKeyEnvVar is used for CSRF token. Must be 32 bytes, hex-encoded, e.g. openssl rand -hex 32

--- a/helpers/settings.go
+++ b/helpers/settings.go
@@ -71,6 +71,8 @@ type Settings struct {
 	SMTPPass string
 	// SMTP from address for UAA invites
 	SMTPFrom string
+	// DeliveryAddress allows overriding the address to which mail is sent.
+	DeliveryAddress string
 	// Shared secret with CF API proxy
 	TICSecret string
 	// CSRFKey used for gorilla CSRF validation
@@ -297,6 +299,7 @@ func (s *Settings) InitSettings(envVars *env.VarSet, app *cfenv.App) (retErr err
 	s.SMTPPass = envVars.String(SMTPPassEnvVar, "")
 	s.SMTPPort = envVars.String(SMTPPortEnvVar, "")
 	s.SMTPUser = envVars.String(SMTPUserEnvVar, "")
+	s.DeliveryAddress = envVars.String(DeliveryAddressEnvVar, "")
 	s.TICSecret = envVars.String(TICSecretEnvVar, "")
 	return nil
 }

--- a/helpers/testhelpers/mocks/Mailer.go
+++ b/helpers/testhelpers/mocks/Mailer.go
@@ -8,13 +8,14 @@ type Mailer struct {
 	mock.Mock
 }
 
-// SendEmail provides a mock function with given fields: emailAddress, subject, body
-func (_m *Mailer) SendEmail(emailAddress string, subject string, body []byte) error {
-	ret := _m.Called(emailAddress, subject, body)
+// SendEmail provides a mock function with given fields:
+// emailAddress, subject, html, text.
+func (_m *Mailer) SendEmail(emailAddress string, subject string, html, text []byte) error {
+	ret := _m.Called(emailAddress, subject, html, text)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, []byte) error); ok {
-		r0 = rf(emailAddress, subject, body)
+	if rf, ok := ret.Get(0).(func(string, string, []byte, []byte) error); ok {
+		r0 = rf(emailAddress, subject, html, text)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/helpers/testhelpers/testhelpers.go
+++ b/helpers/testhelpers/testhelpers.go
@@ -134,7 +134,7 @@ func CreateRouterWithMockSession(sessionData map[string]interface{}, envVars map
 	// mockery converts []byte to []uint8 thus having to check for that in the
 	// argument.
 	mockMailer.On("SendEmail", mock.AnythingOfType("string"),
-		mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8")).Return(nil)
+		mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8")).Return(nil)
 	router := controllers.InitRouter(&settings, templates, mockMailer)
 
 	return router, &store

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -1,7 +1,7 @@
 package mailer
 
 import (
-	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -11,56 +11,80 @@ import (
 
 func TestSendEmail(t *testing.T) {
 	hostname, smtpPort, apiPort, cleanup := CreateTestMailCatcher(t)
-	// Test InitSMTPMailer with valid path for templates.
 	settings := helpers.Settings{
 		SMTPHost: hostname,
 		SMTPPort: smtpPort,
 		SMTPFrom: "test@dashboard.com",
 	}
-	mailer, err := InitSMTPMailer(settings)
-	if mailer == nil {
-		t.Error("Expected non nil mailer.")
-	}
+	mailer, err := NewSMTPMailer(settings)
 	if err != nil {
-		t.Errorf("Expected nil error, found %s", err.Error())
+		t.Fatal(err)
 	}
-	body := bytes.NewBufferString("test html here")
-	err = mailer.SendEmail("test@receiver.com", "sample subject", body.Bytes())
+	html := []byte("<strong>html</strong>")
+	text := []byte("text")
+	if err := mailer.SendEmail("recipient@example.com", "subject", html, text); err != nil {
+		t.Errorf("SendEmail() err = %v, want none", err)
+	}
+	b, err := GetLatestMailMessageData(hostname, apiPort)
 	if err != nil {
-		t.Errorf("Expected nil error, found %s", err.Error())
+		t.Fatal(err)
 	}
-	receivedData, err := GetLatestMailMessageData(hostname, apiPort)
-	if err != nil {
-		t.Errorf("Expected nil error, found %s", err.Error())
+	message := string(b)
+	if want := "test@dashboard.com"; !strings.Contains(message, fmt.Sprintf(`"sender":"<%s>"`, want)) {
+		t.Errorf("sender was wrong, want %q", want)
 	}
-	if !strings.Contains(string(receivedData), `"sender":"<test@dashboard.com>"`) {
-		t.Error("Expected to find sender metadata")
+	if want := "recipient@example.com"; !strings.Contains(message, fmt.Sprintf(`"recipients":["<%s>"]`, want)) {
+		t.Errorf("recipient was wrong, want %q", want)
 	}
-	if !strings.Contains(string(receivedData), `"recipients":["<test@receiver.com>"]`) {
-		t.Error("Expected to find receipient metadata")
+	if want := "subject"; !strings.Contains(message, fmt.Sprintf(`"subject":"%s"`, want)) {
+		t.Errorf("subject was wrong, want %q", want)
 	}
-	if !strings.Contains(string(receivedData), `"subject":"sample subject"`) {
-		t.Error("Expected to find receipient metadata")
-	}
-	// Useful for generating test data. Undo to learn more about the data.
-	// log.Println(string(receivedData))
 
-	cleanup() // Destroy the mail server.
+	cleanup()
 
 	// Try sending mail to bad server.
-	err = mailer.SendEmail("test@receiver.com", "sample subject", body.Bytes())
+	err = mailer.SendEmail("recipient@example.com", "sample subject", html, text)
 	if err == nil {
-		t.Error("Expected non nil error")
+		t.Error("got nil error, want something")
 	}
 }
 
-func TestInitSMTPMailer(t *testing.T) {
-	settings := helpers.Settings{}
-	mailer, err := InitSMTPMailer(settings)
-	if mailer == nil {
-		t.Error("Expected non nil mailer.")
+func TestSendEmailUsesDeliveryAddress(t *testing.T) {
+	hostname, smtpPort, apiPort, cleanup := CreateTestMailCatcher(t)
+	defer cleanup()
+	settings := helpers.Settings{
+		SMTPHost:        hostname,
+		SMTPPort:        smtpPort,
+		SMTPFrom:        "test@dashboard.com",
+		DeliveryAddress: "override@example.com",
 	}
+	mailer, err := NewSMTPMailer(settings)
 	if err != nil {
-		t.Errorf("Expected nil error, found %s", err.Error())
+		t.Fatal(err)
+	}
+	if err := mailer.SendEmail("recipient@example.com", "subject", []byte("<strong>html</strong>"), []byte("text")); err != nil {
+		t.Errorf("SendEmail() err = %v, want none", err)
+	}
+	b, err := GetLatestMailMessageData(hostname, apiPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := string(b)
+	if want := "override@example.com"; !strings.Contains(message, fmt.Sprintf(`"recipients":["<%s>"]`, want)) {
+		t.Errorf("recipient was wrong, want %q", want)
+	}
+	if want := "recipient@example.com"; !strings.Contains(message, fmt.Sprintf(`Would-Send-To: <%s>`, want)) {
+		t.Errorf("Would-Send-To header was wrong, want %q", want)
+	}
+}
+
+func TestNewSMTPMailer(t *testing.T) {
+	settings := helpers.Settings{}
+	mailer, err := NewSMTPMailer(settings)
+	if err != nil {
+		t.Errorf("error = %v, want nil", err)
+	}
+	if mailer == nil {
+		t.Error("mailer = nil, want something")
 	}
 }


### PR DESCRIPTION
@jcscottiii if it's not obvious, the rationale here is to be able to override the delivery address when sending mail in dev. In my current task I'm emailing org managers. In dev, I don't want to email real people. The phrase "delivery address" has been used frequently in my experience, hence my choice of naming.

Again, if not obvious, you don't need to set this env var for prod.

I also cleaned up the mailer tests.