### PR TITLE
Add "Error" to Not Found message to clarify

### DIFF
--- a/static_src/components/not_found.jsx
+++ b/static_src/components/not_found.jsx
@@ -1,5 +1,5 @@
 import React from "react";
 
-const NotFound = () => <h1>Not Found</h1>;
+const NotFound = () => <h1>Error: Not Found</h1>;
 
 export default NotFound;


### PR DESCRIPTION
This will help ZAP identify error pages (which will help it when it tests for Path Traversal - see https://github.com/zaproxy/zaproxy/issues/4209#issuecomment-355177979). Ideal would be to return a 404 response code instead of a 200, but this is an easy mitigation.