### PR TITLE
Update button label and in-app docs for restage button

### DIFF
--- a/static_src/components/app_container.jsx
+++ b/static_src/components/app_container.jsx
@@ -156,7 +156,7 @@ export default class AppContainer extends React.Component {
     let loading;
 
     let handler = this.handleRestart;
-    let actionText = "Restart app";
+    let actionText = "Restage app";
     if (!AppStore.isRunning(this.state.app)) {
       handler = this.handleStart;
       actionText = "Start app";
@@ -167,7 +167,7 @@ export default class AppContainer extends React.Component {
     }
 
     if (AppStore.isRestarting(this.state.app)) {
-      loading = <Loading text="Restarting app" style="inline" />;
+      loading = <Loading text="Restaging app" style="inline" />;
     }
 
     const action = loading || (

--- a/static_src/skins/cg/home_page/info_activities.jsx
+++ b/static_src/skins/cg/home_page/info_activities.jsx
@@ -17,7 +17,7 @@ const InfoActivities = ({ className }) => (
       <li>Create and bind service instances for your apps.</li>
       <li>Create and bind routes for your apps.</li>
       <li>Change memory allocation and number of instances for your apps.</li>
-      <li>Restart your apps.</li>
+      <li>Start and restage your apps.</li>
       <li>Manage permissions for users of your orgs and spaces.</li>
     </ul>
   </section>


### PR DESCRIPTION
[From support chat](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1517246989000096): "looks like a restart actually calls restage in the CF api: https://github.com/18F/cg-dashboard/blob/46216daafa964c3faffa28af9837e09c87d46eac/static_src/util/cf_api.js#L386-L391 ." "So the web `Restart app` is a `cf restage`, and `cf restart` is a different action?"

That's confusing, so this is a tiny effort to fix the label on the button. I didn't test this locally, just poked around to edit the text strings.

cc @LinuxBozo @konklone 