### PR TITLE
Remove offending end slash from URLs

### DIFF
--- a/manifests/manifest-prod.yml
+++ b/manifests/manifest-prod.yml
@@ -9,7 +9,7 @@ applications:
     CONSOLE_HOSTNAME: https://dashboard.fr.cloud.gov
     NEW_RELIC_ID: "20390582"
     NEW_RELIC_BROWSER_LICENSE_KEY: "5d4bc714a6"
-    CONSOLE_LOGIN_URL: https://login.fr.cloud.gov/
-    CONSOLE_UAA_URL: https://uaa.fr.cloud.gov/
-    CONSOLE_API_URL: https://api.fr.cloud.gov/
-    CONSOLE_LOG_URL: https://loggregator.fr.cloud.gov/
+    CONSOLE_LOGIN_URL: https://login.fr.cloud.gov
+    CONSOLE_UAA_URL: https://uaa.fr.cloud.gov
+    CONSOLE_API_URL: https://api.fr.cloud.gov
+    CONSOLE_LOG_URL: https://loggregator.fr.cloud.gov

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -7,7 +7,7 @@ applications:
   instances: 3
   env:
     CONSOLE_HOSTNAME: https://dashboard.fr-stage.cloud.gov
-    CONSOLE_LOGIN_URL: https://login.fr-stage.cloud.gov/
-    CONSOLE_UAA_URL: https://uaa.fr-stage.cloud.gov/
-    CONSOLE_API_URL: https://api.fr-stage.cloud.gov/
-    CONSOLE_LOG_URL: https://loggregator.fr-stage.cloud.gov/
+    CONSOLE_LOGIN_URL: https://login.fr-stage.cloud.gov
+    CONSOLE_UAA_URL: https://uaa.fr-stage.cloud.gov
+    CONSOLE_API_URL: https://api.fr-stage.cloud.gov
+    CONSOLE_LOG_URL: https://loggregator.fr-stage.cloud.gov


### PR DESCRIPTION
These cause issues in URLs generated by the app that look like https://host//path