### PR TITLE
Disable user add to deprecate cg-dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # And then modified to complete a build-and-test cycle.
 
 # The build uses the docker image, circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-# that has all the tools from the v1.0 CircleCI world. That image is 22.9 Gb, and 
+# that has all the tools from the v1.0 CircleCI world. That image is 22.9 Gb, and
 # takes about 8 minutes to set up if it's not already cached on the CircleCI machine
 # that your job lands on.
 
@@ -32,7 +32,6 @@ jobs:
     # The following image, at 22.9 Gb, is the old pre-configured image:
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
     steps:
     - checkout
     # Compatibility step
@@ -86,7 +85,7 @@ jobs:
     - run: NODE_ENV=prod npm run build-prod
     - run: pip install --user ruamel.yaml
     - run: export BUILD_INFO=build::$CIRCLE_BRANCH::$(date -u "+%Y-%m-%d-%H-%M-%S")::$CIRCLE_BUILD_NUM::$(deploy/npm-version.sh) && python deploy/vars-to-manifest.py
-    - run: cd $WS && ./deploy/circle_deploy.sh 
+    - run: cd $WS && ./deploy/circle_deploy.sh
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # And then modified to complete a build-and-test cycle.
 
 # The build uses the docker image, circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-# that has all the tools from the v1.0 CircleCI world. That image is 22.9 Gb, and
+# that has all the tools from the v1.0 CircleCI world. That image is 22.9 Gb, and 
 # takes about 8 minutes to set up if it's not already cached on the CircleCI machine
 # that your job lands on.
 
@@ -32,6 +32,7 @@ jobs:
     # The following image, at 22.9 Gb, is the old pre-configured image:
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
     steps:
     - checkout
     # Compatibility step
@@ -85,7 +86,7 @@ jobs:
     - run: NODE_ENV=prod npm run build-prod
     - run: pip install --user ruamel.yaml
     - run: export BUILD_INFO=build::$CIRCLE_BRANCH::$(date -u "+%Y-%m-%d-%H-%M-%S")::$CIRCLE_BUILD_NUM::$(deploy/npm-version.sh) && python deploy/vars-to-manifest.py
-    - run: cd $WS && ./deploy/circle_deploy.sh
+    - run: cd $WS && ./deploy/circle_deploy.sh 
 
 
 workflows:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,209 +2,358 @@
 
 
 [[projects]]
+  digest = "1:2ef7292c3149be99e4735793b14e4301bf15d9333f1e7e8b88b18164e6c29530"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm",
+  ]
+  pruneopts = ""
   revision = "fa152c58bc15761d0200cb75fe958b89a9d4888e"
 
 [[projects]]
+  digest = "1:3376a5a8d5371e18c4786ba5de78fe1a69761235872a5983ef0a9b7db602de64"
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
+  pruneopts = ""
   revision = "d311c76e775b5092c023569caacdbb4e569c3243"
   version = "v0.4.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3721a10686511b80c052323423f0de17a8c06d417dbdd3b392b1578432a33aae"
   name = "github.com/Nvveen/Gotty"
   packages = ["."]
+  pruneopts = ""
   revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
 
 [[projects]]
+  digest = "1:6d7bc5685a41cc2e545c44f1cc3b45c1321906e21f23d46282e7b5986f9caeb4"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "5b60b3d3ee017ed00bcd0225fcca7acab767844b"
 
 [[projects]]
+  digest = "1:593c1c5622dd4d08df2b3c4d3fa6c008478aec5adb1fff18ac911b0384ba6f06"
   name = "github.com/cenk/backoff"
   packages = ["."]
+  pruneopts = ""
   revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:8a96805d65612589b3c4b4f6885dbe84c41989325363438b268da121e5c25d38"
   name = "github.com/cloudfoundry-community/go-cfenv"
   packages = ["."]
+  pruneopts = ""
   revision = "96ad7376813bfd13c95af69ca5b4ef5725f6b335"
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:dcfc47ed6578a400445d213772a05cbed7204fa64007281c610c96643dd8cc22"
   name = "github.com/cloudfoundry/loggregatorlib"
-  packages = ["logmessage","signature"]
+  packages = [
+    "logmessage",
+    "signature",
+  ]
+  pruneopts = ""
   revision = "03bfd6ee4743a1a21433092663292b65aa4ee14e"
 
 [[projects]]
+  digest = "1:54841a823011a34356f108ae1c31eb00780d62edb9a95051b1559cecb0425fc6"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
 
 [[projects]]
+  digest = "1:1ba3b4c0146cc591d31887f2b4769c2d9cdfe38e40736486c4347e817dec87b9"
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonlog","pkg/jsonmessage","pkg/longpath","pkg/pools","pkg/promise","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/versions",
+    "opts",
+    "pkg/archive",
+    "pkg/fileutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/jsonlog",
+    "pkg/jsonmessage",
+    "pkg/longpath",
+    "pkg/pools",
+    "pkg/promise",
+    "pkg/stdcopy",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows",
+  ]
+  pruneopts = ""
   revision = "4845c567eb35d68f35b0b1713a09b0c8d47fe67e"
   version = "v17.04.0-ce"
 
 [[projects]]
+  digest = "1:ac5cf8a92320ab1cb6608cf8976b49ae842d5d6ea3fbd647df03c3df1c4d6e28"
   name = "github.com/docker/go-connections"
   packages = ["nat"]
+  pruneopts = ""
   revision = "e15c02316c12de00874640cd76311849de2aeed5"
 
 [[projects]]
+  digest = "1:a406cae5eda48c01f8171bd47beb038751393f25ac06774ce04f9d6b0b703f17"
   name = "github.com/docker/go-units"
   packages = ["."]
+  pruneopts = ""
   revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
   version = "v0.3.2"
 
 [[projects]]
+  digest = "1:d634c2ce3664f75f5bc826b3cddd7b1a8a63e2274238b43c65d4d8598f6807b7"
   name = "github.com/fsouza/go-dockerclient"
   packages = ["."]
+  pruneopts = ""
   revision = "30d142bbfdec74e09ecb4bdb89a44440ae4662ac"
 
 [[projects]]
+  digest = "1:c2031bf47747c72c98889126be68c047ae857db909a4a54886a263de9dee13ff"
   name = "github.com/gocraft/web"
   packages = ["."]
+  pruneopts = ""
   revision = "12b4630b4fee3e485b334c4d544bd9dd68fb3d4f"
 
 [[projects]]
+  digest = "1:9f5a55534e7baa6370dc3dac813e09b114e3872d3549904a1bad0e89e470d256"
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "74b6e9deaff6ba6da1389ec97351d337f0d08b06"
 
 [[projects]]
+  digest = "1:928a25b6b7c3ca0b9c70a9b68d05a84d3f0e4287d251206461332089741f014b"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "874264fbbb43f4d91e999fecb4b40143ed611400"
 
 [[projects]]
+  digest = "1:cdf253c55fc03d84937e8591cc9b68f3e8c011e2fc54b258a7aaecb5e0eb699e"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = ""
   revision = "a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd"
 
 [[projects]]
+  digest = "1:4b8a64dd073a0fba6ea681f53ee9963fffbe3e6066d3088dc89318f56e1fd11c"
   name = "github.com/gorilla/csrf"
   packages = ["."]
+  pruneopts = ""
   revision = "50eb875b7d37289a5819742f0d60fa5c890fced9"
   version = "v1.4"
 
 [[projects]]
+  digest = "1:1ff3509899d1357b533eefcc4be703aa4b8b690370de9bce65389aad226acf3c"
   name = "github.com/gorilla/securecookie"
   packages = ["."]
+  pruneopts = ""
   revision = "667fe4e3466a040b780561fe9b51a83a3753eefc"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:bfb5530b06be15a20de32e6c946eddc2d81693980c79205bcda3bd37fe1a931c"
   name = "github.com/gorilla/sessions"
   packages = ["."]
+  pruneopts = ""
   revision = "ca9ada44574153444b00d3fd9c8559e4cc95f896"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:56a54ae88bc84094b320b1eba06e8e99e392326bd3777d3c54eddb71516ed717"
   name = "github.com/govau/cf-common"
   packages = ["env"]
+  pruneopts = ""
   revision = "5c1de868d3662201c4f8ff529479e6153624fbf8"
   version = "v0.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:ae263e6b149fb7aadfc0f2284a8891cc3b9d2700e58b9a613fecf70fcc6e495d"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = ""
   revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
 
 [[projects]]
+  digest = "1:dbd08ed7d567715abe2ce89fd6c69afd266ff261194313acc45f1857eb0277e9"
   name = "github.com/jordan-wright/email"
   packages = ["."]
+  pruneopts = ""
   revision = "09f803b133a9229292871a003eb1a5b077fb32b2"
 
 [[projects]]
+  digest = "1:e6bde7d0156586ff397479872c62f34489f89531d3a91251a259e12f3b0f5da9"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "d2dd0262208475919e1a362f675cfc0e7c10e905"
 
 [[projects]]
+  digest = "1:f71e63e6e038acfb988e8d344679acd82df96f8545423967baa527e65cd9a125"
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user",
+  ]
+  pruneopts = ""
   revision = "2daa11574b12d2dd7f6dad3ffaa302871f21bd12"
 
 [[projects]]
+  digest = "1:0c25e223df166ed20a31331b5349f782522084136a8bdce68f9c1be6fe701693"
   name = "github.com/ory/dockertest"
   packages = ["."]
+  pruneopts = ""
   revision = "9d0647ae761f96a6738c5afb49688d22979b21ff"
   version = "v3.0.7"
 
 [[projects]]
+  digest = "1:8a7c205376f7089e8907eba27dae203da825906c9403e46f46ee44746793e5b1"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "248dadf4e9068a0b3e79f02ed0a610d935de5302"
 
 [[projects]]
+  digest = "1:31ba63a60f9e41b5cbb6cce48f4756718bd514fe73a1c6ee2751ec8fbf6e109f"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 
 [[projects]]
+  digest = "1:6b55df4b0517a459af9d3879c99330af4367adcf45f3d0d37ded80a6272ae057"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:1a1ba17101de55f5071338d895e640daba45d250b5b056408f816596467a7c19"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = ""
   revision = "cbeaeb16a013161a98496fad62933b1d21786672"
 
 [[projects]]
+  digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock"]
+  packages = [
+    "assert",
+    "mock",
+  ]
+  pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
   branch = "master"
+  digest = "1:f9609e4634988c25053812467a391401a1f53567bc789e280e741095add9dfeb"
   name = "github.com/yvasiyarov/go-metrics"
   packages = ["."]
+  pruneopts = ""
   revision = "c25f46c4b94079672242ec48a545e7ca9ebe3aec"
 
 [[projects]]
+  digest = "1:f072f775324bbfeec5fd22450a4d15e3f4830442b2598972a7d3b373d6a611a4"
   name = "github.com/yvasiyarov/gorelic"
   packages = ["."]
+  pruneopts = ""
   revision = "62638bfdaebd09d74b8b07366c23bdc5654866ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:a7b0faca08a05b9d47a6d7ae222230685556c2036663a7d1a648c241834b41b2"
   name = "github.com/yvasiyarov/newrelic_platform_go"
   packages = ["."]
+  pruneopts = ""
   revision = "9c099fbc30e90de5bb5c5f94aa5fd08f2daeaacd"
 
 [[projects]]
+  digest = "1:c19b2928f0d3c840ea2072546a2203dd0f9f78a422610bf34555251840fd3538"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+  ]
+  pruneopts = ""
   revision = "96dbb961a39ddccf16860cdd355bfa639c497f23"
 
 [[projects]]
+  digest = "1:6b6101a70ac4d636282def8bdad147082c486e3e36fcf8b57efc160d8b5df1cd"
   name = "golang.org/x/oauth2"
-  packages = [".","clientcredentials","internal"]
+  packages = [
+    ".",
+    "clientcredentials",
+    "internal",
+  ]
+  pruneopts = ""
   revision = "e86e2718db89775a4604abc10a5d3a5672e7336e"
 
 [[projects]]
+  digest = "1:1ed067f6338b4c6496a27a889a53e5c1adcafdcc4442024a01e035e5dcf28698"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "a408501be4d17ee978c04a618e7a1b22af058c0e"
 
 [[projects]]
+  digest = "1:75aef6f2dacf96064eced9d052089d348dfa6618186aadd6db13ac4cef5a6a7a"
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
   revision = "e234e71924d4aa52444bc76f2f831f13fa1eca60"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0ed688a8f12ee484dd1e6bd446a00f055b45f0696013ff2a5b2d990becc68242"
+  input-imports = [
+    "github.com/cloudfoundry-community/go-cfenv",
+    "github.com/cloudfoundry/loggregatorlib/logmessage",
+    "github.com/fsouza/go-dockerclient",
+    "github.com/gocraft/web",
+    "github.com/gogo/protobuf/proto",
+    "github.com/gorilla/context",
+    "github.com/gorilla/csrf",
+    "github.com/gorilla/sessions",
+    "github.com/govau/cf-common/env",
+    "github.com/jordan-wright/email",
+    "github.com/ory/dockertest",
+    "github.com/satori/go.uuid",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/mock",
+    "github.com/yvasiyarov/gorelic",
+    "golang.org/x/net/context",
+    "golang.org/x/oauth2",
+    "golang.org/x/oauth2/clientcredentials",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - npm-cache:/root/.npm
       - node-modules:/cg-dashboard/node_modules
       - .:/cg-dashboard
-      - ./node_modules:/cg-dashboard/node_modules
+      #- ./node_modules:/cg-dashboard/node_modules
       - cg-style-node-modules:/cg-style/node_modules
       - ${CG_STYLE_PATH-../cg-style}:/cg-style
       - frontend-home:/headless

--- a/static_src/components/header/header.js
+++ b/static_src/components/header/header.js
@@ -36,7 +36,11 @@ const Header = () => {
           </nav>
         </div>
         <div className="form-notification">
-          <h2 className="bg-lightestgray"><a href={header.deprecation_notice.url}>{header.deprecation_notice.text}</a></h2>
+          <h2 className="bg-lightestgray">
+            <a href={header.deprecation_notice.url}>
+              {header.deprecation_notice.text}
+            </a>
+          </h2>
         </div>
       </div>
     </header>

--- a/static_src/components/header/header.js
+++ b/static_src/components/header/header.js
@@ -24,15 +24,20 @@ const Header = () => {
   return (
     <header className={classNames("header", "header-no_sidebar")}>
       <div className="header-wrap">
-        {header.logo.render()}
-        <nav className="header-side">
-          <ul className="nav">
-            {header.links.map((l, i) => (
-              <HeaderLink key={i} url={l.url} text={l.text} />
-            ))}
-            {loginLink}
-          </ul>
-        </nav>
+        <div>
+          {header.logo.render()}
+          <nav className="header-side">
+            <ul className="nav">
+              {header.links.map((l, i) => (
+                <HeaderLink key={i} url={l.url} text={l.text} />
+              ))}
+              {loginLink}
+            </ul>
+          </nav>
+        </div>
+        <div className="form-notification">
+          <h2 className="bg-lightestgray"><a href={header.deprecation_notice.url}>{header.deprecation_notice.text}</a></h2>
+        </div>
       </div>
     </header>
   );

--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -5,9 +5,7 @@
 
 import PropTypes from "prop-types";
 import React from "react";
-import Action from "./action.jsx";
 import FormStore from "../stores/form_store";
-import { Form, FormText } from "./form";
 import PanelDocumentation from "./panel_documentation.jsx";
 import userActions from "../actions/user_actions";
 import { validateEmail } from "../util/validators";
@@ -21,7 +19,6 @@ const propTypes = {
   error: PropTypes.object
 };
 const defaultProps = {
-  inviteDisabled: false,
   currentUserAccess: false,
   error: {}
 };
@@ -77,12 +74,10 @@ export default class UsersInvite extends React.Component {
     return (
       <PanelDocumentation description>
         <p>
-          NOTE: Use  {" "}
-          <a href="https://dashboard-beta.fr.cloud.gov/">
-            the new dashboard
-          </a> {" "}
-          to add a new or existing user to this {entity}, as we deprecate {" "}
-          this dashboard. See our {" "}
+          NOTE: Use{" "}
+          <a href="https://dashboard-beta.fr.cloud.gov/">the new dashboard</a>{" "}
+          to add a new or existing user to this {entity}, as we deprecate this
+          dashboard. See our{" "}
           <a href="https://cloud.gov/docs/orgs-spaces/roles/">
             updated documentation on how to manage user access and roles here
           </a>.
@@ -92,17 +87,11 @@ export default class UsersInvite extends React.Component {
   }
 
   render() {
-    const { inviteDisabled } = true;
-
     if (!this.props.currentUserAccess) {
       return null;
     }
 
-    return (
-      <div className="test-users-invite">
-        {this.invitationMessage}
-      </div>
-    );
+    return <div className="test-users-invite">{this.invitationMessage}</div>;
   }
 }
 

--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -77,14 +77,14 @@ export default class UsersInvite extends React.Component {
     return (
       <PanelDocumentation description>
         <p>
-          To add a new or existing user to cloud.gov and this
-          {entity} {" "}, please use {" "}
+          NOTE: Use  {" "}
           <a href="https://dashboard-beta.fr.cloud.gov/">
             the new dashboard
           </a> {" "}
-          - see our updated instructions on
+          to add a new or existing user to this {entity}, as we deprecate {" "}
+          this dashboard. See our {" "}
           <a href="https://cloud.gov/docs/orgs-spaces/roles/">
-            how to manage user access and roles
+            updated documentation on how to manage user access and roles here
           </a>.
         </p>
       </PanelDocumentation>
@@ -92,7 +92,7 @@ export default class UsersInvite extends React.Component {
   }
 
   render() {
-    const { inviteDisabled } = this.props;
+    const { inviteDisabled } = true;
 
     if (!this.props.currentUserAccess) {
       return null;
@@ -101,23 +101,6 @@ export default class UsersInvite extends React.Component {
     return (
       <div className="test-users-invite">
         {this.invitationMessage}
-        <Form
-          guid={USERS_INVITE_FORM_GUID}
-          classes={["users_invite_form"]}
-          onSubmit={this.handleSubmit}
-          errorOverride={this.errorMessage}
-        >
-          <FormText
-            formGuid={USERS_INVITE_FORM_GUID}
-            classes={["test-users_invite_name"]}
-            label="User's email"
-            name="email"
-            validator={this.validateEmail}
-          />
-          <Action label="submit" type="submit" disabled={inviteDisabled}>
-            Add user to this {this.props.inviteEntityType}
-          </Action>
-        </Form>
       </div>
     );
   }

--- a/static_src/components/users_invite.jsx
+++ b/static_src/components/users_invite.jsx
@@ -75,8 +75,19 @@ export default class UsersInvite extends React.Component {
     const entity = this.props.inviteEntityType;
 
     return (
-      `Invite a new user to cloud.gov and this ${entity}` +
-      ` or add an existing user to this ${entity}.`
+      <PanelDocumentation description>
+        <p>
+          To add a new or existing user to cloud.gov and this
+          {entity} {" "}, please use {" "}
+          <a href="https://dashboard-beta.fr.cloud.gov/">
+            the new dashboard
+          </a> {" "}
+          - see our updated instructions on
+          <a href="https://cloud.gov/docs/orgs-spaces/roles/">
+            how to manage user access and roles
+          </a>.
+        </p>
+      </PanelDocumentation>
     );
   }
 
@@ -89,9 +100,7 @@ export default class UsersInvite extends React.Component {
 
     return (
       <div className="test-users-invite">
-        <PanelDocumentation description>
-          <p>{this.invitationMessage}</p>
-        </PanelDocumentation>
+        {this.invitationMessage}
         <Form
           guid={USERS_INVITE_FORM_GUID}
           classes={["users_invite_form"]}

--- a/static_src/components/users_selector.jsx
+++ b/static_src/components/users_selector.jsx
@@ -8,7 +8,6 @@ import React from "react";
 import Action from "./action.jsx";
 import FormStore from "../stores/form_store";
 import { Form, FormSelect } from "./form";
-import PanelDocumentation from "./panel_documentation.jsx";
 import userActions from "../actions/user_actions";
 import { validateString } from "../util/validators";
 

--- a/static_src/components/users_selector.jsx
+++ b/static_src/components/users_selector.jsx
@@ -100,9 +100,7 @@ export default class UsersSelector extends React.Component {
 
     return (
       <div className="test-users-selector">
-        <PanelDocumentation description>
-          <p>{this.invitationMessage}</p>
-        </PanelDocumentation>
+        {this.invitationMessage}
         <Form
           guid={USERS_SELECTOR_GUID}
           classes={["users_selector"]}

--- a/static_src/skins/cg/header.js
+++ b/static_src/skins/cg/header.js
@@ -96,10 +96,16 @@ const links = [
   }
 ];
 
+const deprecation_notice = {
+  text: "Please join us on the new cloud.gov dashboard!",
+  url: "https://dashboard-beta.cloud.gov/"
+};
+
 const header = {
   disclaimer,
   logo,
-  links
+  links,
+  deprecation_notice
 };
 
 export default header;

--- a/static_src/skins/cg/header.js
+++ b/static_src/skins/cg/header.js
@@ -97,7 +97,7 @@ const links = [
 ];
 
 const deprecation_notice = {
-  text: "Please use the new cloud.gov dashboard here!",
+  text: "Please use the new cloud.gov dashboard.",
   url: "https://dashboard-beta.cloud.gov/"
 };
 

--- a/static_src/skins/cg/header.js
+++ b/static_src/skins/cg/header.js
@@ -96,7 +96,7 @@ const links = [
   }
 ];
 
-const deprecation_notice = {
+const deprecationNotice = {
   text: "Please use the new cloud.gov dashboard.",
   url: "https://dashboard-beta.cloud.gov/"
 };
@@ -105,7 +105,7 @@ const header = {
   disclaimer,
   logo,
   links,
-  deprecation_notice
+  deprecationNotice
 };
 
 export default header;

--- a/static_src/skins/cg/header.js
+++ b/static_src/skins/cg/header.js
@@ -97,7 +97,7 @@ const links = [
 ];
 
 const deprecation_notice = {
-  text: "Please join us on the new cloud.gov dashboard!",
+  text: "Please use the new cloud.gov dashboard here!",
   url: "https://dashboard-beta.cloud.gov/"
 };
 

--- a/static_src/test/unit/components/users_invite.spec.jsx
+++ b/static_src/test/unit/components/users_invite.spec.jsx
@@ -21,19 +21,13 @@ describe("<UsersInvite />", function() {
       wrapper = shallow(<UsersInvite {...props} />);
     });
 
-    it("renders one <Form /> component", () => {
-      expect(wrapper.find(Form).length).toEqual(1);
-    });
-
-    it("renders one <Action /> component", () => {
-      expect(wrapper.find(Action).length).toEqual(1);
-    });
-
     describe("conditional documentation based on inviteEntityType", () => {
       it("refers to `space` when type is space", () => {
         const doc =
-          "Invite a new user to cloud.gov and this space" +
-          " or add an existing user to this space.";
+          "NOTE: Use the new dashboard to add a new or existing user" +
+          " to this space, as we deprecate this dashboard. See our " +
+          "updated documentation on how to manage user access and "+
+          "roles here.";
 
         expect(
           wrapper
@@ -42,47 +36,6 @@ describe("<UsersInvite />", function() {
             .text()
         ).toBe(doc);
       });
-
-      it("refers to `organization` when type is organization", () => {
-        const doc =
-          "Invite a new user to cloud.gov and this organization" +
-          " or add an existing user to this organization.";
-        const orgProps = Object.assign({}, props, {
-          inviteEntityType: "organization"
-        });
-        wrapper = shallow(<UsersInvite {...orgProps} />);
-
-        expect(
-          wrapper
-            .find(PanelDocumentation)
-            .find("p")
-            .text()
-        ).toBe(doc);
-      });
-
-      it("refers to `organization` when type is organization in the action button", () => {
-        const buttonHTML =
-          '<button class="action action-primary usa-button ' +
-          'usa-button-primary" aria-label="submit" type="submit">' +
-          "Add user to this organization</button>";
-        const orgProps = Object.assign({}, props, {
-          inviteEntityType: "organization"
-        });
-        wrapper = shallow(<UsersInvite {...orgProps} />);
-
-        expect(wrapper.find(Action).html()).toEqual(buttonHTML);
-      });
-    });
-  });
-
-  describe("when user does not have ability to invite other users", () => {
-    it("does not render <Form /> component", () => {
-      const noAccessProps = Object.assign({}, props, {
-        currentUserAccess: false
-      });
-      wrapper = shallow(<UsersInvite {...noAccessProps} />);
-
-      expect(wrapper.find(Form).length).toEqual(0);
     });
   });
 });

--- a/static_src/test/unit/components/users_selector.spec.jsx
+++ b/static_src/test/unit/components/users_selector.spec.jsx
@@ -20,22 +20,6 @@ describe("<UsersSelector />", function() {
   };
   let wrapper;
 
-  describe("when the working description is displayed as text panel", () => {
-    beforeEach(() => {
-      wrapper = shallow(<UsersSelector {...props} />);
-    });
-
-    it("displays proper message", () => {
-      const doc = "Invite an existing organization user to this space.";
-      expect(
-        wrapper
-          .find(PanelDocumentation)
-          .find("p")
-          .text()
-      ).toBe(doc);
-    });
-  });
-
   describe("when user selector", () => {
     it("renders users", () => {
       const username = "username";


### PR DESCRIPTION
Adds language to suggest users migrate to the new beta dashboard and disables user-add (which is generally broken).

Links to the new user-adding documentation on cloud.gov.

Dashboard header with deprecation notice and link to new beta dashboard:
<img width="1303" alt="dashboard header with new deprecation notice" src="https://user-images.githubusercontent.com/10235730/73018857-70139b80-3df0-11ea-9fc5-ac4c93f740a0.png">

Adding users dialog removed with note to use new dashboard and documentation:
<img width="778" alt="organization user adding disabled with message to see new documentation and dashboard" src="https://user-images.githubusercontent.com/10235730/73018858-70139b80-3df0-11ea-9c6a-7355cede3392.png">
