### PR TITLE
Rename dashboard to dashboard-old

### DIFF
--- a/manifests/manifest-prod.yml
+++ b/manifests/manifest-prod.yml
@@ -2,11 +2,11 @@
 inherit: manifest-base.yml
 domain: fr.cloud.gov
 applications:
-- name: cg-dashboard
-  host: dashboard
+- name: cg-dashboard-old
+  host: dashboard-old
   instances: 3
   env:
-    CONSOLE_HOSTNAME: https://dashboard.fr.cloud.gov
+    CONSOLE_HOSTNAME: https://dashboard-old.fr.cloud.gov
     CONSOLE_LOGIN_URL: https://login.fr.cloud.gov
     CONSOLE_UAA_URL: https://uaa.fr.cloud.gov
     CONSOLE_API_URL: https://api.fr.cloud.gov

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -2,11 +2,11 @@
 inherit: manifest-base.yml
 domain: fr-stage.cloud.gov
 applications:
-- name: cg-dashboard
-  host: dashboard
+- name: cg-dashboard-old
+  host: dashboard-old
   instances: 3
   env:
-    CONSOLE_HOSTNAME: https://dashboard.fr-stage.cloud.gov
+    CONSOLE_HOSTNAME: https://dashboard-old.fr-stage.cloud.gov
     CONSOLE_LOGIN_URL: https://login.fr-stage.cloud.gov
     CONSOLE_UAA_URL: https://uaa.fr-stage.cloud.gov
     CONSOLE_API_URL: https://api.fr-stage.cloud.gov


### PR DESCRIPTION
Part of the stratos migration

### Security considerations

None