### PR TITLE
add deprecated to the hostname (cg-product#1318)

### DIFF
--- a/manifests/manifest-prod.yml
+++ b/manifests/manifest-prod.yml
@@ -2,11 +2,11 @@
 inherit: manifest-base.yml
 domain: fr.cloud.gov
 applications:
-- name: cg-dashboard-old
-  host: dashboard-old
+- name: cg-dashboard-deprecated
+  host: dashboard-deprecated
   instances: 3
   env:
-    CONSOLE_HOSTNAME: https://dashboard-old.fr.cloud.gov
+    CONSOLE_HOSTNAME: https://dashboard-deprecated.fr.cloud.gov
     CONSOLE_LOGIN_URL: https://login.fr.cloud.gov
     CONSOLE_UAA_URL: https://uaa.fr.cloud.gov
     CONSOLE_API_URL: https://api.fr.cloud.gov

--- a/manifests/manifest-staging.yml
+++ b/manifests/manifest-staging.yml
@@ -2,11 +2,11 @@
 inherit: manifest-base.yml
 domain: fr-stage.cloud.gov
 applications:
-- name: cg-dashboard-old
-  host: dashboard-old
+- name: cg-dashboard-deprecated
+  host: dashboard-deprecated
   instances: 3
   env:
-    CONSOLE_HOSTNAME: https://dashboard-old.fr-stage.cloud.gov
+    CONSOLE_HOSTNAME: https://dashboard-deprecated.fr-stage.cloud.gov
     CONSOLE_LOGIN_URL: https://login.fr-stage.cloud.gov
     CONSOLE_UAA_URL: https://uaa.fr-stage.cloud.gov
     CONSOLE_API_URL: https://api.fr-stage.cloud.gov


### PR DESCRIPTION
Add -depecated to the hostname so we can re-enable as per: https://github.com/cloud-gov/cg-product/issues/1318